### PR TITLE
feat: default debug logging to off and add GM override toggle tooltips

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -127,7 +127,9 @@
     "DefaultItemName": "New Interactive Item",
     "DefaultContainerName": "New Interactive Container",
     "Controls": {
-      "ToolsTool": "Interactive Items Tools"
+      "ToolsTool": "Interactive Items Tools",
+      "EnableGMOverride": "Enable GM Override",
+      "DisableGMOverride": "Disable GM Override"
     },
     "Dialog": {
       "PlaceTitle": "Place Interactive Object",

--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -567,7 +567,9 @@ function onGetSceneControlButtons(controls) {
 
   controls.tokens.tools.interactiveItemsTools = {
     name: "interactiveItemsTools",
-    title: "INTERACTIVE_ITEMS.Controls.ToolsTool",
+    title: game.settings.get(MODULE_ID, "gmOverrideEnabled")
+      ? "INTERACTIVE_ITEMS.Controls.DisableGMOverride"
+      : "INTERACTIVE_ITEMS.Controls.EnableGMOverride",
     icon: "fa-solid fa-hand-holding-box",
     order: 100,
     toggle: true,

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -58,7 +58,7 @@ Hooks.once("init", () => {
     scope: "client",
     config: true,
     type: Boolean,
-    default: true
+    default: false
   });
 
   game.settings.register(MODULE_ID, "gmOverrideEnabled", {


### PR DESCRIPTION
## Summary

- Default the `debugLogging` client setting to `false` so production worlds don't emit console noise out of the box
- Add context-sensitive tooltips to the GM override scene control toggle: shows \"Enable GM Override\" when off and \"Disable GM Override\" when on; tooltip updates on each toggle since `_onGMOverrideChanged` already calls `ui.controls.render({ reset: true })`