### PR TITLE
fix: narrow GM-override scope to canvas-experience sites only

### DIFF
--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -6,7 +6,6 @@ import { getPlayerCandidateTokens, depositItem, buildInteractiveItemData, assign
 import { dbg } from "../utils/debugLog.mjs";
 import { dragModifiersHeld } from "../utils/dragModifier.mjs";
 import { findCanvasDropTargets, promptDropChoice, PLACE_ON_CANVAS } from "../utils/canvasDropTargets.mjs";
-import { isModuleGM, isPlayerView } from "../utils/playerView.mjs";
 import { hasLevels, getViewedLevelId, getTokenLevelId } from "../utils/levels.mjs";
 
 const MODULE_ID = "pick-up-stix";
@@ -99,7 +98,7 @@ async function _handleItemDrop(data) {
   // GMs use the viewed level (null → findCanvasDropTargets internal default).
   // Players use their character's level so a stacked-visible container on a different
   // floor doesn't falsely prompt for deposit.
-  const dropLevel = isModuleGM()
+  const dropLevel = game.user.isGM
     ? (data.level ?? null)
     : (() => {
         const ownerToken = item.actor
@@ -132,7 +131,7 @@ async function _handleItemDrop(data) {
     dbg("place:_handleItemDrop", "user chose PLACE_ON_CANVAS, fall through to placement");
   }
 
-  if (isModuleGM()) {
+  if (game.user.isGM) {
     dbg("place:_handleItemDrop", "GM path — createInteractiveToken", {
       x: data.x, y: data.y, ephemeral, level: data.level ?? null
     });
@@ -221,13 +220,13 @@ async function depositItemToTarget(item, targetToken) {
   });
 
   // Players can't remove world items; depositItem requires a source actor.
-  if (isPlayerView() && !item.actor) {
+  if (!game.user.isGM && !item.actor) {
     dbg("place:depositItemToTarget", "player dropping world item onto target, bail");
     ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
     return;
   }
 
-  if (isModuleGM()) {
+  if (game.user.isGM) {
     // Use item reference directly — synthetic parent actors aren't in game.actors.
     if (!item.actor) {
       const itemData = item.toObject();
@@ -283,7 +282,7 @@ async function depositActorToTarget(droppedActor, targetToken) {
     itemData.system.container = targetActor.system.containerItem.id;
   }
 
-  if (isModuleGM()) {
+  if (game.user.isGM) {
     dbg("place:depositActorToTarget", "GM path: createDocuments on target");
     await CONFIG.Item.documentClass.createDocuments([itemData], { parent: targetActor, keepId: false });
     notifyItemAction("Deposited", droppedActor.name);

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -164,7 +164,7 @@ Hooks.once("init", () => {
       });
     }
 
-    if (isPlayerView()) return;
+    if (!game.user.isGM) return;
     const iiFlags = getItemIIFlags(item);
     if (!iiFlags?.sourceActorId) return;
     const sourceActorId = getItemSourceActorId(item);
@@ -192,7 +192,7 @@ Hooks.once("init", () => {
   // dnd5e uses both `<img class="item-image">` (raster) and `<dnd5e-icon class="item-image">` (SVG);
   // both share the class so the querySelector catches either.
   const _injectIdentifyToggles = (app, html) => {
-    if (isPlayerView()) return;
+    if (!game.user.isGM) return;
     if (isInteractiveActor(app.actor)) return;
     const root = html instanceof HTMLElement ? html : html?.[0];
     if (!root) return;
@@ -229,7 +229,7 @@ Hooks.once("init", () => {
   Hooks.on("renderNPCActorSheet", _injectIdentifyToggles);
 
   Hooks.on("renderItemSheet5e", (app, html) => {
-    if (isPlayerView()) return;
+    if (!game.user.isGM) return;
     const item = app.item;
     const actor = item?.actor;
 
@@ -512,7 +512,7 @@ Hooks.once("init", () => {
   });
 
   Hooks.on("dropActorSheetData", (actor, sheet, data) => {
-    if (isPlayerView()) return;
+    if (!game.user.isGM) return;
     if (isInteractiveActor(actor)) return;
     if (data?.type !== "Actor") return;
 
@@ -1186,7 +1186,7 @@ Hooks.on("updateItem", async (item, changes, options, userId) => {
 Hooks.on("renderActorDirectory", (app, html, context, options) => {
   const ephemeralFolderId = game.settings.get(MODULE_ID, "ephemeralFolder");
   const ephemeralVisible = game.settings.get(MODULE_ID, "ephemeralFolderVisible");
-  const hideEphemeralFolder = isPlayerView() || !ephemeralVisible;
+  const hideEphemeralFolder = !game.user.isGM || !ephemeralVisible;
 
   if (ephemeralFolderId && hideEphemeralFolder) {
     const folderEl = html.querySelector(`.folder[data-folder-id="${ephemeralFolderId}"]`);
@@ -1198,12 +1198,12 @@ Hooks.on("renderActorDirectory", (app, html, context, options) => {
     const actor = game.actors.get(actorId);
     if (!isInteractiveActor(actor)) return;
     const isEphemeral = !!actor.getFlag(MODULE_ID, "ephemeral");
-    if (isPlayerView() || (isEphemeral && hideEphemeralFolder)) {
+    if (!game.user.isGM || (isEphemeral && hideEphemeralFolder)) {
       el.remove();
     }
   });
 
-  if (isPlayerView()) return;
+  if (!game.user.isGM) return;
 
   // Ephemeral actors are created programmatically — block manual creation.
   if (ephemeralFolderId && !hideEphemeralFolder) {
@@ -1244,7 +1244,7 @@ Hooks.on("renderUserConfig", (app, html) => {
 });
 
 Hooks.on("renderActorDirectory", (app, element) => {
-  if (isPlayerView()) return;
+  if (!game.user.isGM) return;
   if (element.dataset.iiCreatePickerAttached) return;
   element.dataset.iiCreatePickerAttached = "1";
 

--- a/scripts/sheets/InteractiveItemSheet.mjs
+++ b/scripts/sheets/InteractiveItemSheet.mjs
@@ -219,7 +219,7 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
 
     // Item-kind actors abandoned in the picker (no item ever dropped) — delete.
     const MODULE_ID = "pick-up-stix";
-    if (actor && game.actors.has(actor.id) && !actor.token && isModuleGM()
+    if (actor && game.actors.has(actor.id) && !actor.token && game.user.isGM
       && actor.getFlag(MODULE_ID, "createKindConfirmed")
       && actor.items.size === 0) {
       await actor.delete();
@@ -367,9 +367,9 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       actorName: this.actor?.name,
       itemName: item?.name,
       itemImg: item?.img,
-      isGM: isModuleGM()
+      isGM: game.user.isGM
     });
-    if (isPlayerView()) {
+    if (!game.user.isGM) {
       dbg("sheet:#syncItemImage", "not GM, bail");
       return;
     }
@@ -484,7 +484,7 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       return;
     }
 
-    if (isPlayerView()) {
+    if (!game.user.isGM) {
       dbg("sheet:_onDrop", "not GM, bail");
       return;
     }


### PR DESCRIPTION
## Summary

- Reverts `isModuleGM()` / `isPlayerView()` to raw `game.user.isGM` at all directory, creation, and inventory-management sites
- GM retains full sidebar access (Interactive Objects folder, ephemeral subfolder, actor rows, create-picker, trash button, abandoned-actor cleanup) regardless of override state
- All item/token creation flows (canvas drops, inventory drops, actor-to-sheet drops, deposits) remain unrestricted for the GM
- Inventory-management affordances (wand-icon identify toggle, Reveal/Hide context menu entry, Lock/Configure on item sheets) stay GM-visible regardless of override
- Canvas-experience sites (token HUD, proximity gating, nameplate, container contents-hide, header injection) remain on the override helpers — those are the only surfaces the toggle is intended to affect