### PR TITLE
Create LootHud instances for previously created loot data

### DIFF
--- a/src/module/pick-up-stix/hooks/delete-token-hook.ts
+++ b/src/module/pick-up-stix/hooks/delete-token-hook.ts
@@ -1,8 +1,8 @@
-// import { lootTokens } from "../main";
+import { LootToken } from "../loot-token";
+import { lootTokens } from "../main";
 
-// TODO: is this needed?
-export function onDeleteToken(scene: Scene, tokenData: any, data: any, userId: string) {
-	console.log(`pick-up-stix | onDeleteToken | called with args:`);
+export function deleteTokenHook(scene: Scene, tokenData: any, data: any, userId: string) {
+	console.log(`pick-up-stix | deleteTokenHook | called with args:`);
 	console.log([scene, tokenData, data, userId]);
-	//lootTokens.findSplice(t => t === tokenData._id);
+	lootTokens?.findSplice((t: LootToken) => t.sceneId === scene.id && t.tokenId === tokenData._id)
 }

--- a/src/pick-up-stix.ts
+++ b/src/pick-up-stix.ts
@@ -1,7 +1,7 @@
 import { canvasReadyHook } from "./module/pick-up-stix/hooks/canvas-ready-hook";
 import { onCreateActor } from "./module/pick-up-stix/hooks/create-actor-hook";
 import { onCreateItem } from "./module/pick-up-stix/hooks/create-item-hook";
-import { onDeleteToken } from "./module/pick-up-stix/hooks/delete-token-hook";
+import { deleteTokenHook } from "./module/pick-up-stix/hooks/delete-token-hook";
 import { initHook } from "./module/pick-up-stix/hooks/init-hook";
 import { onPreCreateOwnedItem } from "./module/pick-up-stix/hooks/pre-create-owned-item-hook";
 import { readyHook } from "./module/pick-up-stix/hooks/ready-hook";
@@ -25,7 +25,7 @@ Hooks.on('preCreateOwnedItem', onPreCreateOwnedItem);
 
 // token hooks
 Hooks.on('updateToken', onUpdateToken);
-Hooks.on('deleteToken', onDeleteToken);
+Hooks.on('deleteToken', deleteTokenHook);
 
 // render hooks
 Hooks.on("renderSettingsConfig", (app, html, user) => {


### PR DESCRIPTION
In the case of reloading a world or changing scenes and coming back, we
needed a way to re-intialize the listeners on LootToken instances since
their previous Token instances would be gone. So on canvas ready, we
look through the loot token data and try and either find an already
created LootToken instance if one exists and if not then a newly created
Token instance that matches the correct IDs in the data and create a ne
LootToken instance. We then setup the listeners on the new token
instance