### PR TITLE
feat: v14 levels integration

### DIFF
--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -7,6 +7,7 @@ import { dbg } from "../utils/debugLog.mjs";
 import { dragModifiersHeld } from "../utils/dragModifier.mjs";
 import { findCanvasDropTargets, promptDropChoice, PLACE_ON_CANVAS } from "../utils/canvasDropTargets.mjs";
 import { isModuleGM, isPlayerView } from "../utils/playerView.mjs";
+import { hasLevels, getViewedLevelId, getTokenLevelId } from "../utils/levels.mjs";
 
 const MODULE_ID = "pick-up-stix";
 
@@ -118,8 +119,10 @@ async function _handleItemDrop(data) {
   }
 
   if (isModuleGM()) {
-    dbg("place:_handleItemDrop", "GM path — createInteractiveToken", { x: data.x, y: data.y, ephemeral });
-    await createInteractiveToken(item, data.x, data.y, { ephemeral });
+    dbg("place:_handleItemDrop", "GM path — createInteractiveToken", {
+      x: data.x, y: data.y, ephemeral, level: data.level ?? null
+    });
+    await createInteractiveToken(item, data.x, data.y, { ephemeral, level: data.level ?? null });
     if (item.actor) await item.delete({ deleteContents: true });
   } else {
     // Prefer the owner's canvas token so the item lands at the dragger's position,
@@ -128,7 +131,9 @@ async function _handleItemDrop(data) {
       ? canvas.tokens.placeables.find(t => t.actor?.id === item.actor.id) ?? null
       : null;
     const playerToken = ownerToken ?? getPlayerCandidateTokens()[0] ?? null;
-    dbg("place:_handleItemDrop", "player path", { ownerTokenId: ownerToken?.document?.id, playerTokenId: playerToken?.document?.id, ephemeral });
+    dbg("place:_handleItemDrop", "player path", {
+      ownerTokenId: ownerToken?.document?.id, playerTokenId: playerToken?.document?.id, ephemeral
+    });
     if (!playerToken) {
       dbg("place:_handleItemDrop", "no player token found, bail");
       ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoCharacter"));
@@ -136,11 +141,22 @@ async function _handleItemDrop(data) {
     }
     const x = playerToken.document.x;
     const y = playerToken.document.y;
+    // Player drops always target the player's character's level, even if the GM
+    // is currently viewing a different level.
+    const playerLevel = getTokenLevelId(playerToken.document);
 
-    dbg("place:_handleItemDrop", "routing placeItem via socket", { x, y, ephemeral, itemUuid: data.uuid });
+    dbg("place:_handleItemDrop", "routing placeItem via socket",
+      { x, y, level: playerLevel, ephemeral, itemUuid: data.uuid });
     dispatchGM(
       "placeItem",
-      { itemUuid: data.uuid, sourceActorId: item.actor?.id ?? null, itemId: item.id, x, y, ephemeral },
+      {
+        itemUuid: data.uuid,
+        sourceActorId: item.actor?.id ?? null,
+        itemId: item.id,
+        x, y,
+        level: playerLevel,
+        ephemeral
+      },
       () => {} // unreachable — game.user.isGM is false in this branch
     );
     notifyItemAction("Placed", item.name);
@@ -349,7 +365,24 @@ async function _handleInteractiveActorDropWithOverlap(dropped, data, targets) {
   await depositActorToTarget(dropped, result);
 }
 
-async function createInteractiveToken(item, x, y, { ephemeral = false } = {}) {
+/**
+ * Creates an interactive token on the canvas for the given item at the given coordinates.
+ *
+ * On Foundry v14, the token will be assigned to the correct scene level using the
+ * following priority order:
+ *   1. Explicit `level` argument (forwarded via socket from the player's character level).
+ *   2. Saved `tokenState.level` from a previous pickup snapshot (round-trip restore).
+ *   3. Currently-viewed level (GM drop default via `canvas.level.id`).
+ * On Foundry v13 (no levels system), `level`/`depth` are never written.
+ *
+ * @param {Item} item - The item to place as an interactive token.
+ * @param {number} x - Canvas x coordinate.
+ * @param {number} y - Canvas y coordinate.
+ * @param {object} [options]
+ * @param {boolean} [options.ephemeral=false] - When true, creates an ephemeral (non-template) actor.
+ * @param {string|null} [options.level=null] - v14 level id to assign. Null = fall through to snapshot/viewed-level logic.
+ */
+async function createInteractiveToken(item, x, y, { ephemeral = false, level = null } = {}) {
   const snapped = canvas.grid.getTopLeftPoint({ x, y });
   x = snapped.x;
   y = snapped.y;
@@ -465,7 +498,10 @@ async function createInteractiveToken(item, x, y, { ephemeral = false } = {}) {
   if (savedState) tokenFlags["pick-up-stix"].savedState = savedState;
   if (ephemeral) tokenFlags["pick-up-stix"].ephemeral = true;
 
-  dbg("place:createInteractiveToken", "placing token", { actorId: actor.id, actorImg: actor.img, x, y, hasSavedState: !!savedState });
+  dbg("place:createInteractiveToken", "placing token", {
+    actorId: actor.id, actorImg: actor.img, x, y,
+    hasSavedState: !!savedState, levelArg: level
+  });
   const tokenData = foundry.utils.mergeObject(
     actor.prototypeToken.toObject(),
     {
@@ -473,16 +509,46 @@ async function createInteractiveToken(item, x, y, { ephemeral = false } = {}) {
       flags: tokenFlags
     }
   );
+
+  // v14: inject level/depth. Priority order:
+  //   1. explicit `level` arg (player-drop forwarded via socket)
+  //   2. saved snapshot's level (round-trip from pickup; Phase 2 populates the snapshot)
+  //   3. currently-viewed level (GM drop default)
+  if (hasLevels()) {
+    const savedLevel = savedState?.level;
+    const savedDepth = savedState?.depth;
+    tokenData.level = level ?? savedLevel ?? getViewedLevelId();
+    if (savedDepth !== undefined) tokenData.depth = savedDepth;
+    dbg("place:createInteractiveToken", "v14 level/depth assigned", {
+      level: tokenData.level, depth: tokenData.depth,
+      fromArg: level !== null, fromSaved: !level && !!savedLevel
+    });
+  }
+
   await canvas.scene.createEmbeddedDocuments("Token", [tokenData]);
   dbg("place:createInteractiveToken", "token placed", { actorId: actor.id, ephemeral });
 
   notifyItemAction("Placed", item.name);
 }
 
+/**
+ * Creates a token on the canvas from a base actor at the given coordinates.
+ * On v14, stamps the currently-viewed level onto the token document so the
+ * token lands on the correct floor without relying on core's _onDropActorData.
+ *
+ * @param {Actor} actor
+ * @param {number} x
+ * @param {number} y
+ */
 async function createTokenFromActor(actor, x, y) {
   dbg("place:createTokenFromActor", { actorName: actor.name, actorId: actor.id, x, y });
   const snapped = canvas.grid.getTopLeftPoint({ x, y });
-  const tokenDocument = await actor.getTokenDocument({ x: snapped.x, y: snapped.y });
+  const data = { x: snapped.x, y: snapped.y };
+  if (hasLevels()) {
+    data.level = getViewedLevelId();
+    dbg("place:createTokenFromActor", "v14 level assigned", { level: data.level });
+  }
+  const tokenDocument = await actor.getTokenDocument(data);
   return canvas.scene.createEmbeddedDocuments("Token", [tokenDocument.toObject()]);
 }
 

--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -95,7 +95,21 @@ async function _handleItemDrop(data) {
   }
 
   const sourceActorId = item.actor?.id ?? null;
-  const overlapTargets = findCanvasDropTargets(data.x, data.y, { sourceActorId });
+  // On v14, restrict overlap targets to the level the item is being dropped onto.
+  // GMs use the viewed level (null → findCanvasDropTargets internal default).
+  // Players use their character's level so a stacked-visible container on a different
+  // floor doesn't falsely prompt for deposit.
+  const dropLevel = isModuleGM()
+    ? (data.level ?? null)
+    : (() => {
+        const ownerToken = item.actor
+          ? canvas.tokens.placeables.find(t => t.actor?.id === item.actor.id) ?? null
+          : null;
+        const playerToken = ownerToken ?? getPlayerCandidateTokens()[0] ?? null;
+        return playerToken ? getTokenLevelId(playerToken.document) : null;
+      })();
+  dbg("place:_handleItemDrop", "resolving overlap targets", { sourceActorId, dropLevel });
+  const overlapTargets = findCanvasDropTargets(data.x, data.y, { sourceActorId, level: dropLevel });
   if (overlapTargets.length) {
     dbg("place:_handleItemDrop", "overlap targets found, prompting user",
       { count: overlapTargets.length, names: overlapTargets.map(t => t.actor.name) });

--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -510,18 +510,15 @@ async function createInteractiveToken(item, x, y, { ephemeral = false, level = n
     }
   );
 
-  // v14: inject level/depth. Priority order:
-  //   1. explicit `level` arg (player-drop forwarded via socket)
-  //   2. saved snapshot's level (round-trip from pickup; Phase 2 populates the snapshot)
-  //   3. currently-viewed level (GM drop default)
+  // v14: tokens always land on the currently-active level.
+  //   - Explicit `level` arg: player-drop level forwarded via socket (the player's own level).
+  //   - Fallback: the GM's currently-viewed level for all other paths.
+  //   Snapshot-saved level is intentionally not used — items should appear wherever
+  //   they are dropped now, not where they were originally picked up from.
   if (hasLevels()) {
-    const savedLevel = savedState?.level;
-    const savedDepth = savedState?.depth;
-    tokenData.level = level ?? savedLevel ?? getViewedLevelId();
-    if (savedDepth !== undefined) tokenData.depth = savedDepth;
-    dbg("place:createInteractiveToken", "v14 level/depth assigned", {
-      level: tokenData.level, depth: tokenData.depth,
-      fromArg: level !== null, fromSaved: !level && !!savedLevel
+    tokenData.level = level ?? getViewedLevelId();
+    dbg("place:createInteractiveToken", "v14 level assigned", {
+      level: tokenData.level, fromArg: level !== null
     });
   }
 

--- a/scripts/hud/InteractiveTokenHUD.mjs
+++ b/scripts/hud/InteractiveTokenHUD.mjs
@@ -6,6 +6,7 @@ import { validateContainerAccess } from "../utils/containerAccess.mjs";
 import { resolvePickupTarget } from "../utils/pickupFlow.mjs";
 import { dbg } from "../utils/debugLog.mjs";
 import { isModuleGM, isPlayerView } from "../utils/playerView.mjs";
+import { hasLevels, getTokenLevelId, getViewedLevelId } from "../utils/levels.mjs";
 
 const MODULE_ID = "pick-up-stix";
 
@@ -21,6 +22,9 @@ function _patchCanHUD() {
     if (isInteractiveActor(this.actor)) {
       dbg("hud:_canHUD", { actorName: this.actor?.name, isDragged: !!this.layer._draggedToken, layerActive: this.layer.active, isPreview: this.isPreview });
       if (this.layer._draggedToken || !this.layer.active || this.isPreview) return false;
+      // Cross-level interactive tokens still return true here so that the PIXI
+      // clickRight event fires and _patchClickRight can handle the level switch.
+      // The HUD itself is suppressed inside _patchClickRight by not calling hud.bind().
       return this.actor.testUserPermission(user, "OBSERVER");
     }
     return wrapped(user, event);
@@ -46,6 +50,22 @@ function _patchClickRight() {
   libWrapper.register(MODULE_ID, "foundry.canvas.placeables.Token.prototype._onClickRight", function(wrapped, event) {
     if (!isInteractiveActor(this.actor)) return wrapped(event);
 
+    // v14: when this interactive token is on a different level than the viewed
+    // level, defer to core. _canHUD intentionally returns true for cross-level
+    // tokens so the PIXI clickRight event is not blocked and this wrapper fires;
+    // returning wrapped(event) lets core's _onClickRight → control() → _onControl()
+    // → scene.view() handle the level switch naturally.
+    if (hasLevels()) {
+      const tokenLevel = getTokenLevelId(this.document);
+      const viewedLevel = getViewedLevelId();
+      if (tokenLevel && viewedLevel && tokenLevel !== viewedLevel) {
+        dbg("hud:_onClickRight", "cross-level click, deferring to core",
+          { actorName: this.actor?.name, tokenLevel, viewedLevel });
+        return wrapped(event);
+      }
+    }
+
+    // Same-level (or v13) interactive token: keep custom HUD-bind behavior.
     dbg("hud:_onClickRight", { actorName: this.actor?.name, hasActiveHUD: this.hasActiveHUD, playerView: isPlayerView() });
     if (this.layer.hud) {
       // In player-view mode skip control() so the interactive token is never

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -16,7 +16,7 @@ import { createStateToggleButton, insertHeaderButton, createRowControl } from ".
 import { dbg } from "./utils/debugLog.mjs";
 import { findCanvasDropTargets } from "./utils/canvasDropTargets.mjs";
 import { isModuleGM, isPlayerView } from "./utils/playerView.mjs";
-import { getTokenLevelId } from "./utils/levels.mjs";
+import { hasLevels, getTokenLevelId } from "./utils/levels.mjs";
 
 const MODULE_ID = "pick-up-stix";
 const DEFAULT_ICON = `modules/${MODULE_ID}/icons/interactive-item-icon.svg`;
@@ -1445,8 +1445,10 @@ function _reevaluateInteractiveProximity() {
 // so we identify stale apps by parent actor rather than instanceof.
 Hooks.on("updateToken", (tokenDoc, changes, options, userId) => {
   if (isModuleGM()) return;
-  if (!("x" in changes || "y" in changes)) {
-    dbg("hook:updateToken", "no x/y in changes, bail", { tokenId: tokenDoc.id });
+  // Trigger on x, y, OR level changes — level is a movement field in v14
+  // and a pure level transition can change proximity outcomes without a coord change.
+  if (!("x" in changes || "y" in changes || "level" in changes)) {
+    dbg("hook:updateToken", "no x/y/level in changes, bail", { tokenId: tokenDoc.id });
     return;
   }
 
@@ -1458,8 +1460,12 @@ Hooks.on("updateToken", (tokenDoc, changes, options, userId) => {
 
   // Record the definitive final position for this specific token. Foundry's
   // animation interpolates document.x/y mid-flight so the `changes` payload
-  // is the only reliable source of the final coordinates.
+  // is the only reliable source of the final coordinates. Also capture level
+  // on v14 so cross-level proximity checks use animation-safe data.
   const newPos = { x: changes.x ?? tokenDoc.x, y: changes.y ?? tokenDoc.y, width: tokenDoc.width, height: tokenDoc.height };
+  if (hasLevels()) {
+    newPos.level = changes.level ?? getTokenLevelId(tokenDoc);
+  }
   dbg("hook:updateToken", "candidate token moved, recording position override", { tokenId: tokenDoc.id, newPos });
   setPlayerPositionOverride(tokenDoc.id, newPos);
 
@@ -1480,8 +1486,13 @@ Hooks.on("controlToken", (token, controlled) => {
 
   // When newly controlled, seed its position override so checkProximity uses
   // fresh coords immediately (rather than waiting for its next updateToken).
+  // Also capture level on v14 so cross-level proximity checks are correct
+  // from the moment of selection.
   if (controlled) {
     const pos = { x: tokenDoc.x, y: tokenDoc.y, width: tokenDoc.width, height: tokenDoc.height };
+    if (hasLevels()) {
+      pos.level = getTokenLevelId(tokenDoc);
+    }
     dbg("hook:controlToken", "seeding position override for newly controlled token", { tokenId: tokenDoc.id, pos });
     setPlayerPositionOverride(tokenDoc.id, pos);
   }

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -687,7 +687,10 @@ Hooks.on("preUpdateToken", (tokenDoc, changes, options, userId) => {
 
   const newX = changes.x ?? tokenDoc.x;
   const newY = changes.y ?? tokenDoc.y;
-  const overlapTargets = findCanvasDropTargets(newX, newY, { sourceActorId: actor.id });
+  // v14: a token can only overlap deposit targets on the same level it's moving to.
+  // Use the destination level from `changes.level` if present, else the token's current level.
+  const newLevel = hasLevels() ? (changes.level ?? getTokenLevelId(tokenDoc)) : null;
+  const overlapTargets = findCanvasDropTargets(newX, newY, { sourceActorId: actor.id, level: newLevel });
 
   if (!overlapTargets.length) {
     dbg("hook:preUpdateToken", "no overlap targets, allow move");

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -16,6 +16,7 @@ import { createStateToggleButton, insertHeaderButton, createRowControl } from ".
 import { dbg } from "./utils/debugLog.mjs";
 import { findCanvasDropTargets } from "./utils/canvasDropTargets.mjs";
 import { isModuleGM, isPlayerView } from "./utils/playerView.mjs";
+import { getTokenLevelId } from "./utils/levels.mjs";
 
 const MODULE_ID = "pick-up-stix";
 const DEFAULT_ICON = `modules/${MODULE_ID}/icons/interactive-item-icon.svg`;
@@ -1675,16 +1676,34 @@ async function _onActorFolderChanged(value) {
   }
 }
 
+/**
+ * Drops an item from the dnd5e context menu "Drop Item" entry onto the canvas
+ * at the dropping actor's current token position. On v14, also forwards the
+ * actor's current level so the placed token lands on the correct floor.
+ *
+ * @param {Item} item - The item to drop from the actor's inventory.
+ */
 async function _dropItemOnCanvas(item) {
   const actor = item.actor;
   if (!actor) return;
 
   const token = canvas.tokens.placeables.find(t => t.actor?.id === actor.id);
   if (!token) {
+    dbg("place:_dropItemOnCanvas", "no canvas token for actor, bail", { actorName: actor?.name });
     ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoToken"));
     return;
   }
 
+  const tokenDoc = token.document;
+  dbg("place:_dropItemOnCanvas", {
+    itemName: item.name, x: tokenDoc.x, y: tokenDoc.y, level: getTokenLevelId(tokenDoc)
+  });
+
   const { handleItemDrop } = await import("./canvas/placement.mjs");
-  await handleItemDrop({ uuid: item.uuid, x: token.document.x, y: token.document.y });
+  await handleItemDrop({
+    uuid: item.uuid,
+    x: tokenDoc.x,
+    y: tokenDoc.y,
+    level: getTokenLevelId(tokenDoc)    // v14: forward the dropping actor's level
+  });
 }

--- a/scripts/socket/SocketHandler.mjs
+++ b/scripts/socket/SocketHandler.mjs
@@ -42,7 +42,8 @@ export function registerSocket() {
         const item = await fromUuid(payload.data.itemUuid);
         if (!item) break;
         await createInteractiveToken(item, payload.data.x, payload.data.y, {
-          ephemeral: !!payload.data.ephemeral
+          ephemeral: !!payload.data.ephemeral,
+          level: payload.data.level ?? null      // forward player-supplied level (v14)
         });
         if (payload.data.sourceActorId && payload.data.itemId) {
           const sourceActor = game.actors.get(payload.data.sourceActorId);

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -4,6 +4,7 @@ import { notifyItemAction, notifyTransferError } from "../utils/notify.mjs";
 import { validateContainerAccess, validateItemAccess } from "../utils/containerAccess.mjs";
 import { dbg } from "../utils/debugLog.mjs";
 import { isModuleGM } from "../utils/playerView.mjs";
+import { hasLevels, getTokenLevelId } from "../utils/levels.mjs";
 
 const MODULE_ID = "pick-up-stix";
 
@@ -232,6 +233,24 @@ export function checkProximity(interactiveActor, { silent = false, range = "inte
   // the updateToken / controlToken hooks) over the live document coords, which
   // Foundry's animation system overwrites mid-flight.
   const override = getPlayerPositionOverride(playerToken.document.id);
+
+  // v14: a candidate on a different level than the interactive object can never
+  // be in interaction or inspection range. Use override.level (animation-safe)
+  // when available, else fall back to the live document's _source.level.
+  if (hasLevels()) {
+    const objectToken = interactiveActor.token
+      ? canvas.tokens.get(interactiveActor.token.id)
+      : canvas.tokens.placeables.find(t => t.actor?.id === interactiveActor.id);
+    const objectLevel = objectToken ? getTokenLevelId(objectToken.document) : null;
+    const playerLevel = override?.level ?? getTokenLevelId(playerToken.document);
+    if (objectLevel && playerLevel && objectLevel !== playerLevel) {
+      dbg("xfer:checkProximity", "level mismatch, fail",
+        { actorName: interactiveActor.name, objectLevel, playerLevel });
+      if (!silent) ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TooFar"));
+      return false;
+    }
+  }
+
   const source = override ?? {
     x: playerToken.document.x,
     y: playerToken.document.y,

--- a/scripts/utils/canvasDropTargets.mjs
+++ b/scripts/utils/canvasDropTargets.mjs
@@ -1,16 +1,40 @@
 import { isInteractiveActor, isInteractiveContainer } from "./actorHelpers.mjs";
 import { dbg } from "./debugLog.mjs";
+import { hasLevels, getViewedLevelId, getTokenLevelId } from "./levels.mjs";
 
 export const PLACE_ON_CANVAS = "__place__";
 
-export function findCanvasDropTargets(x, y, { sourceActorId = null } = {}) {
+/**
+ * Finds canvas tokens whose footprint contains the given pixel position that are
+ * valid deposit targets (non-interactive actors, interactive containers, or PC/NPC
+ * tokens). Excludes the source actor when `sourceActorId` is provided.
+ *
+ * On Foundry v14, an optional `level` filter restricts results to tokens on the
+ * specified level. When `level` is null on v14, defaults to the currently-viewed
+ * level so that stacked-visible tokens on a different floor are never falsely
+ * registered as drop targets. On v13 the filter is a no-op.
+ *
+ * @param {number} x - Canvas x coordinate of the drop point.
+ * @param {number} y - Canvas y coordinate of the drop point.
+ * @param {object} [options]
+ * @param {string|null} [options.sourceActorId=null] - Actor id to exclude from results.
+ * @param {string|null} [options.level=null] - v14 level id to restrict to. Null defaults
+ *   to the currently-viewed level on v14, or no filtering on v13.
+ * @returns {Token[]} Array of matching Token placeables.
+ */
+export function findCanvasDropTargets(x, y, { sourceActorId = null, level = null } = {}) {
   const size = canvas.grid.size;
   const targets = [];
+  // On v14, default to the currently-viewed level when no explicit level was supplied.
+  // On v13 this resolves to null and the level filter below is a no-op.
+  const requireLevel = level ?? (hasLevels() ? getViewedLevelId() : null);
   for (const t of canvas.tokens?.placeables ?? []) {
     const actor = t.actor;
     if (!actor) continue;
     if (isInteractiveActor(actor) && !isInteractiveContainer(actor)) continue;
     if (sourceActorId && actor.id === sourceActorId) continue;
+    // v14: skip tokens on a different level than the drop target level.
+    if (requireLevel && getTokenLevelId(t.document) !== requireLevel) continue;
     const tx = t.document.x;
     const ty = t.document.y;
     const tw = t.document.width * size;
@@ -18,8 +42,8 @@ export function findCanvasDropTargets(x, y, { sourceActorId = null } = {}) {
     if (x < tx || x >= tx + tw || y < ty || y >= ty + th) continue;
     targets.push(t);
   }
-  dbg("dropTargets:find", { x, y, sourceActorId, count: targets.length,
-    names: targets.map(t => t.actor.name) });
+  dbg("dropTargets:find", { x, y, sourceActorId, level: requireLevel,
+    count: targets.length, names: targets.map(t => t.actor.name) });
   return targets;
 }
 

--- a/scripts/utils/levels.mjs
+++ b/scripts/utils/levels.mjs
@@ -1,0 +1,63 @@
+/**
+ * Feature-detected helpers for the v14 native levels system.
+ *
+ * These helpers degrade to the v13 behavior (no levels, single flat plane)
+ * when running on a Foundry version that lacks the `canvas.level` cursor.
+ * Every consumer should call through these helpers rather than reading
+ * `canvas.level` / `tokenDoc.level` directly so that v13 compatibility
+ * remains a one-line check in this file.
+ */
+
+/** Returns true when the active client is running v14+ and a Level is currently displayed. */
+export function hasLevels() {
+  return !!canvas?.level;
+}
+
+/** Returns the id of the currently-viewed level, or null on v13 / no active scene. */
+export function getViewedLevelId() {
+  return canvas?.level?.id ?? null;
+}
+
+/**
+ * Returns the level id of a token document, or null if absent. Reads from
+ * `_source.level` first because v14's animation system can interpolate the
+ * live `tokenDoc.level` mid-flight; the source field is the persisted truth.
+ *
+ * @param {TokenDocument|null} tokenDoc
+ * @returns {string|null}
+ */
+export function getTokenLevelId(tokenDoc) {
+  if (!tokenDoc) return null;
+  return tokenDoc._source?.level ?? tokenDoc.level ?? null;
+}
+
+/**
+ * Returns the elevation base (finite floor) of the currently-viewed level,
+ * or 0 on v13 / no active level.
+ *
+ * @returns {number}
+ */
+export function getViewedLevelElevationBase() {
+  return canvas?.level?.elevation?.base ?? 0;
+}
+
+/**
+ * Decides whether two token documents are on the same level for the purposes
+ * of player interaction. Returns true when:
+ *  - we are on v13 (no level field exists), OR
+ *  - both tokens lack a `level` value, OR
+ *  - both tokens carry the same `level` id.
+ *
+ * Returns false only when both tokens have a `level` and they differ.
+ *
+ * @param {TokenDocument} tokenDocA
+ * @param {TokenDocument} tokenDocB
+ * @returns {boolean}
+ */
+export function tokensOnSameLevel(tokenDocA, tokenDocB) {
+  if (!hasLevels()) return true;
+  const a = getTokenLevelId(tokenDocA);
+  const b = getTokenLevelId(tokenDocB);
+  if (!a && !b) return true;
+  return a === b;
+}


### PR DESCRIPTION
## Summary

Adds native Foundry v14 levels support to pick-up-stix. Interactive tokens are now placed on the correct level when dropped, proximity checks enforce same-level requirements, and the right-click HUD behavior respects level boundaries. All changes are gated behind `hasLevels()` (`!!canvas?.level`) so v13 compatibility is fully preserved.

## Changes

### New file: `scripts/utils/levels.mjs`
Five feature-detected helpers that degrade gracefully on v13:
- `hasLevels()` — guards all v14-specific code paths
- `getViewedLevelId()` — currently-viewed level id
- `getTokenLevelId(tokenDoc)` — reads `_source.level` (animation-safe) with live fallback
- `getViewedLevelElevationBase()` — floor elevation of the current level
- `tokensOnSameLevel(a, b)` — shared predicate for same-level checks

### Token placement (`scripts/canvas/placement.mjs`, `scripts/socket/SocketHandler.mjs`)
- `createInteractiveToken` stamps `tokenData.level` from the explicit arg or the GM's currently-viewed level
- `createTokenFromActor` stamps the viewed level when creating from the sidebar
- Player drops capture their character token's level and forward it over the socket so the GM creates the token on the player's level, not the GM's viewed level
- dnd5e context-menu "Drop Item" path forwards the dropping actor's token level
- Canvas drop target filtering (`scripts/utils/canvasDropTargets.mjs`) restricts overlap candidates to the same level as the drop, preventing stacked-visible containers on other floors from appearing as deposit targets

### Proximity gating (`scripts/transfer/ItemTransfer.mjs`, `scripts/pick-up-stix.mjs`)
- `checkProximity` bails immediately when the player token and interactive object are on different levels (uses the animation-safe position override's `level` field when available)
- `updateToken` hook triggers on `"level" in changes` so pure level transitions re-evaluate open sheets and proximity; captures destination level in the position override
- `controlToken` hook seeds level into the position override on token selection

### HUD and right-click (`scripts/hud/InteractiveTokenHUD.mjs`)
- `_patchCanHUD` returns true for cross-level tokens so the PIXI `clickRight` event is not blocked (returning false there also cancels `_onClickRight`)
- `_patchClickRight` detects cross-level tokens and calls `wrapped(event)`, deferring to core's `_onClickRight → control() → _onControl() → scene.view()` to switch the GM's canvas level; players receive no action, matching core's non-owner behavior

## Design decisions

- **Active level wins:** tokens always land on the currently-active level when dropped — the player's character level (forwarded via socket) or the GM's viewed level. No saved snapshot level is used.
- **Strict floor model:** cross-level tokens are completely inaccessible for interaction (pickup, open/close, deposit, inspection). Players on a different level see no HUD and pass all proximity checks as out-of-range.
- **No breaking change / no migration:** adding `level` to token creation data is additive; existing tokens without a `level` field fall back to the v14 default level transparently.