### PR TITLE
Add ability to configure containers

### DIFF
--- a/src/module/pick-up-stix/hooks/canvas-ready-hook.ts
+++ b/src/module/pick-up-stix/hooks/canvas-ready-hook.ts
@@ -1,44 +1,8 @@
-import { handleItemDropped, drawLockIcon, getLootToken, lootTokens } from "../main";
+import { handleItemDropped, drawLockIcon, getLootToken, lootTokens, normalizeDropData } from "../main";
 import { DropData, PickUpStixFlags } from "../models";
 import { LootHud } from "../loot-hud-application";
 import { getLootTokenData } from "../main";
 import { LootToken } from "../loot-token";
-
-const normalizeDropData = (data: DropData, event?: any): any => {
-	console.log('pick-up-stix | normalizeDropData called with args:');
-	console.log([data, event]);
-
-	// TODO: in version 0.7.0 and above, are the x and y already correct?
-	if (event) {
-		// Acquire the cursor position transformed to Canvas coordinates
-		const [x, y] = [event.clientX, event.clientY];
-		const t = canvas.stage.worldTransform;
-		data.x = (x - t.tx) / canvas.stage.scale.x;
-		data.y = (y - t.ty) / canvas.stage.scale.y;
-	}
-
-	const coreVersion = game.data.verson;
-	const is7Newer = isNewerVersion(coreVersion, '0.6.9');
-
-	if (data.actorId) {
-		let actor;
-
-		if (is7Newer) {
-			actor = data.tokenId ? game.actors.tokens[data.tokenId] : game.actors.get(data.actorId);
-		}
-		else {
-			// if Foundry is 0.6.9 or lower then there is no good way to tell which user-controlled token
-			// that the item comes from. We only have the actor ID and multiple tokens could be associated with
-			// the same actor. So we check if the user is controlling only one token and use that token's actor
-			// reference, otherwise we say there is no actor.
-			actor = canvas?.tokens?.controlled?.length === 1 ? canvas.tokens?.controlled?.[0]?.actor : null;
-		}
-
-		data.actor = actor;
-	}
-
-	return data;
-}
 
 /**
  * Handler for the dropCanvasData Foundry hook. This is used

--- a/src/module/pick-up-stix/hooks/pre-create-item-hook.ts
+++ b/src/module/pick-up-stix/hooks/pre-create-item-hook.ts
@@ -16,8 +16,7 @@ export async function preCreateItemHook(itemData: any, options: any, userId: str
 		// anywhere else anyway
 		setProperty(itemData, 'type', game.system.entityTypes.Item.includes('backpack') ? 'backpack' : game.system.entityTypes.Item[0]);
 
-		setProperty(itemData, 'flags.pick-up-stix', {
-			version: game.settings.get('pick-up-stix', SettingKeys.version),
+		const defaultContainerFlags = {
 			'pick-up-stix': {
 				container: {
 					currency: Object.keys(getCurrencyTypes()).reduce((acc, shortName) => ({...acc, [shortName]: 0}), {}),
@@ -31,7 +30,15 @@ export async function preCreateItemHook(itemData: any, options: any, userId: str
 				isLocked: false,
 				itemType: ItemType.CONTAINER
 			}
-		});
+		};
+
+		const flags = getProperty(itemData, 'flags.pick-up-stix');
+		if (!flags) {
+			options.renderSheet = false;
+			setProperty(itemData, 'flags.pick-up-stix', {
+				...defaultContainerFlags
+			});
+		}
 
 		setProperty(itemData, 'img', game.settings.get('pick-up-stix', SettingKeys.closeImagePath));
 	}

--- a/src/module/pick-up-stix/loot-hud-application.ts
+++ b/src/module/pick-up-stix/loot-hud-application.ts
@@ -45,7 +45,7 @@ export class LootHud extends BasePlaceableHUD {
     console.log(`pick-up-stix | LootHud ${this.appId} | _onTokenConfig`);
 
     const lootToken = getLootToken(canvas.scene.id, this.object.id);
-    lootToken?.openLootTokenConfig();
+    lootToken?.openConfigSheet();
   }
 
   getData(options) {

--- a/src/module/pick-up-stix/models.ts
+++ b/src/module/pick-up-stix/models.ts
@@ -26,7 +26,11 @@ export interface DropData {
 
 	// x and y postion where the item was dropped, this would need to be converted into world coordinates
 	x: number,
-	y: number
+	y: number,
+
+	// this is the type that comes from foundry. We'll test for this when dropping on the item config
+	// application to ensure we are only accepting the "Item" types
+	type?: string
 }
 
 export interface PickUpStixFlags {


### PR DESCRIPTION
You can now edit container Items that are in the items directory, token
container items that are created from a container Item, and token
container items that are created by dragging non-container type items to
the canvas and choosing container from the dialog sepaparte. all data
for each of the types is stored seprately so as not to affect the others