### PR TITLE
Add warning about DB issue

### DIFF
--- a/src/module/pick-up-stix/hooks/ready-hook.ts
+++ b/src/module/pick-up-stix/hooks/ready-hook.ts
@@ -225,7 +225,7 @@ export async function readyHook() {
 	// Do anything once the module is ready
 	console.log(`pick-up-stix | readyHook`);
 
-	// this adds the 'container' type to the game system's entity type.
+	// this adds the 'container' type to the game system's entity types.
 	game.system.entityTypes.Item.push(ItemType.CONTAINER);
 
 	for (let item of game.items.values()) {
@@ -244,6 +244,38 @@ export async function readyHook() {
 	};
 
 	EntitySheetConfig.registerSheet(Item, 'pick-up-stix', ItemConfigApplication, { types: [ 'container' ], makeDefault: true });
+
+	if (!game.settings.get('pick-up-stix', 'notify-db-issue')) {
+		await new Promise(resolve => {
+			new Dialog({
+				title: 'Pick-Up-Stix WARNING!',
+				content: `
+					<p>
+					It has been bought to my attention that while my module is enabled, eventually it is possible
+					that some of the data files used by Foundry can become quite large. This issue is caused by a combination
+					of how the database works and how this module stores data.
+					</p>
+					<p>
+					I am working on a release that will alleviate this issue and I appreciate your patience and support.
+					</p>
+				`,
+				buttons: {
+					ok: {
+						label: 'OK',
+						callback: html => resolve()
+					},
+					dismiss: {
+						label: `DON'T SHOW AGAIN`,
+						callback: html => {
+							game.settings.set('pick-up-stix', 'notify-db-issue', true);
+							resolve();
+						}
+					}
+				},
+				default: 'ok'
+			}).render(true);
+		});
+	}
 
 	const activeVersion = game.modules.get('pick-up-stix').data.version;
 	const previousVersion = game.settings.get('pick-up-stix', SettingKeys.version);

--- a/src/module/pick-up-stix/settings.ts
+++ b/src/module/pick-up-stix/settings.ts
@@ -24,6 +24,13 @@ export const registerSettings = function() {
 	}
 	Object.defineProperty(audioTypeFunc, 'name', {value: 'pick-up-stix-settings-audio'});
 
+	game.settings.register('pick-up-stix', 'notify-db-issue', {
+		name: 'DB issue notification',
+		scope: 'world',
+		type: Boolean,
+		config: false
+	});
+
 	game.settings.register('pick-up-stix', SettingKeys.version, {
 		name: 'Version',
 		hint: 'Used to track which version is last loaded, so that we can give updates to users',


### PR DESCRIPTION
There is an issue with the way that the Foundry DB works and the way that I am storing data. Unfortunately it's a limitation of the system. This adds a notification to users that this can happen and that a new version will alleviate it.