### PR TITLE
chore: move release tag to module.json update commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,5 @@ jobs:
           git add module.json
           git diff --cached --quiet || git commit -m "chore: update module.json to $VERSION"
           git push origin "$SOURCE_BRANCH"
+          git tag -f "$TAG" HEAD
+          git push origin "refs/tags/$TAG" --force


### PR DESCRIPTION
## Summary

- After the release workflow commits the updated `module.json` back to the source branch, force-moves the tag to that new commit
- Ensures the tag and the `module.json` version it references always live on the same commit
- If `module.json` was already up to date (no commit needed), the tag remains on its current commit unchanged