### PR TITLE
feat: add pf2e support via system adapter architecture

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Report something that doesn't work the way it should
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in every section — issues missing version info or repro steps are very hard to act on.
+
+  - type: input
+    id: module-version
+    attributes:
+      label: Module version
+      description: From `module.json` (e.g. `1.0.4`).
+      placeholder: 1.0.4
+    validations:
+      required: true
+
+  - type: input
+    id: foundry-version
+    attributes:
+      label: Foundry VTT version
+      description: Full version including build (e.g. `13.351`, `14.360`).
+      placeholder: 13.351
+    validations:
+      required: true
+
+  - type: dropdown
+    id: system
+    attributes:
+      label: Game system
+      options:
+        - dnd5e
+        - pf2e
+    validations:
+      required: true
+
+  - type: input
+    id: system-version
+    attributes:
+      label: System version
+      description: Full version (e.g. dnd5e `4.3.6`, pf2e `8.1.0`).
+      placeholder: 8.1.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Exact reproduction steps
+      description: Numbered steps starting (from a fresh world is best if possible). Include what you clicked, dragged, typed, and which sheet/dialog was open.
+      placeholder: |
+        1. Create a new interactive container actor (which method was used?).
+        2. Drop a backpack item onto its config sheet.
+        3. Place a token on the canvas.
+        4. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug logs
+      description: |
+        Enable debug logging in the module settings (`Pick-Up-Stix > Debug Logging`), reproduce the bug, then paste the relevant `[PUS]` lines from the browser console (F12 → Console). Include any non-PUS errors that fired in the same window.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Other modules / notes
+      description: Other active modules that touch tokens, sheets, drag-and-drop, or items. Anything else you think might be relevant.
+    validations:
+      required: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+**/Procfile*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Pick-Up-Stix
 
-A Foundry VTT v13+ module for the dnd5e and pf2e systems that lets GMs place interactive objects on the canvas for players to discover, inspect, and interact with. Objects use the active system's native item and container sheets for a seamless experience.
+A Foundry VTT v13+ module that lets GMs place interactive objects on the canvas for players to discover, inspect, and interact with. Objects use the active game system's native item and container sheets for a seamless experience.
+
+> Behavior may differ slightly between supported game systems where the underlying system handles a feature differently (most notably around identification and how a system displays container contents). The module follows each system's own conventions rather than imposing its own UI.
 
 ## Features
 
@@ -8,53 +10,48 @@ A Foundry VTT v13+ module for the dnd5e and pf2e systems that lets GMs place int
 
 A single interactive object actor type adapts its behavior to whatever Item is dropped onto it:
 
-- **Item mode** -- When the embedded item is any non-container (weapon, potion, quest item, etc.). Players inspect via the system's native item sheet and pick the object up, removing the token from the canvas. Supports an unidentified state with a separate name, image, and description, powered by the active system's built-in identification model.
-- **Container mode** -- When the embedded item is a container (dnd5e `container`, pf2e `backpack`, etc.). Opens the system's native container sheet with full inventory display. Supports open/close and lock/unlock states with token image swapping between closed and open art.
+- **Item mode** -- When the embedded item is any non-container (weapon, potion, quest item, etc.). Players inspect via the system's native item sheet and pick the object up, removing the token from the canvas. Supports an unidentified state with a separate name, image, and description.
+- **Container mode** -- When the embedded item is a container. Opens the system's native container sheet with full inventory display. Supports open/close and lock/unlock states with the token image swapping between closed and open art.
 
 ### Native System Sheet Integration
 
-Interactive objects display their contents through the active system's own sheets, routed through a per-system adapter:
-
-- **dnd5e** -- Item-mode opens `ItemSheet5e`; container-mode opens `ContainerSheet` with the full dnd5e inventory grid, drag/drop, encumbrance, and filtering. Identification uses dnd5e's built-in `system.identified` / `system.unidentified` fields.
-- **pf2e** -- Item-mode opens the matching per-type sheet (`WeaponSheetPF2e`, `EquipmentSheetPF2e`, `ConsumableSheetPF2e`, etc.); container-mode opens `ContainerSheetPF2e` for the embedded backpack item. Identification uses pf2e's `system.identification.status` (with the system's own mystify popup for image/name/description overrides).
-- The native sheet automatically hides details from non-GM players when an item is unidentified, regardless of system.
+Interactive objects display through the active system's own item and container sheets so players see a familiar interface. Identification leverages each system's built-in identification model, with the actor and embedded item kept in sync; toggling identification preserves both the identified and unidentified presentations across cycles.
 
 ### Player Interaction
 
 - **Token HUD** -- Players interact through buttons on the Token HUD: inspect contents, pick up items, and open/close containers.
 - **Two proximity ranges** -- Each object has a configurable **inspection range** (to see the nameplate and open the sheet) and a tighter **interaction range** (to pick up, open/close, lock, or view container contents). Beyond inspection range, players see a **limited-view dialog** with a generic name and description; when they move into inspection range, the dialog is promoted in place to the real sheet. Sheets update live as a player moves through the ranges.
 - **Limited name / description** -- GMs can set a `Limited Name` and `Limited Description` shown to distant observers. When blank, a sensible fallback is used ("A chest of some sort" / "You are too far away to discern any details."). Containers append an "it appears open/closed" line automatically.
-- **Hidden container contents** -- (dnd5e) When a player opens a container sheet while closed, locked, or outside interaction range, the inventory is replaced with a placeholder message instead of listing contents. On pf2e the native `ContainerSheetPF2e` only displays the backpack's properties, so contents are not exposed regardless of state.
-- **Drop items** -- Players can drop items from their inventory onto the canvas via drag-and-drop or the "Drop Item" right-click context menu. Items are placed at the player's token position. By default no modifier key is required; GMs can optionally require Ctrl via the "Require Ctrl for drag actions" Module Setting.
-- **Deposit items** -- Players can drag items from their inventory into an open container's sheet to deposit them.
+- **Hidden container contents** -- When a player opens a container while it is closed, locked, or they are outside interaction range, the inventory listing is replaced with a placeholder message instead of revealing what's inside.
+- **Drop items** -- Players can drop items from their inventory onto the canvas via drag-and-drop or a "Drop Item" right-click context menu where the system supports it. Items are placed at the player's token position. By default no modifier key is required; GMs can optionally require Ctrl via the "Require Ctrl for drag actions" Module Setting.
+- **Deposit items** -- Players can drag items from their inventory into an open container to deposit them.
 - **Unidentified item privacy** -- When an interactive object item is in a player's inventory, the player sees only the generic name, image, and description until a GM reveals it.
 
 ### GM Tools
 
 - **GM configuration dialog** -- Each interactive object has a dedicated config dialog for module-specific properties (interaction range, inspection range, identified/open/limited images, limited name/description, locked message). Accessible from the Token HUD (gear icon), the system sheet header (gear icon), or by clicking the base actor in the sidebar.
-- **Drag-and-drop placement** -- Drag any item from an inventory or the Items sidebar onto the canvas to create an interactive object, or drag an interactive actor from the sidebar to place one of its tokens. GMs can place anywhere; players drop at their own token. By default no modifier key is required; GMs can require Ctrl via the "Require Ctrl for drag actions" Module Setting (Cmd on macOS).
+- **Drag-and-drop placement** -- Drag any item from an inventory or the Items sidebar onto the canvas to create an interactive object, or drag an interactive actor from the sidebar to place one of its tokens. GMs can place anywhere; players drop at their own token.
 - **Template vs ephemeral actors** -- When placing a world item, GMs can choose to create a persistent template actor (reusable) or an ephemeral one-off placement that auto-cleans when the token is removed.
-- **Drop actors into containers** -- Drag an item-mode interactive object actor from the sidebar onto any container sheet (interactive container, PC/NPC backpack, or world-level container) to add it. The container preserves the actor's identification state and round-trip flags. Container-mode actors cannot be nested.
+- **Drop actors into containers** -- Drag an item-mode interactive object actor from the sidebar onto any container sheet to add it. The container preserves the actor's identification state and round-trip flags. Container-mode actors cannot be nested.
 - **Scene control button** -- A toolbar button to create empty interactive objects from scratch.
 - **GM actor picker** -- When a GM picks up an item with no unambiguous target (no single controlled NPC/PC token), a searchable dialog lists all non-interactive actors on the current scene so the GM can choose who receives the item. When multiple non-interactive tokens are already controlled, the picker is scoped to just those candidates.
 - **Lock and identify controls** -- Available from the config dialog, Token HUD, and the system's native sheet header. Locking an open container also closes it.
 - **Open/close toggle on container sheet** -- GMs see an open/close button in the container sheet header that toggles the container state and updates both the sheet image and token image.
-- **Per-item identification toggle** -- (dnd5e) In a player's character sheet inventory, a GM-only wand icon appears next to each interactive object item, and a "Reveal / Hide" entry is added to the inventory context menu. (pf2e) The system's own per-row identify control is used.
-- **Pickup buttons in container sheets** -- Token container sheets show pickup buttons next to each item in the inventory for quick item transfer.
+- **Per-item pickup and management in containers** -- GMs see lock, identify, and delete controls per row inside a container's contents listing. Where the system displays its own row controls, those are reused; otherwise the module renders its own.
+- **Drag items from container contents** -- Items in a container's contents listing can be dragged out to the canvas (placed as an interactive token) or onto another character/container sheet (transfers ownership).
 - **Configurable defaults** -- Module settings for default container images (open and closed), default interaction and inspection ranges, actor folder organization, and folder color.
 
 ### Architecture Highlights
 
-- **System adapter** -- All system-specific surfaces (item types, identification, sheet delegation, drop hooks, context menus) are isolated behind a `SystemAdapter` contract. The active adapter (`dnd5e/`, `pf2e/`) is selected at module entry by `game.system.id`, so core code never branches on system identity.
+- **System adapter** -- All system-specific surfaces are isolated behind a `SystemAdapter` contract; one concrete adapter per supported system. Core code never branches on `game.system.id`, which keeps adding a new system to a single module under `scripts/adapter/`.
 - **Unlinked tokens** -- Each placed token is independent from the base actor template. Picking up an item from one token doesn't affect other tokens created from the same actor.
 - **Socket-based security** -- All player mutations (pickup, deposit, open/close, placement) route through sockets to the active GM client for processing.
 - **Round-trip placement** -- Items picked up from the canvas remember their source actor and token state. Dropping them back restores the original token appearance and reuses the original base actor.
-- **Native identification** -- Leverages each system's built-in identification model (dnd5e `IdentifiableTemplate`, pf2e `system.identification`), with bidirectional sync between the actor and embedded item via the adapter.
 
 ## Requirements
 
 - Foundry VTT v13+
-- One of: dnd5e system 4.0.0+ **or** pf2e system 8.0.0+
+- A supported game system (currently dnd5e 4.0.0+ or pf2e 8.0.0+)
 - [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper) module
 
 ## Installation
@@ -63,7 +60,7 @@ Install via the Foundry module browser by searching for "Pick-Up-Stix", or paste
 
 ## AI Usage
 
-AI has been used to CSS styling and for researching the Foundry VTT APIs to ensure proper usage most especially for determine the differences between the various versions of Foundry supported by the module.
+AI has been used for CSS styling and for researching the Foundry VTT APIs to ensure proper usage, most especially for determining the differences between the various versions of Foundry supported by the module.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,64 +1,65 @@
 # Pick-Up-Stix
 
-A Foundry VTT v13+ module for the dnd5e system that lets GMs place interactive objects on the canvas for players to discover, inspect, and interact with. Objects use native dnd5e item and container sheets for a seamless experience.
+A Foundry VTT v13+ module for the dnd5e and pf2e systems that lets GMs place interactive objects on the canvas for players to discover, inspect, and interact with. Objects use the active system's native item and container sheets for a seamless experience.
 
 ## Features
 
 ### One Actor, Two Modes
 
-A single interactive object actor type adapts its behavior to whatever dnd5e Item is dropped onto it:
+A single interactive object actor type adapts its behavior to whatever Item is dropped onto it:
 
-- **Item mode** -- When the embedded item is any non-container (weapon, potion, quest item, etc.). Players inspect via the native dnd5e item sheet and pick the object up, removing the token from the canvas. Supports an unidentified state with a separate name, image, and description, powered by dnd5e's built-in identification system.
-- **Container mode** -- When the embedded item is a dnd5e container (chests, barrels, crates, etc.). Opens the native dnd5e container sheet with full inventory grid, drag/drop, and filtering. Supports open/close and lock/unlock states with token image swapping between closed and open art.
+- **Item mode** -- When the embedded item is any non-container (weapon, potion, quest item, etc.). Players inspect via the system's native item sheet and pick the object up, removing the token from the canvas. Supports an unidentified state with a separate name, image, and description, powered by the active system's built-in identification model.
+- **Container mode** -- When the embedded item is a container (dnd5e `container`, pf2e `backpack`, etc.). Opens the system's native container sheet with full inventory display. Supports open/close and lock/unlock states with token image swapping between closed and open art.
 
-### Native dnd5e Sheet Integration
+### Native System Sheet Integration
 
-Interactive objects display their contents through dnd5e's own sheets:
+Interactive objects display their contents through the active system's own sheets, routed through a per-system adapter:
 
-- **Item-mode objects** open the embedded item's native `ItemSheet5e` -- players see the same polished sheet they'd see for any dnd5e item, with full description rendering, property display, and detail tabs.
-- **Container-mode objects** open the embedded container's native `ContainerSheet` -- the full dnd5e inventory grid with columns, drag/drop support, encumbrance tracking, and item filtering.
-- **Identification** uses dnd5e's built-in `system.identified` and `system.unidentified` fields. The dnd5e sheet automatically hides details from non-GM players when an item is unidentified.
+- **dnd5e** -- Item-mode opens `ItemSheet5e`; container-mode opens `ContainerSheet` with the full dnd5e inventory grid, drag/drop, encumbrance, and filtering. Identification uses dnd5e's built-in `system.identified` / `system.unidentified` fields.
+- **pf2e** -- Item-mode opens the matching per-type sheet (`WeaponSheetPF2e`, `EquipmentSheetPF2e`, `ConsumableSheetPF2e`, etc.); container-mode opens `ContainerSheetPF2e` for the embedded backpack item. Identification uses pf2e's `system.identification.status` (with the system's own mystify popup for image/name/description overrides).
+- The native sheet automatically hides details from non-GM players when an item is unidentified, regardless of system.
 
 ### Player Interaction
 
 - **Token HUD** -- Players interact through buttons on the Token HUD: inspect contents, pick up items, and open/close containers.
 - **Two proximity ranges** -- Each object has a configurable **inspection range** (to see the nameplate and open the sheet) and a tighter **interaction range** (to pick up, open/close, lock, or view container contents). Beyond inspection range, players see a **limited-view dialog** with a generic name and description; when they move into inspection range, the dialog is promoted in place to the real sheet. Sheets update live as a player moves through the ranges.
 - **Limited name / description** -- GMs can set a `Limited Name` and `Limited Description` shown to distant observers. When blank, a sensible fallback is used ("A chest of some sort" / "You are too far away to discern any details."). Containers append an "it appears open/closed" line automatically.
-- **Hidden container contents** -- When a player opens a container sheet while closed, locked, or outside interaction range, the inventory is replaced with a placeholder message instead of listing contents.
+- **Hidden container contents** -- (dnd5e) When a player opens a container sheet while closed, locked, or outside interaction range, the inventory is replaced with a placeholder message instead of listing contents. On pf2e the native `ContainerSheetPF2e` only displays the backpack's properties, so contents are not exposed regardless of state.
 - **Drop items** -- Players can drop items from their inventory onto the canvas via drag-and-drop or the "Drop Item" right-click context menu. Items are placed at the player's token position. By default no modifier key is required; GMs can optionally require Ctrl via the "Require Ctrl for drag actions" Module Setting.
 - **Deposit items** -- Players can drag items from their inventory into an open container's sheet to deposit them.
 - **Unidentified item privacy** -- When an interactive object item is in a player's inventory, the player sees only the generic name, image, and description until a GM reveals it.
 
 ### GM Tools
 
-- **GM configuration dialog** -- Each interactive object has a dedicated config dialog for module-specific properties (interaction range, inspection range, identified/open/limited images, limited name/description, locked message). Accessible from the Token HUD (gear icon), the dnd5e sheet header (gear icon), or by clicking the base actor in the sidebar.
+- **GM configuration dialog** -- Each interactive object has a dedicated config dialog for module-specific properties (interaction range, inspection range, identified/open/limited images, limited name/description, locked message). Accessible from the Token HUD (gear icon), the system sheet header (gear icon), or by clicking the base actor in the sidebar.
 - **Drag-and-drop placement** -- Drag any item from an inventory or the Items sidebar onto the canvas to create an interactive object, or drag an interactive actor from the sidebar to place one of its tokens. GMs can place anywhere; players drop at their own token. By default no modifier key is required; GMs can require Ctrl via the "Require Ctrl for drag actions" Module Setting (Cmd on macOS).
 - **Template vs ephemeral actors** -- When placing a world item, GMs can choose to create a persistent template actor (reusable) or an ephemeral one-off placement that auto-cleans when the token is removed.
-- **Drop actors into containers** -- Drag an item-mode interactive object actor from the sidebar onto any dnd5e container sheet (interactive container, PC/NPC backpack, or world-level container) to add it. The container preserves the actor's identification state and round-trip flags. Container-mode actors cannot be nested.
+- **Drop actors into containers** -- Drag an item-mode interactive object actor from the sidebar onto any container sheet (interactive container, PC/NPC backpack, or world-level container) to add it. The container preserves the actor's identification state and round-trip flags. Container-mode actors cannot be nested.
 - **Scene control button** -- A toolbar button to create empty interactive objects from scratch.
 - **GM actor picker** -- When a GM picks up an item with no unambiguous target (no single controlled NPC/PC token), a searchable dialog lists all non-interactive actors on the current scene so the GM can choose who receives the item. When multiple non-interactive tokens are already controlled, the picker is scoped to just those candidates.
-- **Lock and identify controls** -- Available from the config dialog, Token HUD, and dnd5e sheet header buttons. Locking an open container also closes it.
-- **Open/close toggle on container sheet** -- GMs see an open/close button in the dnd5e ContainerSheet header that toggles the container state and updates both the sheet image and token image.
-- **Per-item identification toggle** -- In a player's dnd5e character sheet inventory, a GM-only wand icon appears next to each interactive object item, and a "Reveal / Hide" entry is added to the inventory context menu.
+- **Lock and identify controls** -- Available from the config dialog, Token HUD, and the system's native sheet header. Locking an open container also closes it.
+- **Open/close toggle on container sheet** -- GMs see an open/close button in the container sheet header that toggles the container state and updates both the sheet image and token image.
+- **Per-item identification toggle** -- (dnd5e) In a player's character sheet inventory, a GM-only wand icon appears next to each interactive object item, and a "Reveal / Hide" entry is added to the inventory context menu. (pf2e) The system's own per-row identify control is used.
 - **Pickup buttons in container sheets** -- Token container sheets show pickup buttons next to each item in the inventory for quick item transfer.
 - **Configurable defaults** -- Module settings for default container images (open and closed), default interaction and inspection ranges, actor folder organization, and folder color.
 
 ### Architecture Highlights
 
+- **System adapter** -- All system-specific surfaces (item types, identification, sheet delegation, drop hooks, context menus) are isolated behind a `SystemAdapter` contract. The active adapter (`dnd5e/`, `pf2e/`) is selected at module entry by `game.system.id`, so core code never branches on system identity.
 - **Unlinked tokens** -- Each placed token is independent from the base actor template. Picking up an item from one token doesn't affect other tokens created from the same actor.
 - **Socket-based security** -- All player mutations (pickup, deposit, open/close, placement) route through sockets to the active GM client for processing.
 - **Round-trip placement** -- Items picked up from the canvas remember their source actor and token state. Dropping them back restores the original token appearance and reuses the original base actor.
-- **Native dnd5e identification** -- Leverages dnd5e's built-in `IdentifiableTemplate` for identification display, with bidirectional sync between the actor and embedded item.
+- **Native identification** -- Leverages each system's built-in identification model (dnd5e `IdentifiableTemplate`, pf2e `system.identification`), with bidirectional sync between the actor and embedded item via the adapter.
 
 ## Requirements
 
 - Foundry VTT v13+
-- dnd5e system 4.0.0+
+- One of: dnd5e system 4.0.0+ **or** pf2e system 8.0.0+
 - [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper) module
 
 ## Installation
 
-Install via the Foundry module browser by searching for "Interactive Items", or paste the manifest URL into the Install Module dialog.
+Install via the Foundry module browser by searching for "Pick-Up-Stix", or paste the manifest URL into the Install Module dialog.
 
 ## AI Usage
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -65,6 +65,8 @@
       "InspectionRange": "Inspection Range (squares)",
       "NameLabel": "Name",
       "Name": "Name",
+      "Quantity": "Qty",
+      "Bulk": "Bulk",
       "NamePlaceholder": "Name for this object...",
       "UnidentifiedName": "Unidentified Name",
       "UnidentifiedNamePlaceholder": "Name shown when unidentified...",

--- a/module.json
+++ b/module.json
@@ -26,6 +26,14 @@
         "compatibility": {
           "minimum": "4.0.0"
         }
+      },
+      {
+        "id": "pf2e",
+        "type": "system",
+        "compatibility": {
+          "minimum": "8.0.0",
+          "verified": "8.1.0"
+        }
       }
     ]
   },

--- a/scripts/adapter/NotImplementedError.mjs
+++ b/scripts/adapter/NotImplementedError.mjs
@@ -1,0 +1,17 @@
+/**
+ * Error thrown when a required SystemAdapter method has not been overridden
+ * by a concrete subclass. This surfaces missing adapter implementations early
+ * with a descriptive message rather than a generic TypeError.
+ */
+export class NotImplementedError extends Error {
+  /**
+   * @param {string} [methodName] - Optional name of the unimplemented method.
+   */
+  constructor(methodName) {
+    const msg = methodName
+      ? `SystemAdapter subclass did not override "${methodName}"`
+      : "SystemAdapter subclass did not override this method";
+    super(msg);
+    this.name = "NotImplementedError";
+  }
+}

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -166,25 +166,27 @@ export default class SystemAdapter {
   buildEmbeddedItemSourceUpdate(actor, isIdentified) { return {}; }
 
   /**
-   * Inverse of `buildEmbeddedItemSourceUpdate`: when the GM edits the
-   * embedded item's source-level name input on the system's native item
-   * sheet, return the matching actor update so the wrapping interactive
-   * actor's authoritative name fields stay in sync.
+   * Inverse of `buildEmbeddedItemSourceUpdate` and
+   * `buildItemIdentificationUpdate`: when the GM edits the embedded item
+   * via its native sheet, return the matching actor update so the wrapping
+   * interactive actor stays the source of truth.
    *
-   * For pf2e the in-sheet name input writes `_source.name` regardless of
-   * identification state; we route that change to either `actor.name`
-   * (identified) or `actor.system.unidentifiedName` (unidentified).
+   * For pf2e this routes:
+   *   - the main sheet "Name" input (`_source.name`)
+   *   - the Mystification tab "Display Details" name input
+   *     (`system.identification.unidentified.name`)
+   *   - the Mystification tab description editor
+   *     (`system.identification.unidentified.data.description.value`)
    *
-   * Systems that route name edits through their own identification field
-   * paths internally (dnd5e) should return `{}` — there is nothing for the
-   * module to do.
+   * Systems that route their sheet edits through their own field paths
+   * internally (dnd5e) should return `{}`.
    *
    * @param {Item} item - The embedded item that was just updated.
    * @param {object} changes - The raw changeset from the updateItem hook.
    * @param {Actor} actor - The wrapping interactive actor (item.actor).
    * @returns {object} A flat update object for `actor.update(...)`.
    */
-  parseEmbeddedItemNameChange(item, changes, actor) { return {}; }
+  parseEmbeddedItemChanges(item, changes, actor) { return {}; }
 
   /**
    * Returns true if the `updateItem` hook changeset contains an identification

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -209,8 +209,8 @@ export default class SystemAdapter {
 
   /**
    * Render the embedded item's "real" view for an interactive container actor.
-   * dnd5e opens the native ContainerSheet; pf2e opens the pick-up-stix-owned
-   * PfContainerView (see Phase 6).
+   * dnd5e opens the native ContainerSheet; pf2e opens the embedded backpack
+   * item's native ContainerSheetPF2e.
    *
    * @abstract
    * @param {Actor} actor

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -34,7 +34,9 @@ export default class SystemAdapter {
      *  where containers render inline on the actor sheet. */
     hasNativeContainerWindow: false,
     /** System exposes Item5e.createWithContents-style deep-create static. */
-    hasNativeDeepCreate: false
+    hasNativeDeepCreate: false,
+    /** System already renders identify/mystify controls on inventory rows (pf2e). */
+    hasNativeInventoryIdentify: false
   };
 
   // === Item type vocabulary ==================================================
@@ -134,6 +136,17 @@ export default class SystemAdapter {
   buildItemIdentificationUpdate(actor, changes) { _abstract("buildItemIdentificationUpdate"); }
 
   /**
+   * Returns true if the `updateItem` hook changeset contains an identification
+   * state change for this system. Used to decide whether the `updateItem` hook
+   * should trigger actor/token sync.
+   *
+   * @param {Item} item
+   * @param {object} changes - The raw changes object passed by the `updateItem` hook.
+   * @returns {boolean}
+   */
+  isIdentificationChange(item, changes) { return false; }
+
+  /**
    * Stamp identification status onto raw item data prior to `createDocuments`.
    * Used when initialising a freshly-dropped item.
    *
@@ -143,6 +156,54 @@ export default class SystemAdapter {
    * @returns {object} The mutated itemData.
    */
   stampNewItemIdentified(itemData, isIdentified) { _abstract("stampNewItemIdentified"); }
+
+  /**
+   * Return the icon/label configuration for the identify toggle button, driven
+   * by the current identification state. Subclasses override to provide system-
+   * appropriate icons and localization keys (e.g. pf2e uses a question-mark
+   * icon and its own "Mystify" / "Identify" labels).
+   *
+   * @param {boolean} isIdentified - Current identification state of the item.
+   * @returns {{ iconOn: string, iconFamilyOn: string, labelOnKey: string,
+   *             iconOff: string, iconFamilyOff: string, labelOffKey: string }}
+   */
+  getIdentifyButtonConfig(isIdentified) {
+    return {
+      iconOn: "fa-wand-sparkles",
+      iconFamilyOn: "fa-solid",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateIdentified",
+      iconOff: "fa-wand-sparkles",
+      iconFamilyOff: "fa-solid",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnidentified"
+    };
+  }
+
+  /**
+   * Perform the system-appropriate "toggle identification" action for an item.
+   * dnd5e simply flips `system.identified`. pf2e opens the native
+   * `IdentifyItemPopup` (when unidentified) or calls
+   * `item.setIdentificationStatus("unidentified")` (when identified).
+   *
+   * @abstract
+   * @param {Item} item - The live embedded Item document to act on.
+   * @returns {Promise<void>}
+   */
+  async performIdentifyToggle(item) { _abstract("performIdentifyToggle"); }
+
+  /**
+   * Flatten a list of items (and any nested contents) into plain data objects
+   * ready for `Item.createDocuments`. Applies `transformAll` to each data
+   * object when provided; returning `null` from the callback drops that item.
+   *
+   * dnd5e delegates to `Item5e.createWithContents`; pf2e walks `system.contents`
+   * manually (the same logic as `createItemsWithContents` but without creating).
+   *
+   * @param {Item[]|object[]} items
+   * @param {object} [options]
+   * @param {(itemData: object) => object|null} [options.transformAll]
+   * @returns {Promise<object[]>}
+   */
+  async flattenItemsForCreate(items, options = {}) { _abstract("flattenItemsForCreate"); }
 
   // === Sheet delegation ======================================================
 

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -166,6 +166,27 @@ export default class SystemAdapter {
   buildEmbeddedItemSourceUpdate(actor, isIdentified) { return {}; }
 
   /**
+   * Inverse of `buildEmbeddedItemSourceUpdate`: when the GM edits the
+   * embedded item's source-level name input on the system's native item
+   * sheet, return the matching actor update so the wrapping interactive
+   * actor's authoritative name fields stay in sync.
+   *
+   * For pf2e the in-sheet name input writes `_source.name` regardless of
+   * identification state; we route that change to either `actor.name`
+   * (identified) or `actor.system.unidentifiedName` (unidentified).
+   *
+   * Systems that route name edits through their own identification field
+   * paths internally (dnd5e) should return `{}` — there is nothing for the
+   * module to do.
+   *
+   * @param {Item} item - The embedded item that was just updated.
+   * @param {object} changes - The raw changeset from the updateItem hook.
+   * @param {Actor} actor - The wrapping interactive actor (item.actor).
+   * @returns {object} A flat update object for `actor.update(...)`.
+   */
+  parseEmbeddedItemNameChange(item, changes, actor) { return {}; }
+
+  /**
    * Returns true if the `updateItem` hook changeset contains an identification
    * state change for this system. Used to decide whether the `updateItem` hook
    * should trigger actor/token sync.

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -56,6 +56,17 @@ export default class SystemAdapter {
     return item?.type === this.containerItemType;
   }
 
+  /**
+   * True if `item` is a "physical" item the module is willing to wrap as an
+   * interactive object. dnd5e checks for `quantity` on `system`; pf2e checks
+   * the system's PHYSICAL_ITEM_TYPES set.
+   *
+   * @abstract
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  isPhysicalItem(item) { _abstract("isPhysicalItem"); }
+
   // === Container parent reference ============================================
 
   /**
@@ -229,6 +240,20 @@ export default class SystemAdapter {
    * @returns {Promise<Application|null>}
    */
   async renderItemView(actor, options) { _abstract("renderItemView"); }
+
+  /**
+   * Render the GM-only configuration sheet for an interactive object actor.
+   * Each adapter ships its own sheet implementation matching the active
+   * system's UI conventions: dnd5e uses an ApplicationV2 sheet (consistent
+   * with dnd5e's own actor/item sheets); pf2e uses an ApplicationV1 sheet
+   * (consistent with pf2e's actor/item sheets).
+   *
+   * @abstract
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderConfigSheet(actor, options) { _abstract("renderConfigSheet"); }
 
   // === Hook registration =====================================================
   // Each `register*` is a one-shot called from init. Inside, the adapter

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -341,13 +341,21 @@ export default class SystemAdapter {
    * native sheet header. Different systems use different classes; the adapter
    * picks values that compose with the system's stylesheet.
    *
-   * @returns {{ stateToggle: string, configButton: string, rowControl: string }}
+   * `headerElementType` selects the DOM element kind used for header buttons:
+   *   - `"button"` for ApplicationV2 sheets (dnd5e), styled by Foundry's
+   *     `.header-control` CSS.
+   *   - `"a"` for ApplicationV1 sheets (pf2e), where the system stylesheet
+   *     targets `<a class="header-button">`.
+   *
+   * @returns {{ stateToggle: string, configButton: string, rowControl: string,
+   *             headerElementType: "button"|"a" }}
    */
   get cssClasses() {
     return {
-      stateToggle: "header-control",
+      stateToggle: "header-control pseudo-header-control state-toggle",
       configButton: "header-control-button",
-      rowControl: ""
+      rowControl: "",
+      headerElementType: "button"
     };
   }
 }

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -1,0 +1,276 @@
+import { NotImplementedError } from "./NotImplementedError.mjs";
+
+/**
+ * Abstract base class describing every system-specific surface pick-up-stix
+ * needs to address. One concrete subclass per supported system, located under
+ * `scripts/adapter/<systemId>/index.mjs`.
+ *
+ * Methods marked with a call to `_abstract()` throw `NotImplementedError` if a
+ * subclass forgets to override them. Capability flags default to `false` / `null`
+ * (the safest value). Each adapter subclass overrides only what its system
+ * supports, keeping core code free of `game.system.id` branches.
+ *
+ * @abstract
+ */
+export default class SystemAdapter {
+
+  // === Identity ==============================================================
+
+  /** @type {string|null} Foundry system id this adapter handles, e.g. "dnd5e" or "pf2e". */
+  static SYSTEM_ID = null;
+
+  // === Capability flags ======================================================
+  // Capability flags express *feature presence*, not system identity.
+  // Core code branches on these, never on game.system.id.
+
+  capabilities = {
+    /** System exposes a per-item "unidentified image" data field. */
+    hasUnidentifiedItemImage: false,
+    /** System fires a hook before container-sheet drops we can intercept. */
+    hasItemDropSheetHook: false,
+    /** System fires a hook to extend item context menus. */
+    hasItemContextMenuHook: false,
+    /** System ships a window-style ContainerSheet (dnd5e). False on pf2e
+     *  where containers render inline on the actor sheet. */
+    hasNativeContainerWindow: false,
+    /** System exposes Item5e.createWithContents-style deep-create static. */
+    hasNativeDeepCreate: false
+  };
+
+  // === Item type vocabulary ==================================================
+  // Subclasses must define `containerItemType` and `defaultLootItemType` as
+  // plain string prototype properties (e.g. via an Object.assign mixin or a
+  // class getter override). They are intentionally absent from this base class
+  // so that Object.assign-based mixins can write them onto the subclass
+  // prototype without fighting a getter-only accessor.
+
+  /**
+   * True if `item` is the system's container type.
+   *
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  isContainerItem(item) {
+    return item?.type === this.containerItemType;
+  }
+
+  // === Container parent reference ============================================
+
+  /**
+   * Read the parent-container id from a live Item document.
+   *
+   * @abstract
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemContainerId(item) { _abstract("getItemContainerId"); }
+
+  /**
+   * Write the parent-container id onto raw item data prior to create/update.
+   *
+   * @abstract
+   * @param {object} itemData - Plain item data object (not a live document).
+   * @param {string} containerId - Id of the parent container item.
+   */
+  setItemContainerId(itemData, containerId) { _abstract("setItemContainerId"); }
+
+  // === Identification ========================================================
+
+  /**
+   * True if the item is currently identified.
+   *
+   * @abstract
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  isItemIdentified(item) { _abstract("isItemIdentified"); }
+
+  /**
+   * Persist a new identification status on an existing item.
+   *
+   * @abstract
+   * @param {Item} item
+   * @param {boolean} isIdentified
+   * @returns {Promise<Item>}
+   */
+  async setItemIdentified(item, isIdentified) { _abstract("setItemIdentified"); }
+
+  /**
+   * Return the unidentified name on the item (or null).
+   *
+   * @abstract
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedName(item) { _abstract("getItemUnidentifiedName"); }
+
+  /**
+   * Return the unidentified description (HTML string) on the item (or null).
+   *
+   * @abstract
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedDescription(item) { _abstract("getItemUnidentifiedDescription"); }
+
+  /**
+   * Return the unidentified image path on the item (or null). Returns null on
+   * systems whose data model has no equivalent (e.g. dnd5e).
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedImage(item) { return null; }
+
+  /**
+   * Build the partial update payload that mirrors the actor's identification
+   * state into its embedded item. Returns `{}` if no fields apply.
+   *
+   * @abstract
+   * @param {Actor} actor - The interactive actor whose system fields changed.
+   * @param {object} changes - The `system` slice of an Actor#update changeset.
+   * @returns {object} A flat update object suitable for `item.update(...)`.
+   */
+  buildItemIdentificationUpdate(actor, changes) { _abstract("buildItemIdentificationUpdate"); }
+
+  /**
+   * Stamp identification status onto raw item data prior to `createDocuments`.
+   * Used when initialising a freshly-dropped item.
+   *
+   * @abstract
+   * @param {object} itemData - Plain item data object (mutated in-place).
+   * @param {boolean} isIdentified
+   * @returns {object} The mutated itemData.
+   */
+  stampNewItemIdentified(itemData, isIdentified) { _abstract("stampNewItemIdentified"); }
+
+  // === Sheet delegation ======================================================
+
+  /**
+   * Render the embedded item's "real" view for an interactive container actor.
+   * dnd5e opens the native ContainerSheet; pf2e opens the pick-up-stix-owned
+   * PfContainerView (see Phase 6).
+   *
+   * @abstract
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderContainerView(actor, options) { _abstract("renderContainerView"); }
+
+  /**
+   * Render the embedded item's "real" view for an item-mode actor.
+   * dnd5e opens ItemSheet5e; pf2e opens the per-type *SheetPF2e.
+   *
+   * @abstract
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderItemView(actor, options) { _abstract("renderItemView"); }
+
+  // === Hook registration =====================================================
+  // Each `register*` is a one-shot called from init. Inside, the adapter
+  // calls Hooks.on(...) with whatever hook name(s) make sense for its system,
+  // wrapping a system-agnostic callback supplied by core.
+
+  /**
+   * Register handlers for "an interactive container's contents view was
+   * rendered". Core supplies one or more callbacks; adapter subscribes to the
+   * appropriate hook(s).
+   *
+   * Each callback receives `{ actor, app, html }` (system-agnostic).
+   *
+   * @abstract
+   * @param {object} handlers
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectHeaderControls]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.maybeHideContents]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.installActorDropListener]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectItemRowControls]
+   */
+  registerContainerViewHooks(handlers) { _abstract("registerContainerViewHooks"); }
+
+  /**
+   * Register a header-button injection hook for the embedded item-mode sheet.
+   * The supplied callback receives `{ actor, app, html }`.
+   *
+   * @abstract
+   * @param {object} handlers
+   * @param {(ctx: {app: Application, html: HTMLElement}) => void} [handlers.injectHeaderControls]
+   */
+  registerItemSheetHooks(handlers) { _abstract("registerItemSheetHooks"); }
+
+  /**
+   * Register a "wand icon on inventory rows" injection on actor sheets that
+   * display character/NPC inventories. Callback signature: `(app, html) => void`.
+   *
+   * @abstract
+   * @param {(app: Application, html: HTMLElement) => void} callback
+   */
+  registerActorInventoryHooks(callback) { _abstract("registerActorInventoryHooks"); }
+
+  /**
+   * Register a drop-into-container intercept used to gate deposits on
+   * proximity / open / lock state. Callback signature:
+   * `({ actor, item, sheet, data }) => boolean | undefined`
+   * (returning false cancels). On systems without a drop hook (pf2e) the
+   * adapter installs a `_onDrop` override or equivalent intercept and routes
+   * through the same callback.
+   *
+   * @abstract
+   * @param {(ctx: {actor: Actor, item: Item|null, sheet: Application, data: object}) => boolean|undefined} callback
+   */
+  registerContainerDropGate(callback) { _abstract("registerContainerDropGate"); }
+
+  /**
+   * Register an item-context-menu extension. The supplied `extender` is called
+   * with `(item, menuItems)` where it may push entries. On systems without a
+   * hook (pf2e) the adapter overrides the relevant sheet's context-option
+   * builder and forwards.
+   *
+   * @abstract
+   * @param {(item: Item, menuItems: object[]) => void} extender
+   */
+  registerItemContextMenu(extender) { _abstract("registerItemContextMenu"); }
+
+  // === Deep create ===========================================================
+
+  /**
+   * Create a top-level item plus its nested container contents on `parent`.
+   * Equivalent to dnd5e `Item5e.createWithContents`. On systems lacking a
+   * native helper, walks `system.contents` manually, stamps the container
+   * parent field on each child, and calls `createDocuments`.
+   *
+   * @abstract
+   * @param {object[]|Item[]} items - Items to create (may be plain data or live documents).
+   * @param {object} [options] - Options forwarded to `createDocuments`. May include `parent`.
+   * @returns {Promise<Item[]>}
+   */
+  async createItemsWithContents(items, options) { _abstract("createItemsWithContents"); }
+
+  // === CSS class constants ===================================================
+
+  /**
+   * CSS class names the module should use when injecting controls into the
+   * native sheet header. Different systems use different classes; the adapter
+   * picks values that compose with the system's stylesheet.
+   *
+   * @returns {{ stateToggle: string, configButton: string, rowControl: string }}
+   */
+  get cssClasses() {
+    return {
+      stateToggle: "header-control",
+      configButton: "header-control-button",
+      rowControl: ""
+    };
+  }
+}
+
+/**
+ * Internal helper that throws `NotImplementedError` for abstract method stubs.
+ *
+ * @param {string} [methodName]
+ */
+function _abstract(methodName) {
+  throw new NotImplementedError(methodName);
+}

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -358,6 +358,22 @@ export default class SystemAdapter {
       headerElementType: "button"
     };
   }
+
+  /**
+   * Selector for the system's own identify-toggle button injected into item
+   * and container sheet headers, if the system provides one. When present,
+   * the unified header-controls decorator skips emitting its own identify
+   * toggle and relocates the system's button into the module's canonical
+   * slot (between Lock and Configure) so the two don't appear duplicated.
+   *
+   * Return `null` when the system has no header-level identify control —
+   * the module will inject its own toggle in that case.
+   *
+   * @returns {string|null}
+   */
+  get nativeIdentifyHeaderSelector() {
+    return null;
+  }
 }
 
 /**

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -147,6 +147,25 @@ export default class SystemAdapter {
   buildItemIdentificationUpdate(actor, changes) { _abstract("buildItemIdentificationUpdate"); }
 
   /**
+   * Build a partial item update that synchronises the embedded item's
+   * source-level fields (e.g. `name`) with the current identification state.
+   *
+   * Some systems display data-prepared values everywhere (dnd5e: item.name in
+   * the sheet header swaps automatically), and need no source sync.
+   * Others bind sheet inputs to the source (pf2e: the name input reads
+   * `item._source.name`), and require an explicit name update so the input
+   * reflects the identification state.
+   *
+   * @param {Actor} actor - The interactive actor (whose name holds the
+   *                        identified display name and whose
+   *                        `system.unidentifiedName` holds the mystified one).
+   * @param {boolean} isIdentified - The post-change identification state.
+   * @returns {object} A flat update object for `item.update(...)`. Empty when
+   *                   the system needs no source sync.
+   */
+  buildEmbeddedItemSourceUpdate(actor, isIdentified) { return {}; }
+
+  /**
    * Returns true if the `updateItem` hook changeset contains an identification
    * state change for this system. Used to decide whether the `updateItem` hook
    * should trigger actor/token sync.

--- a/scripts/adapter/dnd5e/configSheet.mjs
+++ b/scripts/adapter/dnd5e/configSheet.mjs
@@ -151,10 +151,7 @@ export default class Dnd5eInteractiveItemConfigSheet extends HandlebarsApplicati
 
     if (this.isEditable) {
       const header = this.element.querySelector(".window-header");
-      if (header) {
-        const closeBtn = header.querySelector("button.close, [data-action='close']");
-        this.#injectHeaderToggles(header, closeBtn);
-      }
+      if (header) this.#injectHeaderToggles(header);
     }
   }
 
@@ -269,9 +266,10 @@ export default class Dnd5eInteractiveItemConfigSheet extends HandlebarsApplicati
    * Inject Open/Close (containers only), Lock, and Identify toggles into the
    * config window's own header. Buttons are removed and re-added on every
    * render so their on/off state stays in sync with `system.isOpen`/`isLocked`/
-   * `isIdentified`.
+   * `isIdentified`. Inserted immediately after `.window-title` so they sit
+   * left of dnd5e/V2's right-aligned system controls (ellipsis, close).
    */
-  #injectHeaderToggles(header, closeBtn) {
+  #injectHeaderToggles(header) {
     header.querySelectorAll(".ii-config-toggle").forEach(el => el.remove());
 
     const system = this.actor.system;
@@ -312,8 +310,9 @@ export default class Dnd5eInteractiveItemConfigSheet extends HandlebarsApplicati
       action: "toggleIdentified"
     }));
 
-    if (closeBtn) closeBtn.before(...buttons);
-    else header.append(...buttons);
+    const title = header.querySelector(".window-title");
+    if (title) title.after(...buttons);
+    else header.prepend(...buttons);
   }
 
   /**

--- a/scripts/adapter/dnd5e/configSheet.mjs
+++ b/scripts/adapter/dnd5e/configSheet.mjs
@@ -1,0 +1,382 @@
+/**
+ * Dnd5eInteractiveItemConfigSheet — ApplicationV2 GM config dialog for
+ * pick-up-stix interactive object actors on dnd5e.
+ *
+ * Matches dnd5e's own AppV2 sheet conventions (HandlebarsApplicationMixin,
+ * `static actions`, `<file-picker>` / `<prose-mirror>` custom elements,
+ * `_prepareSubmitData`). Constructed by `Dnd5eAdapter.renderConfigSheet()`
+ * and cached per-actor in `#instances` so repeated clicks on the same actor
+ * reuse the open window.
+ */
+
+import { getAdapter } from "../index.mjs";
+import { setContainerOpen, toggleContainerLocked } from "../../transfer/ItemTransfer.mjs";
+import { createStateToggleButton } from "../../utils/domButtons.mjs";
+import { dbg } from "../../utils/debugLog.mjs";
+
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;
+
+/**
+ * dnd5e GM-only config sheet for `pick-up-stix.interactiveItem` actors.
+ */
+export default class Dnd5eInteractiveItemConfigSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
+
+  /** Per-actor singleton cache so repeat opens reuse the existing window. */
+  static #instances = new Map();
+
+  /**
+   * Resolve the config sheet for a given actor, creating one on first call
+   * and returning the cached instance on subsequent calls.
+   *
+   * @param {Actor} actor
+   * @returns {Dnd5eInteractiveItemConfigSheet}
+   */
+  static forActor(actor) {
+    const key = actor.uuid;
+    let sheet = Dnd5eInteractiveItemConfigSheet.#instances.get(key);
+    if (!sheet) {
+      sheet = new Dnd5eInteractiveItemConfigSheet({ document: actor });
+      Dnd5eInteractiveItemConfigSheet.#instances.set(key, sheet);
+    }
+    return sheet;
+  }
+
+  #editingDescriptionTarget = null;
+
+  #expandedSections = {};
+
+  static DEFAULT_OPTIONS = {
+    classes: ["pick-up-stix", "interactive-item-sheet", "dnd5e2", "sheet", "item", "standard-form"],
+    position: { width: 400, height: "auto" },
+    window: { resizable: true },
+    form: { submitOnChange: true },
+    actions: {
+      openItemSheet: Dnd5eInteractiveItemConfigSheet.#onOpenItemSheet,
+      openContainerSheet: Dnd5eInteractiveItemConfigSheet.#onOpenContainerSheet,
+      editActorImage: Dnd5eInteractiveItemConfigSheet.#onEditActorImage,
+      toggleOpen: Dnd5eInteractiveItemConfigSheet.#onToggleOpen,
+      toggleIdentified: Dnd5eInteractiveItemConfigSheet.#onToggleIdentified,
+      toggleLock: Dnd5eInteractiveItemConfigSheet.#onToggleLock,
+      editDescription: Dnd5eInteractiveItemConfigSheet.#onEditDescription,
+      toggleCollapsed: Dnd5eInteractiveItemConfigSheet.#onToggleCollapsed
+    }
+  };
+
+  static PARTS = {
+    config: {
+      template: "modules/pick-up-stix/templates/item-config.hbs"
+    }
+  };
+
+  get title() {
+    return `${game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Configure")}: ${this.actor.system.displayName}`;
+  }
+
+  get containerItem() {
+    return this.actor.system.containerItem;
+  }
+
+  get _tokenDoc() {
+    return this.actor.token ?? null;
+  }
+
+  async close(options = {}) {
+    dbg("dnd5e-config:close", { actorName: this.actor?.name, actorId: this.actor?.id });
+    const actor = this.actor;
+    Dnd5eInteractiveItemConfigSheet.#instances.delete(actor?.uuid);
+    const result = await super.close(options);
+
+    // Item-kind actors abandoned in the picker (no item ever dropped) — delete.
+    const MODULE_ID = "pick-up-stix";
+    if (actor && game.actors.has(actor.id) && !actor.token && game.user.isGM
+      && actor.getFlag(MODULE_ID, "createKindConfirmed")
+      && actor.items.size === 0) {
+      await actor.delete();
+    }
+    return result;
+  }
+
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const system = this.actor.system;
+    context.actor = this.actor;
+    context.system = system;
+    context.isEditable = this.isEditable;
+    context.isContainer = system.isContainer;
+    context.needsItem = this.actor.items.size === 0 && !this._tokenDoc;
+    context.isIdentified = system.isIdentified;
+    context.displayName = system.displayName;
+
+    if (system.isContainer) {
+      const item = this.containerItem;
+      context.hasContainerItem = !!item;
+      context.containerName = system.resolveTokenName();
+      context.containerImg = (system.isOpen && system.openImage)
+        ? system.openImage
+        : (item?.img ?? this.actor.img);
+    } else {
+      const item = this.actor.items.contents[0];
+      context.hasItem = !!item;
+      context.itemName = system.resolveTokenName();
+      context.itemImg = system.resolveImage();
+    }
+
+    if (this.isEditable) {
+      context.source = this.actor._source;
+    }
+    context.editingDescriptionTarget = this.#editingDescriptionTarget;
+    context.expanded = this.#expandedSections;
+    context.descriptionEnriched = !!system.description;
+    context.unidentifiedDescriptionEnriched = !!system.unidentifiedDescription;
+    context.limitedDescriptionEnriched = !!system.limitedDescription;
+
+    if (this.#editingDescriptionTarget) {
+      const parts = this.#editingDescriptionTarget.split(".");
+      let value = this.actor._source;
+      for (const part of parts) value = value?.[part];
+      context.editingDescriptionValue = value ?? "";
+    }
+    return context;
+  }
+
+  _onRender(context, options) {
+    super._onRender(context, options);
+    this.element.querySelectorAll("prose-mirror").forEach(editor => {
+      editor.addEventListener("save", () => {
+        this.#editingDescriptionTarget = null;
+        this.render();
+      });
+    });
+
+    if (this.isEditable) {
+      const header = this.element.querySelector(".window-header");
+      if (header) {
+        const closeBtn = header.querySelector("button.close, [data-action='close']");
+        this.#injectHeaderToggles(header, closeBtn);
+      }
+    }
+  }
+
+  _canDragDrop(_selector) {
+    return true;
+  }
+
+  _onDropStackConsumables() {
+    return null;
+  }
+
+  /**
+   * Inject prototypeToken.texture.src whenever `img` or `system.unidentifiedImage`
+   * changes so the placed token's portrait stays in sync with the configured
+   * identified/unidentified image.
+   */
+  _prepareSubmitData(event, form, formData) {
+    const data = super._prepareSubmitData(event, form, formData);
+    dbg("dnd5e-config:_prepareSubmitData", {
+      incomingKeys: Object.keys(data),
+      imgInData: "img" in data,
+      dataImg: data.img,
+      actorImg: this.actor.img,
+      isIdentified: this.actor.system.isIdentified,
+      unidentifiedImage: this.actor.system.unidentifiedImage,
+      unidentifiedImageInData: "system.unidentifiedImage" in data
+    });
+    if (data.img && data.img !== this.actor.img) {
+      if (this.actor.system.isIdentified || !this.actor.system.unidentifiedImage) {
+        data["prototypeToken.texture.src"] = data.img;
+      }
+    }
+    if ("system.unidentifiedImage" in data && !this.actor.system.isIdentified) {
+      const newUnidentifiedImage = data["system.unidentifiedImage"];
+      if (newUnidentifiedImage) {
+        data["prototypeToken.texture.src"] = newUnidentifiedImage;
+      } else {
+        data["prototypeToken.texture.src"] = data.img || this.actor.img;
+      }
+    }
+    return data;
+  }
+
+  static #onEditActorImage(event, _target) {
+    event.preventDefault();
+    const fp = new foundry.applications.apps.FilePicker.implementation({
+      type: "image",
+      current: this.actor.img,
+      callback: (path) => this.actor.system.updateImage(path)
+    });
+    fp.render(true);
+  }
+
+  static async #onOpenItemSheet(_event, _target) {
+    const item = this.actor.items.contents[0];
+    if (!item) return;
+    await this.#syncItemImage(item);
+    await this.close();
+    await getAdapter().renderItemView(this.actor);
+  }
+
+  static async #onOpenContainerSheet(_event, _target) {
+    if (!this.containerItem) return;
+    await this.close();
+    await getAdapter().renderContainerView(this.actor);
+  }
+
+  /**
+   * If the embedded item's image has drifted from the actor's resolved image
+   * (identified vs unidentified), push the actor's resolved image down to the
+   * item before opening its sheet. GM-only.
+   */
+  async #syncItemImage(item) {
+    if (!game.user.isGM) return;
+    const system = this.actor.system;
+    const expectedImg = system.resolveImage();
+    if (item.img !== expectedImg) {
+      await item.update({ img: expectedImg });
+    }
+  }
+
+  static async #onToggleOpen(_event, _target) {
+    await setContainerOpen(this.actor, !this.actor.system.isOpen);
+  }
+
+  static async #onToggleIdentified(_event, _target) {
+    const item = this.actor.system.embeddedItem;
+    const adapter = getAdapter();
+    const currentIdentified = item ? adapter.isItemIdentified(item) : undefined;
+    if (!item || currentIdentified === undefined) return;
+    await adapter.performIdentifyToggle(item);
+  }
+
+  static async #onToggleLock(_event, _target) {
+    await toggleContainerLocked(this.actor);
+  }
+
+  static #onEditDescription(event, target) {
+    event.stopPropagation();
+    this.#editingDescriptionTarget = target.dataset.target;
+    this.render();
+  }
+
+  static #onToggleCollapsed(event, target) {
+    if (event.target.closest(".collapsible-content")) return;
+    const expandId = target.dataset.expandId;
+    if (expandId) this.#expandedSections[expandId] = !this.#expandedSections[expandId];
+    target.classList.toggle("collapsed");
+  }
+
+  /**
+   * Inject Open/Close (containers only), Lock, and Identify toggles into the
+   * config window's own header. Buttons are removed and re-added on every
+   * render so their on/off state stays in sync with `system.isOpen`/`isLocked`/
+   * `isIdentified`.
+   */
+  #injectHeaderToggles(header, closeBtn) {
+    header.querySelectorAll(".ii-config-toggle").forEach(el => el.remove());
+
+    const system = this.actor.system;
+    const buttons = [];
+
+    if (system.isContainer) {
+      buttons.push(createStateToggleButton({
+        extraClass: "ii-config-toggle",
+        active: system.isOpen,
+        iconOn: "fa-box-open",
+        iconOff: "fa-box",
+        labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
+        labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
+        action: "toggleOpen"
+      }));
+    }
+
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-config-toggle",
+      active: system.isLocked,
+      iconOn: "fa-lock",
+      iconOff: "fa-lock-open",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
+      action: "toggleLock"
+    }));
+
+    const identCfg = getAdapter().getIdentifyButtonConfig(system.isIdentified);
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-config-toggle",
+      active: system.isIdentified,
+      iconOn: identCfg.iconOn,
+      iconFamilyOn: identCfg.iconFamilyOn,
+      iconOff: identCfg.iconOff,
+      iconFamilyOff: identCfg.iconFamilyOff,
+      labelOnKey: identCfg.labelOnKey,
+      labelOffKey: identCfg.labelOffKey,
+      action: "toggleIdentified"
+    }));
+
+    if (closeBtn) closeBtn.before(...buttons);
+    else header.append(...buttons);
+  }
+
+  /**
+   * Drop handler for assigning the actor's embedded item. Mirrors the original
+   * InteractiveItemSheet._onDrop verbatim — system-specific fields are routed
+   * through the adapter so this implementation works for any system whose
+   * config sheet extends from this one (currently only dnd5e).
+   */
+  async _onDrop(event) {
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    dbg("dnd5e-config:_onDrop", { dataType: data.type, uuid: data.uuid });
+    if (data.type !== "Item") return;
+
+    const item = await fromUuid(data.uuid);
+    if (!item) return;
+
+    const adapter = getAdapter();
+    if (!adapter.isPhysicalItem(item)) {
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotPhysical"));
+      return;
+    }
+
+    if (!game.user.isGM) return;
+    const itemData = item.toObject();
+    delete itemData._id;
+
+    // Stamp identified before creation so updateItem doesn't fire mid-update.
+    adapter.stampNewItemIdentified(itemData, true);
+
+    if (this.actor.items.size > 0) {
+      const ids = this.actor.items.map(i => i.id);
+      await this.actor.deleteEmbeddedDocuments("Item", ids);
+    }
+
+    const updates = {
+      name: item.name,
+      img: item.img,
+      "prototypeToken.name": item.name,
+      "prototypeToken.texture.src": item.img
+    };
+    if (item.system.description?.value) {
+      updates["system.description"] = item.system.description.value;
+    }
+    const droppedUnidentifiedName = adapter.getItemUnidentifiedName(item);
+    const droppedUnidentifiedDescription = adapter.getItemUnidentifiedDescription(item);
+    if (droppedUnidentifiedName) updates["system.unidentifiedName"] = droppedUnidentifiedName;
+    if (droppedUnidentifiedDescription) updates["system.unidentifiedDescription"] = droppedUnidentifiedDescription;
+
+    await this.actor.update(updates);
+
+    const [createdItem] = await this.actor.createEmbeddedDocuments("Item", [itemData]);
+
+    if (createdItem) {
+      const allIdentificationChanges = {
+        isIdentified: true,
+        unidentifiedName: this.actor.system.unidentifiedName,
+        description: this.actor.system.description,
+        unidentifiedDescription: this.actor.system.unidentifiedDescription
+      };
+      const itemUpdates = adapter.buildItemIdentificationUpdate(this.actor, allIdentificationChanges);
+      if (Object.keys(itemUpdates).length > 0) await createdItem.update(itemUpdates);
+    }
+
+    ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Notify.Deposited", { name: item.name }));
+  }
+}

--- a/scripts/adapter/dnd5e/container.mjs
+++ b/scripts/adapter/dnd5e/container.mjs
@@ -1,0 +1,66 @@
+/**
+ * dnd5e container-parent and deep-create methods for the SystemAdapter contract.
+ * dnd5e uses `system.container` to track the parent-container item's id, and
+ * exposes a static `Item5e.createWithContents` helper for deep-creating
+ * container hierarchies.
+ *
+ * These methods are mixed into `Dnd5eAdapter` in `dnd5e/index.mjs`.
+ */
+export const Dnd5eContainer = {
+
+  /**
+   * Item type for containers. dnd5e calls this "container" (the legacy
+   * "backpack" type is auto-migrated by Item5e._initializeSource).
+   *
+   * @type {string}
+   */
+  containerItemType: "container",
+
+  /**
+   * Item type for generic loot we create from scratch.
+   *
+   * @type {string}
+   */
+  defaultLootItemType: "loot",
+
+  /**
+   * Read the parent-container id (or null) from a live Item.
+   * dnd5e stores this in `system.container`.
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemContainerId(item) {
+    return item?.system?.container ?? null;
+  },
+
+  /**
+   * Stamp the parent-container id onto raw item data prior to create/update.
+   * dnd5e uses `system.container` for this relationship.
+   *
+   * @param {object} itemData - Plain item data object (mutated in-place).
+   * @param {string} containerId - Id of the parent container item.
+   */
+  setItemContainerId(itemData, containerId) {
+    itemData.system = itemData.system ?? {};
+    itemData.system.container = containerId;
+  },
+
+  /**
+   * Deep-create a container plus its nested contents using the dnd5e static
+   * helper `Item5e.createWithContents`. This mirrors the behaviour of the
+   * existing core code that calls the helper directly; the adapter wraps it so
+   * pf2e (and future systems) can substitute a hand-rolled walker.
+   *
+   * @param {object[]|Item[]} items - Items to create (may be plain data or live documents).
+   * @param {object} [options] - Options forwarded to `createDocuments`. May include `parent`.
+   * @returns {Promise<Item[]>}
+   */
+  async createItemsWithContents(items, options) {
+    const docs = await CONFIG.Item.documentClass.createWithContents(items, options);
+    if (options?.parent) {
+      return CONFIG.Item.documentClass.createDocuments(docs, { parent: options.parent, keepId: options.keepId ?? false });
+    }
+    return CONFIG.Item.documentClass.createDocuments(docs, { keepId: options?.keepId ?? false });
+  }
+};

--- a/scripts/adapter/dnd5e/container.mjs
+++ b/scripts/adapter/dnd5e/container.mjs
@@ -24,6 +24,17 @@ export const Dnd5eContainer = {
   defaultLootItemType: "loot",
 
   /**
+   * dnd5e marks physical items by exposing a `quantity` field on the system
+   * data. Spells / classes / features etc. don't carry one.
+   *
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  isPhysicalItem(item) {
+    return item != null && "quantity" in (item.system ?? {});
+  },
+
+  /**
    * Read the parent-container id (or null) from a live Item.
    * dnd5e stores this in `system.container`.
    *

--- a/scripts/adapter/dnd5e/container.mjs
+++ b/scripts/adapter/dnd5e/container.mjs
@@ -62,5 +62,18 @@ export const Dnd5eContainer = {
       return CONFIG.Item.documentClass.createDocuments(docs, { parent: options.parent, keepId: options.keepId ?? false });
     }
     return CONFIG.Item.documentClass.createDocuments(docs, { keepId: options?.keepId ?? false });
+  },
+
+  /**
+   * Flatten items into plain data objects using dnd5e's native
+   * `Item5e.createWithContents` which handles nested container hierarchies.
+   *
+   * @param {Item[]|object[]} items
+   * @param {object} [options]
+   * @param {(itemData: object) => object|null} [options.transformAll]
+   * @returns {Promise<object[]>}
+   */
+  async flattenItemsForCreate(items, options = {}) {
+    return CONFIG.Item.documentClass.createWithContents(items, options);
   }
 };

--- a/scripts/adapter/dnd5e/hooks.mjs
+++ b/scripts/adapter/dnd5e/hooks.mjs
@@ -59,11 +59,12 @@ export const Dnd5eHooks = {
    * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.installActorDropListener]
    * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectItemRowControls]
    */
-  registerContainerViewHooks({ injectHeaderControls, maybeHideContents, installActorDropListener, injectItemRowControls }) {
+  registerContainerViewHooks({ injectHeaderControls, maybeHideContents, installActorDropListener, injectItemRowControls, injectContentsTab }) {
     Hooks.on("renderContainerSheet", (app, html) => injectHeaderControls?.({ actor: app.item?.actor, app, html }));
     Hooks.on("renderContainerSheet", (app, html) => maybeHideContents?.({ actor: app.item?.actor, app, html }));
     Hooks.on("renderContainerSheet", (app, html) => installActorDropListener?.({ actor: app.item?.actor, app, html }));
     Hooks.on("renderContainerSheet", (app, html) => injectItemRowControls?.({ actor: app.item?.actor, app, html }));
+    Hooks.on("renderContainerSheet", (app, html) => injectContentsTab?.({ actor: app.item?.actor, app, html }));
   },
 
   /**

--- a/scripts/adapter/dnd5e/hooks.mjs
+++ b/scripts/adapter/dnd5e/hooks.mjs
@@ -59,10 +59,11 @@ export const Dnd5eHooks = {
    * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.installActorDropListener]
    * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectItemRowControls]
    */
-  registerContainerViewHooks({ injectHeaderControls, maybeHideContents, installActorDropListener, injectItemRowControls, injectContentsTab }) {
+  registerContainerViewHooks({ injectHeaderControls, maybeHideContents, installActorDropListener, installItemDropListener, injectItemRowControls, injectContentsTab }) {
     Hooks.on("renderContainerSheet", (app, html) => injectHeaderControls?.({ actor: app.item?.actor, app, html }));
     Hooks.on("renderContainerSheet", (app, html) => maybeHideContents?.({ actor: app.item?.actor, app, html }));
     Hooks.on("renderContainerSheet", (app, html) => installActorDropListener?.({ actor: app.item?.actor, app, html }));
+    Hooks.on("renderContainerSheet", (app, html) => installItemDropListener?.({ actor: app.item?.actor, app, html }));
     Hooks.on("renderContainerSheet", (app, html) => injectItemRowControls?.({ actor: app.item?.actor, app, html }));
     Hooks.on("renderContainerSheet", (app, html) => injectContentsTab?.({ actor: app.item?.actor, app, html }));
   },

--- a/scripts/adapter/dnd5e/hooks.mjs
+++ b/scripts/adapter/dnd5e/hooks.mjs
@@ -1,0 +1,81 @@
+/**
+ * dnd5e hook-registration methods for the SystemAdapter contract.
+ * Each `register*` method subscribes to the dnd5e- or Foundry-core hook
+ * that provides the relevant event and routes it through the system-agnostic
+ * callback supplied by core code.
+ *
+ * These methods are mixed into `Dnd5eAdapter` in `dnd5e/index.mjs`.
+ */
+export const Dnd5eHooks = {
+
+  /**
+   * Subscribe to `dnd5e.getItemContextOptions` and forward to the supplied
+   * `extender`, which receives `(item, menuItems)` and may push new entries.
+   *
+   * @param {(item: Item, menuItems: object[]) => void} extender
+   */
+  registerItemContextMenu(extender) {
+    Hooks.on("dnd5e.getItemContextOptions", (item, menuItems) => extender(item, menuItems));
+  },
+
+  /**
+   * Subscribe to `dnd5e.dropItemSheetData` and forward to the supplied
+   * `callback`. The hook fires before dnd5e processes the drop; returning
+   * `false` from the callback cancels dnd5e's native handling.
+   *
+   * The callback receives `{ actor, item, sheet, data }` where `item` is the
+   * container item (whose actor is the interactive container actor).
+   *
+   * @param {(ctx: {actor: Actor, item: Item, sheet: Application, data: object}) => boolean|undefined} callback
+   */
+  registerContainerDropGate(callback) {
+    Hooks.on("dnd5e.dropItemSheetData", (item, sheet, data) => {
+      const actor = item.actor;
+      return callback({ actor, item, sheet, data });
+    });
+  },
+
+  /**
+   * Subscribe to `renderItemSheet5e` and forward to the supplied
+   * `injectHeaderControls` handler, which receives `{ app, html }`.
+   *
+   * @param {object} handlers
+   * @param {(ctx: {app: Application, html: HTMLElement}) => void} [handlers.injectHeaderControls]
+   */
+  registerItemSheetHooks({ injectHeaderControls }) {
+    Hooks.on("renderItemSheet5e", (app, html) => injectHeaderControls?.({ app, html }));
+  },
+
+  /**
+   * Subscribe to `renderContainerSheet` four times, each with one of the
+   * supplied decorator callbacks. Each callback receives `{ actor, app, html }`.
+   *
+   * Four separate subscriptions are used (rather than one combined handler) so
+   * the individual concerns remain independent and can be debugged in isolation.
+   *
+   * @param {object} handlers
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectHeaderControls]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.maybeHideContents]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.installActorDropListener]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectItemRowControls]
+   */
+  registerContainerViewHooks({ injectHeaderControls, maybeHideContents, installActorDropListener, injectItemRowControls }) {
+    Hooks.on("renderContainerSheet", (app, html) => injectHeaderControls?.({ actor: app.item?.actor, app, html }));
+    Hooks.on("renderContainerSheet", (app, html) => maybeHideContents?.({ actor: app.item?.actor, app, html }));
+    Hooks.on("renderContainerSheet", (app, html) => installActorDropListener?.({ actor: app.item?.actor, app, html }));
+    Hooks.on("renderContainerSheet", (app, html) => injectItemRowControls?.({ actor: app.item?.actor, app, html }));
+  },
+
+  /**
+   * Subscribe to the three actor-sheet render hooks that dnd5e fires when an
+   * actor sheet is rendered, and forward each to the supplied `callback`.
+   * The callback receives `(app, html)` as supplied by the hook.
+   *
+   * @param {(app: Application, html: HTMLElement) => void} callback
+   */
+  registerActorInventoryHooks(callback) {
+    Hooks.on("renderActorSheet", callback);
+    Hooks.on("renderCharacterActorSheet", callback);
+    Hooks.on("renderNPCActorSheet", callback);
+  }
+};

--- a/scripts/adapter/dnd5e/identification.mjs
+++ b/scripts/adapter/dnd5e/identification.mjs
@@ -91,5 +91,28 @@ export const Dnd5eIdentification = {
     itemData.system = itemData.system ?? {};
     itemData.system.identified = !!isIdentified;
     return itemData;
+  },
+
+  /**
+   * True if the updateItem changeset contains dnd5e's identification field.
+   * dnd5e stores identification as a boolean at system.identified.
+   *
+   * @param {Item} item
+   * @param {object} changes
+   * @returns {boolean}
+   */
+  isIdentificationChange(item, changes) {
+    return "identified" in (changes.system ?? {});
+  },
+
+  /**
+   * Toggle identification on a dnd5e item. dnd5e has no native identify dialog;
+   * the state is flipped directly.
+   *
+   * @param {Item} item
+   * @returns {Promise<void>}
+   */
+  async performIdentifyToggle(item) {
+    await this.setItemIdentified(item, !this.isItemIdentified(item));
   }
 };

--- a/scripts/adapter/dnd5e/identification.mjs
+++ b/scripts/adapter/dnd5e/identification.mjs
@@ -1,0 +1,95 @@
+/**
+ * dnd5e identification methods for the SystemAdapter contract.
+ * dnd5e stores identification state as a boolean `system.identified` on the
+ * item, and exposes unidentified presentation via `system.unidentified.name`
+ * and `system.unidentified.description`.
+ *
+ * These methods are mixed into `Dnd5eAdapter` in `dnd5e/index.mjs`.
+ */
+export const Dnd5eIdentification = {
+
+  /**
+   * True if the item is currently identified. dnd5e treats `undefined` (field
+   * absent) as identified, so the check is an explicit `!== false`.
+   *
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  isItemIdentified(item) {
+    return item?.system?.identified !== false;
+  },
+
+  /**
+   * Persist a new identification state on an existing item via dnd5e's native
+   * `system.identified` boolean field.
+   *
+   * @param {Item} item
+   * @param {boolean} isIdentified
+   * @returns {Promise<Item>}
+   */
+  async setItemIdentified(item, isIdentified) {
+    return item.update({ "system.identified": !!isIdentified });
+  },
+
+  /**
+   * Read the unidentified name on the item (or null).
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedName(item) {
+    return item?.system?.unidentified?.name ?? null;
+  },
+
+  /**
+   * Read the unidentified description (HTML string) on the item (or null).
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedDescription(item) {
+    return item?.system?.unidentified?.description ?? null;
+  },
+
+  /**
+   * dnd5e has no per-item unidentified image field — always returns null.
+   *
+   * @param {Item} _item
+   * @returns {null}
+   */
+  getItemUnidentifiedImage(_item) {
+    return null;
+  },
+
+  /**
+   * Build the embedded-item update payload that mirrors the actor's
+   * identification state changes. `changes` is the `system` slice of an
+   * Actor#update changeset (so we can detect which fields actually changed).
+   *
+   * @param {Actor} actor - The interactive actor whose system fields changed.
+   * @param {object} changes - The `system` slice of the Actor#update changeset.
+   * @returns {object} A flat update object suitable for `item.update(...)`.
+   */
+  buildItemIdentificationUpdate(actor, changes) {
+    const u = {};
+    if ("isIdentified" in changes) u["system.identified"] = actor.system.isIdentified;
+    if ("unidentifiedName" in changes) u["system.unidentified.name"] = actor.system.unidentifiedName || "";
+    if ("description" in changes) u["system.description.value"] = actor.system.description || "";
+    if ("unidentifiedDescription" in changes) u["system.unidentified.description"] = actor.system.unidentifiedDescription || "";
+    return u;
+  },
+
+  /**
+   * Stamp identification status onto raw item data prior to `createDocuments`.
+   * Used when initialising a freshly-dropped item.
+   *
+   * @param {object} itemData - Plain item data object (mutated in-place).
+   * @param {boolean} isIdentified
+   * @returns {object} The mutated itemData.
+   */
+  stampNewItemIdentified(itemData, isIdentified) {
+    itemData.system = itemData.system ?? {};
+    itemData.system.identified = !!isIdentified;
+    return itemData;
+  }
+};

--- a/scripts/adapter/dnd5e/index.mjs
+++ b/scripts/adapter/dnd5e/index.mjs
@@ -36,6 +36,19 @@ export default class Dnd5eAdapter extends SystemAdapter {
     hasNativeDeepCreate: true
   };
 
+  /**
+   * dnd5e injects a `<button class="header-control pseudo-header-control state-toggle ... toggle-identified">`
+   * into every item sheet header for items with `system.identified` (see
+   * dnd5e's ItemSheet5e._renderFrame). The unified header decorator picks
+   * this up and relocates it into the canonical Lock → Identify → Configure
+   * slot so the module doesn't render a duplicate.
+   *
+   * @returns {string}
+   */
+  get nativeIdentifyHeaderSelector() {
+    return ".toggle-identified";
+  }
+
   // containerItemType and defaultLootItemType come from Dnd5eContainer (assigned below).
 }
 

--- a/scripts/adapter/dnd5e/index.mjs
+++ b/scripts/adapter/dnd5e/index.mjs
@@ -1,0 +1,47 @@
+import SystemAdapter from "../SystemAdapter.mjs";
+import { Dnd5eIdentification } from "./identification.mjs";
+import { Dnd5eContainer } from "./container.mjs";
+import { Dnd5eSheets } from "./sheets.mjs";
+import { Dnd5eHooks } from "./hooks.mjs";
+
+/**
+ * Concrete SystemAdapter implementation for the dnd5e game system.
+ *
+ * All method bodies are provided by the four sub-module mixins
+ * (Dnd5eIdentification, Dnd5eContainer, Dnd5eSheets, Dnd5eHooks) which are
+ * assigned onto the prototype below. This keeps each concern in its own file
+ * without requiring class inheritance per concern.
+ *
+ * Capability flags reflect what dnd5e actually provides:
+ * - Unidentified images are not a dnd5e data field (hasUnidentifiedItemImage: false).
+ * - dnd5e fires `dnd5e.dropItemSheetData` and `dnd5e.getItemContextOptions` hooks.
+ * - dnd5e ships a window-style ContainerSheet.
+ * - dnd5e exposes `Item5e.createWithContents` for deep-creating container hierarchies.
+ */
+export default class Dnd5eAdapter extends SystemAdapter {
+
+  /** @type {string} */
+  static SYSTEM_ID = "dnd5e";
+
+  capabilities = {
+    /** dnd5e has no unidentified-image field on items. */
+    hasUnidentifiedItemImage: false,
+    /** dnd5e fires `dnd5e.dropItemSheetData` before container-sheet drops. */
+    hasItemDropSheetHook: true,
+    /** dnd5e fires `dnd5e.getItemContextOptions` for context menu extension. */
+    hasItemContextMenuHook: true,
+    /** dnd5e ships a full window-style ContainerSheet application. */
+    hasNativeContainerWindow: true,
+    /** dnd5e exposes `Item5e.createWithContents` for deep-creating containers. */
+    hasNativeDeepCreate: true
+  };
+
+  // containerItemType and defaultLootItemType come from Dnd5eContainer (assigned below).
+}
+
+// Assign sub-module methods directly onto the prototype so that `this` inside
+// each method correctly refers to the Dnd5eAdapter instance.
+Object.assign(Dnd5eAdapter.prototype, Dnd5eIdentification);
+Object.assign(Dnd5eAdapter.prototype, Dnd5eContainer);
+Object.assign(Dnd5eAdapter.prototype, Dnd5eSheets);
+Object.assign(Dnd5eAdapter.prototype, Dnd5eHooks);

--- a/scripts/adapter/dnd5e/sheets.mjs
+++ b/scripts/adapter/dnd5e/sheets.mjs
@@ -1,0 +1,54 @@
+/**
+ * dnd5e sheet-delegation methods for the SystemAdapter contract.
+ * dnd5e ships a window-style ContainerSheet and ItemSheet5e; this adapter
+ * delegates to each via the live item's `.sheet` reference exactly as the
+ * original core code did before the adapter layer was introduced.
+ *
+ * These methods are mixed into `Dnd5eAdapter` in `dnd5e/index.mjs`.
+ */
+export const Dnd5eSheets = {
+
+  /**
+   * Open the dnd5e ContainerSheet for an interactive container actor. Delegates
+   * to `actor.system.containerItem.sheet` so dnd5e resolves the correct sheet
+   * class for the registered item type.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderContainerView(actor, options = {}) {
+    const item = actor.system.containerItem;
+    if (!item) return null;
+    return item.sheet.render({ force: true, ...options });
+  },
+
+  /**
+   * Open the dnd5e ItemSheet5e for an item-mode actor. Delegates to
+   * `actor.items.contents[0].sheet` — item-mode actors carry exactly one
+   * embedded item.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderItemView(actor, options = {}) {
+    const item = actor.items.contents[0];
+    if (!item) return null;
+    return item.sheet.render({ force: true, ...options });
+  },
+
+  /**
+   * Convenience wrapper used by limited-dialog promotion: opens the container
+   * sheet or item sheet depending on whether the actor is in container mode.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderEmbeddedSheet(actor, options = {}) {
+    return actor.system.isContainer
+      ? this.renderContainerView(actor, options)
+      : this.renderItemView(actor, options);
+  }
+};

--- a/scripts/adapter/dnd5e/sheets.mjs
+++ b/scripts/adapter/dnd5e/sheets.mjs
@@ -62,6 +62,9 @@ export const Dnd5eSheets = {
    * @returns {Promise<Application|null>}
    */
   async renderConfigSheet(actor, options = {}) {
+    // Coerce the legacy boolean "force" form into a V2 options object so the
+    // spread below doesn't silently drop the request.
+    if (typeof options !== "object" || options === null) options = {};
     const { default: Dnd5eInteractiveItemConfigSheet } = await import("./configSheet.mjs");
     const sheet = Dnd5eInteractiveItemConfigSheet.forActor(actor);
     await sheet.render({ force: true, ...options });

--- a/scripts/adapter/dnd5e/sheets.mjs
+++ b/scripts/adapter/dnd5e/sheets.mjs
@@ -50,5 +50,21 @@ export const Dnd5eSheets = {
     return actor.system.isContainer
       ? this.renderContainerView(actor, options)
       : this.renderItemView(actor, options);
+  },
+
+  /**
+   * Open the dnd5e GM config sheet (ApplicationV2). The concrete class is
+   * imported lazily so that the dnd5e adapter file does not pull the sheet
+   * module at module-evaluation time on systems where the adapter is unused.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderConfigSheet(actor, options = {}) {
+    const { default: Dnd5eInteractiveItemConfigSheet } = await import("./configSheet.mjs");
+    const sheet = Dnd5eInteractiveItemConfigSheet.forActor(actor);
+    await sheet.render({ force: true, ...options });
+    return sheet;
   }
 };

--- a/scripts/adapter/index.mjs
+++ b/scripts/adapter/index.mjs
@@ -1,0 +1,49 @@
+/** @type {import("./SystemAdapter.mjs").default|null} */
+let _adapter = null;
+
+/**
+ * Resolve the adapter for the current Foundry system. Called once during
+ * module entry (before any `Hooks.once("init", ...)` registration) via a
+ * top-level await in `pick-up-stix.mjs`.
+ *
+ * The function is idempotent — calling it multiple times returns the same
+ * singleton. On first call it dynamically imports
+ * `./adapter/<systemId>/index.mjs`, so only the active system's code is
+ * fetched over the network.
+ *
+ * @returns {Promise<import("./SystemAdapter.mjs").default>}
+ * @throws {Error} If `game.system` is not available at module-entry time, or
+ *   if no adapter exists for the active system.
+ */
+export async function loadAdapter() {
+  if (_adapter) return _adapter;
+
+  const systemId = game.system?.id;
+  if (!systemId) {
+    throw new Error("pick-up-stix: game.system is not available at module-entry time");
+  }
+
+  let mod;
+  try {
+    mod = await import(`./${systemId}/index.mjs`);
+  } catch (err) {
+    console.error(`pick-up-stix: no adapter for system "${systemId}"`, err);
+    throw err;
+  }
+
+  _adapter = new mod.default();
+  return _adapter;
+}
+
+/**
+ * Synchronous accessor for the resolved system adapter. Throws if
+ * `loadAdapter()` has not yet resolved (i.e. called too early in the
+ * module lifecycle).
+ *
+ * @returns {import("./SystemAdapter.mjs").default}
+ * @throws {Error} If called before `loadAdapter()` has resolved.
+ */
+export function getAdapter() {
+  if (!_adapter) throw new Error("pick-up-stix: getAdapter() called before loadAdapter() resolved");
+  return _adapter;
+}

--- a/scripts/adapter/pf2e/IdentifyPopup.mjs
+++ b/scripts/adapter/pf2e/IdentifyPopup.mjs
@@ -1,0 +1,134 @@
+/**
+ * Replicates pf2e's native IdentifyItemPopup using the same template and DC
+ * formula. IdentifyItemPopup is module-scoped inside pf2e.mjs and not exported,
+ * so we construct an equivalent FormApplication that produces an identical UX.
+ *
+ * DC table and rarity adjustments copied verbatim from pf2e 8.x source
+ * (pf2e.mjs dcByLevel / dcAdjustments). These are fixed game-rule constants
+ * published in the PF2e CRB, so embedding them here is safe against pf2e
+ * version drift.
+ */
+
+// Level → base DC lookup (Pathfinder 2e CRB p.503).
+const DC_BY_LEVEL = new Map([
+  [-1, 13], [0, 14], [1, 15], [2, 16], [3, 18], [4, 19], [5, 20],
+  [6, 22], [7, 23], [8, 24], [9, 26], [10, 27], [11, 28], [12, 30],
+  [13, 31], [14, 32], [15, 34], [16, 35], [17, 36], [18, 38],
+  [19, 39], [20, 40], [21, 42], [22, 44], [23, 46], [24, 48], [25, 50]
+]);
+
+const DC_ADJUSTMENT = new Map([
+  ["incredibly-easy", -10], ["very-easy", -5], ["easy", -2],
+  ["normal", 0], ["hard", 2], ["very-hard", 5], ["incredibly-hard", 10]
+]);
+
+const MAGIC_TRADITIONS = new Set(["arcane", "divine", "occult", "primal"]);
+
+/**
+ * Compute per-skill identification DCs for `item`, replicating pf2e's
+ * module-scoped `getItemIdentificationDCs` helper exactly.
+ *
+ * @param {Item} item - A pf2e physical item document.
+ * @returns {{ arcana?: number, nature?: number, religion?: number, occultism?: number, crafting?: number }}
+ */
+function _computeItemDCs(item) {
+  const pwol = game.pf2e.settings.variants.pwol.enabled;
+  const level = item.level ?? 0;
+  const baseDC = DC_BY_LEVEL.get(level) ?? 14;
+  const dcNoRarity = pwol ? baseDC - Math.max(level, 0) : baseDC;
+
+  // Cursed items use "unique" rarity for the DC calculation.
+  const rarity = item.traits?.has?.("cursed") ? "unique" : (item.rarity ?? "common");
+  const rarityKey = rarity === "uncommon" ? "hard"
+    : rarity === "rare" ? "very-hard"
+      : rarity === "unique" ? "incredibly-hard"
+        : "normal";
+  const dc = dcNoRarity + (DC_ADJUSTMENT.get(rarityKey) ?? 0);
+
+  if (!item.isMagical) return { crafting: dc };
+
+  const notMatchingMod = Number(
+    game.settings.get("pf2e", "identifyMagicNotMatchingTraditionModifier")
+  ) || 5;
+  const traditions = new Set(
+    (item.system?.traits?.value ?? []).filter(t => MAGIC_TRADITIONS.has(t))
+  );
+  const raw = { arcane: dc, divine: dc, occult: dc, primal: dc };
+  for (const trad of MAGIC_TRADITIONS) {
+    if (traditions.size > 0 && !traditions.has(trad)) raw[trad] += notMatchingMod;
+  }
+  return {
+    arcana: raw.arcane,
+    nature: raw.primal,
+    religion: raw.divine,
+    occultism: raw.occult
+  };
+}
+
+/**
+ * Dialog shown when a GM clicks the Identify button on an unidentified pf2e
+ * item. Renders pf2e's own identify-item.hbs template with calculated DCs and
+ * wires up the "Post to Chat" and "Identify" buttons.
+ */
+export class Pf2eIdentifyPopup extends foundry.appv1.api.FormApplication {
+
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      id: "identify-item",
+      title: game.i18n.localize("PF2E.identification.Identify"),
+      template: "systems/pf2e/templates/actors/identify-item.hbs",
+      width: "auto",
+      classes: ["identify-popup"]
+    });
+  }
+
+  // Class field runs after FormApplication sets this.object in its constructor.
+  dcs = _computeItemDCs(this.object);
+
+  /** @override */
+  async getData() {
+    const item = this.object;
+    return {
+      ...await super.getData(),
+      isMagic: item.isMagical,
+      isAlchemical: item.isAlchemical,
+      dcs: this.dcs
+    };
+  }
+
+  /** @override */
+  activateListeners($html) {
+    super.activateListeners($html);
+    const html = $html[0];
+
+    html.querySelector("button.update-identification")?.addEventListener("click", (ev) => {
+      const btn = ev.currentTarget;
+      this.submit({ updateData: { status: btn.value } });
+    });
+
+    html.querySelector("button.post-skill-checks")?.addEventListener("click", async () => {
+      const item = this.object;
+      const action = item.isMagical ? "identify-magic"
+        : item.isAlchemical ? "identify-alchemy"
+          : "recall-knowledge";
+      const content = await foundry.applications.handlebars.renderTemplate(
+        "systems/pf2e/templates/actors/identify-item-chat-skill-checks.hbs",
+        {
+          identifiedName: item.system.identification.identified.name,
+          action,
+          skills: this.dcs,
+          unidentified: item.system.identification.unidentified,
+          uuid: item.uuid
+        }
+      );
+      await ChatMessage.implementation.create({ author: game.user.id, content });
+    });
+  }
+
+  /** @override */
+  async _updateObject(_event, formData) {
+    if (formData.status === "identified") {
+      return this.object.setIdentificationStatus("identified");
+    }
+  }
+}

--- a/scripts/adapter/pf2e/configSheet.mjs
+++ b/scripts/adapter/pf2e/configSheet.mjs
@@ -239,6 +239,11 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
    * fails that lookup and crashes the click handler with
    * `Cannot read properties of undefined (reading 'onclick')`.
    *
+   * Buttons are unshifted in REVERSE canonical order (identify → lock → open)
+   * so the final layout reads `open, lock, identify, [system buttons], close`
+   * left-to-right — module toggles to the left of pf2e's own `Sheet` and
+   * `Prototype Token` buttons.
+   *
    * Active/inactive state is conveyed by the icon itself (lock vs lock-open,
    * box vs box-open), so no separate "active" class is needed.
    */
@@ -248,28 +253,7 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
 
     const system = this.actor.system;
 
-    if (system.isContainer) {
-      buttons.unshift({
-        label: "",
-        tooltip: game.i18n.localize(system.isOpen
-          ? "INTERACTIVE_ITEMS.Sheet.StateOpened"
-          : "INTERACTIVE_ITEMS.Sheet.StateClosed"),
-        class: "ii-toggle-open",
-        icon: `fas ${system.isOpen ? "fa-box-open" : "fa-box"}`,
-        onclick: () => setContainerOpen(this.actor, !this.actor.system.isOpen)
-      });
-    }
-
-    buttons.unshift({
-      label: "",
-      tooltip: game.i18n.localize(system.isLocked
-        ? "INTERACTIVE_ITEMS.Sheet.StateLocked"
-        : "INTERACTIVE_ITEMS.Sheet.StateUnlocked"),
-      class: "ii-toggle-lock",
-      icon: `fas ${system.isLocked ? "fa-lock" : "fa-lock-open"}`,
-      onclick: () => toggleContainerLocked(this.actor)
-    });
-
+    // Identify (will end up at position 2 — third from left)
     const identCfg = getAdapter().getIdentifyButtonConfig(system.isIdentified);
     const identIconFamily = system.isIdentified
       ? (identCfg.iconFamilyOn ?? "fas")
@@ -288,6 +272,30 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
         adapter.performIdentifyToggle(item);
       }
     });
+
+    // Lock (position 1)
+    buttons.unshift({
+      label: "",
+      tooltip: game.i18n.localize(system.isLocked
+        ? "INTERACTIVE_ITEMS.Sheet.StateLocked"
+        : "INTERACTIVE_ITEMS.Sheet.StateUnlocked"),
+      class: "ii-toggle-lock",
+      icon: `fas ${system.isLocked ? "fa-lock" : "fa-lock-open"}`,
+      onclick: () => toggleContainerLocked(this.actor)
+    });
+
+    // Open/Close (position 0 — leftmost) — containers only
+    if (system.isContainer) {
+      buttons.unshift({
+        label: "",
+        tooltip: game.i18n.localize(system.isOpen
+          ? "INTERACTIVE_ITEMS.Sheet.StateOpened"
+          : "INTERACTIVE_ITEMS.Sheet.StateClosed"),
+        class: "ii-toggle-open",
+        icon: `fas ${system.isOpen ? "fa-box-open" : "fa-box"}`,
+        onclick: () => setContainerOpen(this.actor, !this.actor.system.isOpen)
+      });
+    }
 
     return buttons;
   }

--- a/scripts/adapter/pf2e/configSheet.mjs
+++ b/scripts/adapter/pf2e/configSheet.mjs
@@ -169,6 +169,69 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
   }
 
   /**
+   * Foundry V1 `_replaceHTML` only swaps `.window-content` on re-render —
+   * the `.window-header` (and our injected toggles in it) is never refreshed,
+   * so `_getHeaderButtons` is effectively a one-shot at initial render.
+   * Override `_render` to re-sync the existing header buttons' icon, tooltip,
+   * and `active` state after each render so they always reflect the actor's
+   * current isOpen / isLocked / isIdentified.
+   *
+   * @param {boolean} force
+   * @param {object} options
+   */
+  async _render(force, options) {
+    const result = await super._render(force, options);
+    this.#refreshHeaderToggleVisuals();
+    return result;
+  }
+
+  /**
+   * Walk the live header buttons and update each toggle's icon class and
+   * tooltip in place. Click handlers were bound at initial render with
+   * closures that read live actor state, so they don't need to be re-bound.
+   */
+  #refreshHeaderToggleVisuals() {
+    const header = this.element?.[0]?.querySelector(".window-header");
+    if (!header) return;
+    const system = this.actor.system;
+
+    const updateToggle = (selector, iconClassName, tooltip) => {
+      const btn = header.querySelector(selector);
+      if (!btn) return;
+      const i = btn.querySelector("i");
+      if (i) i.className = iconClassName;
+      if (tooltip) {
+        btn.dataset.tooltip = tooltip;
+        btn.setAttribute("aria-label", tooltip);
+      }
+    };
+
+    if (system.isContainer) {
+      updateToggle(
+        ".ii-toggle-open",
+        `fas ${system.isOpen ? "fa-box-open" : "fa-box"}`,
+        game.i18n.localize(system.isOpen
+          ? "INTERACTIVE_ITEMS.Sheet.StateOpened"
+          : "INTERACTIVE_ITEMS.Sheet.StateClosed")
+      );
+    }
+
+    updateToggle(
+      ".ii-toggle-lock",
+      `fas ${system.isLocked ? "fa-lock" : "fa-lock-open"}`,
+      game.i18n.localize(system.isLocked
+        ? "INTERACTIVE_ITEMS.Sheet.StateLocked"
+        : "INTERACTIVE_ITEMS.Sheet.StateUnlocked")
+    );
+
+    const identCfg = getAdapter().getIdentifyButtonConfig(system.isIdentified);
+    const family = system.isIdentified ? (identCfg.iconFamilyOn ?? "fas") : (identCfg.iconFamilyOff ?? "fas");
+    const icon = system.isIdentified ? identCfg.iconOn : identCfg.iconOff;
+    const labelKey = system.isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey;
+    updateToggle(".ii-toggle-identify", `${family} ${icon}`, game.i18n.localize(labelKey));
+  }
+
+  /**
    * V1 header buttons — Foundry calls this on every render. Module-specific
    * toggles are emitted icon-only (empty label) and use a single-token `class`
    * because Foundry's V1 click delegation looks the descriptor up via

--- a/scripts/adapter/pf2e/configSheet.mjs
+++ b/scripts/adapter/pf2e/configSheet.mjs
@@ -170,9 +170,14 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
 
   /**
    * V1 header buttons — Foundry calls this on every render. Module-specific
-   * toggles are emitted with an empty `label` so they render icon-only,
-   * keeping the header tidy alongside pf2e's own labelled buttons (`Sheet`,
-   * `Prototype Token`).
+   * toggles are emitted icon-only (empty label) and use a single-token `class`
+   * because Foundry's V1 click delegation looks the descriptor up via
+   * `event.currentTarget.classList.contains(b.class)` — a multi-token string
+   * fails that lookup and crashes the click handler with
+   * `Cannot read properties of undefined (reading 'onclick')`.
+   *
+   * Active/inactive state is conveyed by the icon itself (lock vs lock-open,
+   * box vs box-open), so no separate "active" class is needed.
    */
   _getHeaderButtons() {
     const buttons = super._getHeaderButtons();
@@ -183,7 +188,10 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
     if (system.isContainer) {
       buttons.unshift({
         label: "",
-        class: `ii-config-toggle ii-toggle-open ${system.isOpen ? "active" : ""}`,
+        tooltip: game.i18n.localize(system.isOpen
+          ? "INTERACTIVE_ITEMS.Sheet.StateOpened"
+          : "INTERACTIVE_ITEMS.Sheet.StateClosed"),
+        class: "ii-toggle-open",
         icon: `fas ${system.isOpen ? "fa-box-open" : "fa-box"}`,
         onclick: () => setContainerOpen(this.actor, !this.actor.system.isOpen)
       });
@@ -191,7 +199,10 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
 
     buttons.unshift({
       label: "",
-      class: `ii-config-toggle ii-toggle-lock ${system.isLocked ? "active" : ""}`,
+      tooltip: game.i18n.localize(system.isLocked
+        ? "INTERACTIVE_ITEMS.Sheet.StateLocked"
+        : "INTERACTIVE_ITEMS.Sheet.StateUnlocked"),
+      class: "ii-toggle-lock",
       icon: `fas ${system.isLocked ? "fa-lock" : "fa-lock-open"}`,
       onclick: () => toggleContainerLocked(this.actor)
     });
@@ -201,9 +212,11 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
       ? (identCfg.iconFamilyOn ?? "fas")
       : (identCfg.iconFamilyOff ?? "fas");
     const identIcon = system.isIdentified ? identCfg.iconOn : identCfg.iconOff;
+    const identLabelKey = system.isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey;
     buttons.unshift({
       label: "",
-      class: `ii-config-toggle ii-toggle-identify ${system.isIdentified ? "active" : ""}`,
+      tooltip: game.i18n.localize(identLabelKey),
+      class: "ii-toggle-identify",
       icon: `${identIconFamily} ${identIcon}`,
       onclick: () => {
         const item = this.actor.system.embeddedItem;

--- a/scripts/adapter/pf2e/configSheet.mjs
+++ b/scripts/adapter/pf2e/configSheet.mjs
@@ -1,0 +1,321 @@
+/**
+ * Pf2eInteractiveItemConfigSheet — ApplicationV1 GM config dialog for
+ * pick-up-stix interactive object actors on pf2e.
+ *
+ * Uses V1 conventions to match pf2e's own actor/item sheets:
+ *   - extends `foundry.appv1.sheets.ActorSheet`
+ *   - `getData()` for context, `_updateObject()` for form submission
+ *   - jQuery `activateListeners(html)` for event binding
+ *   - `_getHeaderButtons()` for the open/close, lock, identify toggles
+ *   - file-picker buttons handled by FormApplication's `_activateFilePicker`
+ *
+ * Constructed by `Pf2eAdapter.renderConfigSheet()` and cached per-actor in
+ * `#instances` so repeated clicks on the same actor reuse the open window.
+ */
+
+import { getAdapter } from "../index.mjs";
+import { setContainerOpen, toggleContainerLocked } from "../../transfer/ItemTransfer.mjs";
+import { dbg } from "../../utils/debugLog.mjs";
+
+/**
+ * pf2e GM-only config sheet for `pick-up-stix.interactiveItem` actors.
+ */
+export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets.ActorSheet {
+
+  /** Per-actor singleton cache so repeat opens reuse the existing window. */
+  static #instances = new Map();
+
+  /**
+   * Resolve the config sheet for a given actor, creating one on first call
+   * and returning the cached instance on subsequent calls.
+   *
+   * @param {Actor} actor
+   * @returns {Pf2eInteractiveItemConfigSheet}
+   */
+  static forActor(actor) {
+    const key = actor.uuid;
+    let sheet = Pf2eInteractiveItemConfigSheet.#instances.get(key);
+    if (!sheet) {
+      sheet = new Pf2eInteractiveItemConfigSheet(actor);
+      Pf2eInteractiveItemConfigSheet.#instances.set(key, sheet);
+    }
+    return sheet;
+  }
+
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["pick-up-stix", "pf2e", "sheet", "actor", "interactive-item-config"],
+      template: "modules/pick-up-stix/templates/item-config-v1.hbs",
+      width: 420,
+      height: "auto",
+      resizable: true,
+      submitOnChange: true,
+      submitOnClose: true,
+      closeOnSubmit: false
+    });
+  }
+
+  get title() {
+    return `${game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Configure")}: ${this.actor.system.displayName}`;
+  }
+
+  get containerItem() {
+    return this.actor.system.containerItem;
+  }
+
+  get _tokenDoc() {
+    return this.actor.token ?? null;
+  }
+
+  /**
+   * Build the V1 template context. Description fields are pre-enriched so the
+   * `{{editor}}` helper can render them without an extra async pass.
+   */
+  async getData(options) {
+    const context = await super.getData(options);
+    const system = this.actor.system;
+    context.actor = this.actor;
+    context.system = system;
+    context.isEditable = this.isEditable;
+    context.isContainer = system.isContainer;
+    context.needsItem = this.actor.items.size === 0 && !this._tokenDoc;
+    context.isIdentified = system.isIdentified;
+    context.displayName = system.displayName;
+
+    if (system.isContainer) {
+      const item = this.containerItem;
+      context.hasContainerItem = !!item;
+      context.containerName = system.resolveTokenName();
+      context.containerImg = (system.isOpen && system.openImage)
+        ? system.openImage
+        : (item?.img ?? this.actor.img);
+    } else {
+      const item = this.actor.items.contents[0];
+      context.hasItem = !!item;
+      context.itemName = system.resolveTokenName();
+      context.itemImg = system.resolveImage();
+    }
+
+    const enrich = (html) =>
+      foundry.applications.ux.TextEditor.implementation.enrichHTML(html ?? "", { async: true });
+    context.descriptionHTML = await enrich(system.description);
+    context.unidentifiedDescriptionHTML = await enrich(system.unidentifiedDescription);
+    context.limitedDescriptionHTML = await enrich(system.limitedDescription);
+
+    return context;
+  }
+
+  /**
+   * Bind data-action click handlers (image edit, open native sheet) and the
+   * file-picker buttons. The form's `<input>` / `<button>` submission flow is
+   * handled by FormApplication via `submitOnChange`.
+   */
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    if (!this.isEditable) return;
+
+    html.find("[data-action='editActorImage']").on("click", (event) => {
+      event.preventDefault();
+      const fp = new foundry.applications.apps.FilePicker.implementation({
+        type: "image",
+        current: this.actor.img,
+        callback: (path) => this.actor.system.updateImage(path)
+      });
+      fp.render(true);
+    });
+
+    html.find("[data-action='openItemSheet']").on("click", async (event) => {
+      event.preventDefault();
+      const item = this.actor.items.contents[0];
+      if (!item) return;
+      await this.#syncItemImage(item);
+      await this.close();
+      await getAdapter().renderItemView(this.actor);
+    });
+
+    html.find("[data-action='openContainerSheet']").on("click", async (event) => {
+      event.preventDefault();
+      if (!this.containerItem) return;
+      await this.close();
+      await getAdapter().renderContainerView(this.actor);
+    });
+  }
+
+  /**
+   * V1 form submission. Inject `prototypeToken.texture.src` whenever `img` or
+   * `system.unidentifiedImage` changes so the placed token's portrait stays in
+   * sync with the configured identified/unidentified image.
+   */
+  async _updateObject(event, formData) {
+    dbg("pf2e-config:_updateObject", { actorName: this.actor?.name, formKeys: Object.keys(formData) });
+    const data = foundry.utils.expandObject(formData);
+
+    // Re-flatten so we can patch the dotted keys consumed by Document.update.
+    const flat = foundry.utils.flattenObject(data);
+
+    if (flat.img && flat.img !== this.actor.img) {
+      if (this.actor.system.isIdentified || !this.actor.system.unidentifiedImage) {
+        flat["prototypeToken.texture.src"] = flat.img;
+      }
+    }
+    if ("system.unidentifiedImage" in flat && !this.actor.system.isIdentified) {
+      const newUnidentifiedImage = flat["system.unidentifiedImage"];
+      if (newUnidentifiedImage) flat["prototypeToken.texture.src"] = newUnidentifiedImage;
+      else flat["prototypeToken.texture.src"] = flat.img || this.actor.img;
+    }
+
+    return this.actor.update(flat);
+  }
+
+  /**
+   * V1 header buttons — Foundry calls this on every render. Return descriptors
+   * for Open/Close (containers only), Lock, and Identify so the toggles always
+   * reflect the actor's current state.
+   */
+  _getHeaderButtons() {
+    const buttons = super._getHeaderButtons();
+    if (!this.isEditable) return buttons;
+
+    const system = this.actor.system;
+
+    if (system.isContainer) {
+      buttons.unshift({
+        label: system.isOpen
+          ? game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateOpened")
+          : game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateClosed"),
+        class: `ii-config-toggle ${system.isOpen ? "active" : ""}`,
+        icon: `fas ${system.isOpen ? "fa-box-open" : "fa-box"}`,
+        onclick: () => setContainerOpen(this.actor, !this.actor.system.isOpen)
+      });
+    }
+
+    buttons.unshift({
+      label: system.isLocked
+        ? game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateLocked")
+        : game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateUnlocked"),
+      class: `ii-config-toggle ${system.isLocked ? "active" : ""}`,
+      icon: `fas ${system.isLocked ? "fa-lock" : "fa-lock-open"}`,
+      onclick: () => toggleContainerLocked(this.actor)
+    });
+
+    const identCfg = getAdapter().getIdentifyButtonConfig(system.isIdentified);
+    const identIconFamily = system.isIdentified
+      ? (identCfg.iconFamilyOn ?? "fas")
+      : (identCfg.iconFamilyOff ?? "fas");
+    const identIcon = system.isIdentified ? identCfg.iconOn : identCfg.iconOff;
+    const identLabelKey = system.isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey;
+    buttons.unshift({
+      label: game.i18n.localize(identLabelKey),
+      class: `ii-config-toggle ${system.isIdentified ? "active" : ""}`,
+      icon: `${identIconFamily} ${identIcon}`,
+      onclick: () => {
+        const item = this.actor.system.embeddedItem;
+        const adapter = getAdapter();
+        if (!item || adapter.isItemIdentified(item) === undefined) return;
+        adapter.performIdentifyToggle(item);
+      }
+    });
+
+    return buttons;
+  }
+
+  /**
+   * If the embedded item's image has drifted from the actor's resolved image
+   * (identified vs unidentified), push the actor's resolved image down to the
+   * item before opening its sheet. GM-only.
+   */
+  async #syncItemImage(item) {
+    if (!game.user.isGM) return;
+    const expectedImg = this.actor.system.resolveImage();
+    if (item.img !== expectedImg) await item.update({ img: expectedImg });
+  }
+
+  _canDragDrop(_selector) {
+    return true;
+  }
+
+  /**
+   * Drop handler for assigning the actor's embedded item. Mirrors the dnd5e
+   * config sheet's drop logic but uses pf2e's `isPhysicalItem` capability —
+   * pf2e's "physical item" predicate replaces dnd5e's `quantity in system`
+   * heuristic.
+   */
+  async _onDrop(event) {
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    dbg("pf2e-config:_onDrop", { dataType: data.type, uuid: data.uuid });
+    if (data.type !== "Item") return;
+
+    const item = await fromUuid(data.uuid);
+    if (!item) return;
+
+    const adapter = getAdapter();
+    if (!adapter.isPhysicalItem(item)) {
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotPhysical"));
+      return;
+    }
+
+    if (!game.user.isGM) return;
+
+    const itemData = item.toObject();
+    delete itemData._id;
+
+    adapter.stampNewItemIdentified(itemData, true);
+
+    if (this.actor.items.size > 0) {
+      const ids = this.actor.items.map(i => i.id);
+      await this.actor.deleteEmbeddedDocuments("Item", ids);
+    }
+
+    const updates = {
+      name: item.name,
+      img: item.img,
+      "prototypeToken.name": item.name,
+      "prototypeToken.texture.src": item.img
+    };
+    if (item.system.description?.value) {
+      updates["system.description"] = item.system.description.value;
+    }
+    const droppedUnidentifiedName = adapter.getItemUnidentifiedName(item);
+    const droppedUnidentifiedDescription = adapter.getItemUnidentifiedDescription(item);
+    if (droppedUnidentifiedName) updates["system.unidentifiedName"] = droppedUnidentifiedName;
+    if (droppedUnidentifiedDescription) updates["system.unidentifiedDescription"] = droppedUnidentifiedDescription;
+
+    await this.actor.update(updates);
+
+    const [createdItem] = await this.actor.createEmbeddedDocuments("Item", [itemData]);
+
+    if (createdItem) {
+      const allIdentificationChanges = {
+        isIdentified: true,
+        unidentifiedName: this.actor.system.unidentifiedName,
+        description: this.actor.system.description,
+        unidentifiedDescription: this.actor.system.unidentifiedDescription
+      };
+      const itemUpdates = adapter.buildItemIdentificationUpdate(this.actor, allIdentificationChanges);
+      if (Object.keys(itemUpdates).length > 0) await createdItem.update(itemUpdates);
+    }
+
+    ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Notify.Deposited", { name: item.name }));
+  }
+
+  /**
+   * Tear-down: drop the per-actor instance cache entry, then run the dnd5e-
+   * equivalent abandoned-actor cleanup (delete the kind-picker actor if the
+   * GM dismissed without ever dropping an item).
+   */
+  async close(options = {}) {
+    dbg("pf2e-config:close", { actorName: this.actor?.name, actorId: this.actor?.id });
+    const actor = this.actor;
+    Pf2eInteractiveItemConfigSheet.#instances.delete(actor?.uuid);
+    const result = await super.close(options);
+
+    const MODULE_ID = "pick-up-stix";
+    if (actor && game.actors.has(actor.id) && !actor.token && game.user.isGM
+      && actor.getFlag(MODULE_ID, "createKindConfirmed")
+      && actor.items.size === 0) {
+      await actor.delete();
+    }
+    return result;
+  }
+}

--- a/scripts/adapter/pf2e/configSheet.mjs
+++ b/scripts/adapter/pf2e/configSheet.mjs
@@ -169,9 +169,10 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
   }
 
   /**
-   * V1 header buttons — Foundry calls this on every render. Return descriptors
-   * for Open/Close (containers only), Lock, and Identify so the toggles always
-   * reflect the actor's current state.
+   * V1 header buttons — Foundry calls this on every render. Module-specific
+   * toggles are emitted with an empty `label` so they render icon-only,
+   * keeping the header tidy alongside pf2e's own labelled buttons (`Sheet`,
+   * `Prototype Token`).
    */
   _getHeaderButtons() {
     const buttons = super._getHeaderButtons();
@@ -181,20 +182,16 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
 
     if (system.isContainer) {
       buttons.unshift({
-        label: system.isOpen
-          ? game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateOpened")
-          : game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateClosed"),
-        class: `ii-config-toggle ${system.isOpen ? "active" : ""}`,
+        label: "",
+        class: `ii-config-toggle ii-toggle-open ${system.isOpen ? "active" : ""}`,
         icon: `fas ${system.isOpen ? "fa-box-open" : "fa-box"}`,
         onclick: () => setContainerOpen(this.actor, !this.actor.system.isOpen)
       });
     }
 
     buttons.unshift({
-      label: system.isLocked
-        ? game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateLocked")
-        : game.i18n.localize("INTERACTIVE_ITEMS.Sheet.StateUnlocked"),
-      class: `ii-config-toggle ${system.isLocked ? "active" : ""}`,
+      label: "",
+      class: `ii-config-toggle ii-toggle-lock ${system.isLocked ? "active" : ""}`,
       icon: `fas ${system.isLocked ? "fa-lock" : "fa-lock-open"}`,
       onclick: () => toggleContainerLocked(this.actor)
     });
@@ -204,10 +201,9 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
       ? (identCfg.iconFamilyOn ?? "fas")
       : (identCfg.iconFamilyOff ?? "fas");
     const identIcon = system.isIdentified ? identCfg.iconOn : identCfg.iconOff;
-    const identLabelKey = system.isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey;
     buttons.unshift({
-      label: game.i18n.localize(identLabelKey),
-      class: `ii-config-toggle ${system.isIdentified ? "active" : ""}`,
+      label: "",
+      class: `ii-config-toggle ii-toggle-identify ${system.isIdentified ? "active" : ""}`,
       icon: `${identIconFamily} ${identIcon}`,
       onclick: () => {
         const item = this.actor.system.embeddedItem;

--- a/scripts/adapter/pf2e/container.mjs
+++ b/scripts/adapter/pf2e/container.mjs
@@ -1,0 +1,153 @@
+/**
+ * pf2e container-parent and deep-create methods for the SystemAdapter contract.
+ *
+ * pf2e uses `system.containerId` (a plain string | null) to track the
+ * parent-container item's id. The item type for containers is "backpack"
+ * (pf2e registers ContainerSheetPF2e for the "backpack" type). pf2e has no
+ * native equivalent of dnd5e's `Item5e.createWithContents`, so this adapter
+ * walks `system.contents` manually.
+ *
+ * Verified against pf2e 8.1.0 source (pf2e.mjs):
+ * - `system.containerId` is a plain string or null (modern API; the legacy
+ *   `{ value: null }` shape is normalised during migration and no longer
+ *   appears on live documents).
+ * - `item.type === "backpack"` is the canonical container type check.
+ * - `"equipment"` is the closest pf2e analog to dnd5e's "loot" — a generic
+ *   physical item with no special sub-type semantics.
+ *
+ * These methods are mixed into `Pf2eAdapter` in `pf2e/index.mjs`.
+ */
+export const Pf2eContainer = {
+
+  /**
+   * Item type for containers. pf2e calls these "backpack" items; the
+   * ContainerSheetPF2e sheet is registered for this type.
+   *
+   * @type {string}
+   */
+  containerItemType: "backpack",
+
+  /**
+   * Item type for generic loot created from scratch. pf2e has no "loot" item
+   * type; "equipment" is the closest physical-item analog.
+   *
+   * @type {string}
+   */
+  defaultLootItemType: "equipment",
+
+  /**
+   * Read the parent-container id (or null) from a live pf2e Item.
+   * pf2e stores this as a plain string in `system.containerId`.
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemContainerId(item) {
+    return item?.system?.containerId ?? null;
+  },
+
+  /**
+   * Stamp the parent-container id onto raw item data prior to create/update.
+   * pf2e uses `system.containerId` (plain string) for this relationship.
+   *
+   * @param {object} itemData - Plain item data object (mutated in-place).
+   * @param {string|null} containerId - Id of the parent container item.
+   */
+  setItemContainerId(itemData, containerId) {
+    itemData.system = itemData.system ?? {};
+    itemData.system.containerId = containerId;
+  },
+
+  /**
+   * Deep-create a container plus its nested contents using a hand-rolled walker.
+   *
+   * pf2e has no native equivalent of dnd5e's `Item5e.createWithContents`.
+   * This method:
+   *   1. Clones each input item (or plain data object).
+   *   2. Assigns a fresh `_id` to each clone so callers can reference them.
+   *   3. Stamps `system.containerId` on each child to point at its parent.
+   *   4. Recurses into `system.contents` (pf2e may store nested items there)
+   *      up to a maximum depth of 5 to match dnd5e's MAX_DEPTH convention.
+   *   5. Calls `CONFIG.Item.documentClass.createDocuments` with `keepId: true`
+   *      so the pre-assigned ids are honoured.
+   *
+   * @param {object[]|Item[]} items - Items to create (plain data or live documents).
+   * @param {object} [options] - Options forwarded to `createDocuments`. May include `parent`.
+   * @returns {Promise<Item[]>}
+   */
+  /**
+   * Flatten items into plain data objects by walking `system.contents`
+   * recursively. pf2e has no `createWithContents` equivalent.
+   *
+   * @param {Item[]|object[]} items
+   * @param {object} [options]
+   * @param {(itemData: object) => object|null} [options.transformAll]
+   * @returns {Promise<object[]>}
+   */
+  async flattenItemsForCreate(items, options = {}) {
+    const { transformAll } = options;
+    const flat = [];
+    const MAX_DEPTH = 5;
+    const walk = (list, parentId, depth) => {
+      if (depth > MAX_DEPTH) return;
+      for (const src of list) {
+        const data = src instanceof foundry.abstract.Document
+          ? src.toObject()
+          : foundry.utils.deepClone(src);
+        if (parentId) {
+          data.system = data.system ?? {};
+          data.system.containerId = parentId;
+        }
+        const newId = foundry.utils.randomID();
+        data._id = newId;
+        const children = Array.isArray(data.system?.contents) ? data.system.contents : [];
+        if (data.system?.contents) delete data.system.contents;
+        const result = transformAll ? transformAll(data) : data;
+        if (result != null) flat.push(result);
+        if (children.length) walk(children, newId, depth + 1);
+      }
+    };
+    walk(items, null, 0);
+    return flat;
+  },
+
+  async createItemsWithContents(items, options = {}) {
+    const flat = [];
+    const MAX_DEPTH = 5;
+
+    /**
+     * Recursively flatten a list of items (and their `system.contents`) into
+     * a single array, stamping parent ids as we go.
+     *
+     * @param {object[]|Item[]} list
+     * @param {string|null} parentId
+     * @param {number} depth
+     */
+    const walk = (list, parentId, depth) => {
+      if (depth > MAX_DEPTH) return;
+      for (const itemSrc of list) {
+        const data = foundry.utils.deepClone(
+          itemSrc instanceof Item ? itemSrc.toObject() : itemSrc
+        );
+        const newId = foundry.utils.randomID();
+        data._id = newId;
+        if (parentId) {
+          data.system = data.system ?? {};
+          data.system.containerId = parentId;
+        }
+        // Extract and remove nested contents before pushing so we don't
+        // persist the contents array on the created item.
+        const children = data.system?.contents ?? [];
+        if (data.system?.contents) delete data.system.contents;
+        flat.push(data);
+        if (children.length) walk(children, newId, depth + 1);
+      }
+    };
+
+    walk(items, null, 0);
+
+    const createOptions = { keepId: true };
+    if (options.parent) createOptions.parent = options.parent;
+    return CONFIG.Item.documentClass.createDocuments(flat, createOptions);
+  }
+};

--- a/scripts/adapter/pf2e/container.mjs
+++ b/scripts/adapter/pf2e/container.mjs
@@ -36,6 +36,22 @@ export const Pf2eContainer = {
   defaultLootItemType: "equipment",
 
   /**
+   * pf2e enumerates physical-item types in `game.pf2e.system.PHYSICAL_ITEM_TYPES`.
+   * Falls back to a hardcoded set when the runtime symbol isn't reachable
+   * (e.g. very early init before pf2e finishes booting).
+   *
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  isPhysicalItem(item) {
+    if (item == null) return false;
+    const fromRuntime = game.pf2e?.system?.PHYSICAL_ITEM_TYPES;
+    if (fromRuntime?.has) return fromRuntime.has(item.type);
+    const FALLBACK = new Set(["ammo", "armor", "backpack", "book", "consumable", "equipment", "shield", "treasure", "weapon"]);
+    return FALLBACK.has(item.type);
+  },
+
+  /**
    * Read the parent-container id (or null) from a live pf2e Item.
    * pf2e stores this as a plain string in `system.containerId`.
    *

--- a/scripts/adapter/pf2e/hooks.mjs
+++ b/scripts/adapter/pf2e/hooks.mjs
@@ -302,6 +302,7 @@ export const Pf2eHooks = {
       handlers.injectHeaderControls?.(ctx);
       handlers.maybeHideContents?.(ctx);
       handlers.installActorDropListener?.(ctx);
+      handlers.installItemDropListener?.(ctx);
       handlers.injectItemRowControls?.(ctx);
       handlers.injectContentsTab?.(ctx);
     });

--- a/scripts/adapter/pf2e/hooks.mjs
+++ b/scripts/adapter/pf2e/hooks.mjs
@@ -29,6 +29,7 @@
  */
 
 import { dbg } from "../../utils/debugLog.mjs";
+import { isInteractiveContainer } from "../../utils/actorHelpers.mjs";
 
 // ── Shared ────────────────────────────────────────────────────────────────────
 
@@ -147,7 +148,7 @@ export const Pf2eHooks = {
    */
   registerContainerDropGate(callback) {
     // Defer until `setup` so pf2e has registered its sheets.
-    Hooks.once("setup", () => {
+    Hooks.once("setup", async () => {
       // Retrieve ActorSheetPF2e from the registered sheet list. The class is
       // not on the global scope because pf2e bundles it inside an IIFE.
       const registeredSheets = foundry.documents.collections.Actors.registeredSheets ?? [];
@@ -251,15 +252,23 @@ export const Pf2eHooks = {
   },
 
   /**
-   * Register handlers for "an interactive container's contents view was
-   * rendered" on pf2e.
+   * Register handlers for "a pf2e container item sheet was rendered".
    *
-   * pf2e containers render inline on actor sheets rather than in a dedicated
-   * ContainerSheet window. In Phase 7 a dedicated pick-up-stix ContainerView
-   * ApplicationV2 will replace this; for Phase 6 this is a no-op so that the
-   * four decorator callbacks (`injectHeaderControls`, `maybeHideContents`,
-   * `installActorDropListener`, `injectItemRowControls`) do not throw, and so
-   * that Phase 7 can wire them up to `renderPfContainerView` cleanly.
+   * pf2e has no standalone window-style container view. We use ContainerSheetPF2e
+   * (the native pf2e backpack item sheet) as the container UX. This hook subscribes
+   * to `renderContainerSheetPF2e` and forwards each render to the four system-agnostic
+   * decorators, but ONLY when the backpack item belongs to one of our interactive
+   * container actors.
+   *
+   * AppV1 render hooks supply the inner content element; the decorators need the
+   * full window (`.window-header` is outside the inner content), so we pass
+   * `app.element[0]` as `html`.
+   *
+   * Decorators that look for pf2e actor-sheet-specific DOM (e.g.
+   * `section.inventory.tab[data-tab="contents"] .items-list`) will be no-ops
+   * because ContainerSheetPF2e uses the standard pf2e item sheet template
+   * (description + details tabs). Header-control injection and actor-drop
+   * listening both work correctly.
    *
    * @param {object} handlers
    * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectHeaderControls]
@@ -268,8 +277,32 @@ export const Pf2eHooks = {
    * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectItemRowControls]
    */
   registerContainerViewHooks(handlers) {
-    // Phase 6: no-op. Phase 7 replaces this with Hooks.on("renderPfContainerView", ...)
-    // when the dedicated ContainerView ApplicationV2 is introduced.
-    dbg("pf2e-hooks:registerContainerViewHooks", "no-op in Phase 6 — deferred to Phase 7");
+    dbg("pf2e-hooks:registerContainerViewHooks", "subscribing to renderContainerSheetPF2e");
+
+    Hooks.on("renderContainerSheetPF2e", (app, element) => {
+      // Only handle backpack items embedded in our interactive container actors.
+      const actor = app.item?.actor;
+      if (!isInteractiveContainer(actor)) return;
+
+      // AppV1 render hooks pass the inner template content. Decorators need the
+      // full window element to reach `.window-header`. Use app.element[0].
+      const windowEl = app.element instanceof HTMLElement
+        ? app.element
+        : app.element?.[0] ?? null;
+      if (!windowEl) return;
+
+      const ctx = { actor, app, html: windowEl };
+
+      dbg("pf2e-hooks:renderContainerSheetPF2e", {
+        actorName: actor?.name,
+        actorId: actor?.id,
+        itemId: app.item?.id
+      });
+
+      handlers.injectHeaderControls?.(ctx);
+      handlers.maybeHideContents?.(ctx);
+      handlers.installActorDropListener?.(ctx);
+      handlers.injectItemRowControls?.(ctx);
+    });
   }
 };

--- a/scripts/adapter/pf2e/hooks.mjs
+++ b/scripts/adapter/pf2e/hooks.mjs
@@ -303,6 +303,7 @@ export const Pf2eHooks = {
       handlers.maybeHideContents?.(ctx);
       handlers.installActorDropListener?.(ctx);
       handlers.injectItemRowControls?.(ctx);
+      handlers.injectContentsTab?.(ctx);
     });
   }
 };

--- a/scripts/adapter/pf2e/hooks.mjs
+++ b/scripts/adapter/pf2e/hooks.mjs
@@ -1,0 +1,275 @@
+/**
+ * pf2e hook-registration methods for the SystemAdapter contract.
+ *
+ * pf2e does not fire any of the dnd5e-specific hooks this module previously
+ * relied on (`dnd5e.dropItemSheetData`, `dnd5e.getItemContextOptions`,
+ * `renderContainerSheet`, `renderItemSheet5e`). Each `register*` method
+ * below substitutes an equivalent pf2e-native approach, using libWrapper where
+ * a clean hook surface does not exist.
+ *
+ * Verified against pf2e 8.1.0 source (pf2e.mjs):
+ * - Actor sheets: CharacterSheetPF2e, NPCSheetPF2e, LootSheetPF2e each have
+ *   `__name(this, "<ClassName>")` set, so Foundry fires "render<ClassName>" hooks.
+ * - Physical item sheets: AmmoSheetPF2e, ArmorSheetPF2e, BookSheetPF2e,
+ *   ConsumableSheetPF2e, ContainerSheetPF2e (backpack), EquipmentSheetPF2e,
+ *   ShieldSheetPF2e, TreasureSheetPF2e, WeaponSheetPF2e — all named, all
+ *   extend PhysicalItemSheetPF2e which extends ItemSheetPF2e (AppV1).
+ * - Drop: `_handleDroppedItem(event, item, data)` exists on ActorSheetPF2e
+ *   (line ~22609 in pf2e.mjs). This is the earliest interception point for
+ *   external-item drops onto a pf2e actor sheet.
+ * - Context menu: pf2e builds inventory context menus internally; there is no
+ *   public `pf2e.getItemContextOptions` hook equivalent. The plan proposes a
+ *   libWrapper wrap on a context-menu builder method — however, pf2e's
+ *   inventory context menus are assembled inline and do not have a separately
+ *   named builder method on ActorSheetPF2e that is safe to wrap without
+ *   risk. For Phase 6, a Hooks-based approach on the actor sheet render hooks
+ *   is used instead (documented below).
+ *
+ * These methods are mixed into `Pf2eAdapter` in `pf2e/index.mjs`.
+ */
+
+import { dbg } from "../../utils/debugLog.mjs";
+
+// ── Shared ────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalise the `html` argument supplied by Foundry AppV1 render hooks to a
+ * bare `HTMLElement`. Foundry v13/v14 with AppV1 sheets may supply either a
+ * jQuery wrapper or a plain element depending on the Foundry generation.
+ *
+ * @param {jQuery|HTMLElement|undefined} html
+ * @returns {HTMLElement|null}
+ */
+function _resolveHtml(html) {
+  if (!html) return null;
+  if (html instanceof HTMLElement) return html;
+  // jQuery-wrapped: take the first element.
+  if (typeof html[0] !== "undefined") return html[0] ?? null;
+  return null;
+}
+
+// ── Actor render hook names (verified) ───────────────────────────────────────
+//
+// Foundry derives the render hook name from the class name set by __name().
+// Each class below has __name(this, "<Name>") in its static block — verified.
+
+const ACTOR_INVENTORY_HOOKS = [
+  "renderCharacterSheetPF2e",
+  "renderNPCSheetPF2e",
+  "renderLootSheetPF2e"
+];
+
+// ── Physical item sheet render hook names (verified) ─────────────────────────
+//
+// All physical-item sheet classes use __name() — verified in pf2e.mjs.
+// The hook "renderPhysicalItemSheetPF2e" does NOT exist separately; Foundry
+// fires the concrete subclass hook only. We must enumerate all subclasses.
+
+const PHYSICAL_ITEM_SHEET_HOOKS = [
+  "renderAmmoSheetPF2e",
+  "renderArmorSheetPF2e",
+  "renderBookSheetPF2e",
+  "renderConsumableSheetPF2e",
+  "renderContainerSheetPF2e",   // "backpack" type — ContainerSheetPF2e
+  "renderEquipmentSheetPF2e",
+  "renderShieldSheetPF2e",
+  "renderTreasureSheetPF2e",
+  "renderWeaponSheetPF2e"
+];
+
+// ── exports ───────────────────────────────────────────────────────────────────
+
+export const Pf2eHooks = {
+
+  /**
+   * Subscribe to pf2e actor sheet render hooks and forward each render to the
+   * supplied `callback`. The callback receives `(app, html)` as supplied by
+   * the hook, with `html` normalised to a plain HTMLElement.
+   *
+   * Subscribes to CharacterSheetPF2e, NPCSheetPF2e, and LootSheetPF2e because
+   * those are the actor types that show an inventory where the wand-icon
+   * identification toggles need to appear.
+   *
+   * @param {(app: Application, html: HTMLElement) => void} callback
+   */
+  registerActorInventoryHooks(callback) {
+    for (const hookName of ACTOR_INVENTORY_HOOKS) {
+      Hooks.on(hookName, (app, html) => {
+        dbg("pf2e-hooks:registerActorInventoryHooks", hookName, app?.actor?.id);
+        callback(app, _resolveHtml(html));
+      });
+    }
+  },
+
+  /**
+   * Subscribe to pf2e physical-item sheet render hooks and forward each render
+   * to the `injectHeaderControls` handler, which receives `{ app, html }`.
+   *
+   * pf2e fires per-type render hooks (renderWeaponSheetPF2e, etc.) rather than
+   * a single renderItemSheet hook. We subscribe to all known physical-item sheet
+   * classes so that any embedded item type gets the GM configure/lock buttons.
+   *
+   * @param {object} handlers
+   * @param {(ctx: {app: Application, html: HTMLElement}) => void} [handlers.injectHeaderControls]
+   */
+  registerItemSheetHooks({ injectHeaderControls }) {
+    for (const hookName of PHYSICAL_ITEM_SHEET_HOOKS) {
+      Hooks.on(hookName, (app, html) => {
+        dbg("pf2e-hooks:registerItemSheetHooks", hookName, app?.item?.id);
+        injectHeaderControls?.({ app, html: _resolveHtml(html) });
+      });
+    }
+  },
+
+  /**
+   * Register a drop-into-container intercept for pf2e actor sheets.
+   *
+   * pf2e has no `pf2e.dropItemSheetData` hook equivalent. The earliest
+   * cancellable interception point for external-item drops onto a pf2e actor
+   * sheet is `ActorSheetPF2e.prototype._handleDroppedItem`, verified in
+   * pf2e 8.1.0 at line ~22609. This method is called from `_onDropItem` for
+   * items dropped from outside the actor's own inventory.
+   *
+   * Because `ActorSheetPF2e` is defined inside pf2e's bundled IIFE it is not
+   * exported to the global scope; libWrapper's string-path resolution cannot
+   * reach it. Instead we defer to the `setup` hook (after pf2e has registered
+   * its sheets), retrieve the class from the Foundry sheet registry, and patch
+   * its prototype directly. We store the original method so the patch is
+   * idempotent and compatible with other modules that do the same.
+   *
+   * The wrapper inspects the drop target element to see if it lands inside a
+   * pf2e container row (`li[data-is-container]`). If a matching interactive
+   * container actor is found, or if the target actor itself is an interactive
+   * container, the gate callback is invoked. Returning `false` from the
+   * callback cancels pf2e's native drop handling.
+   *
+   * @param {(ctx: {actor: Actor, item: Item|null, sheet: Application, data: object}) => boolean|undefined} callback
+   */
+  registerContainerDropGate(callback) {
+    // Defer until `setup` so pf2e has registered its sheets.
+    Hooks.once("setup", () => {
+      // Retrieve ActorSheetPF2e from the registered sheet list. The class is
+      // not on the global scope because pf2e bundles it inside an IIFE.
+      const registeredSheets = foundry.documents.collections.Actors.registeredSheets ?? [];
+      const actorSheetPf2eClass = registeredSheets.find(
+        (s) => s.name === "ActorSheetPF2e"
+      );
+
+      if (!actorSheetPf2eClass) {
+        console.warn(
+          "pick-up-stix | pf2e: registerContainerDropGate — ActorSheetPF2e not found in " +
+          "registered actor sheets. Drop gating will not function on pf2e. " +
+          "This may indicate a pf2e version mismatch (target: 8.x)."
+        );
+        return;
+      }
+
+      // Direct prototype patch: store the original so other modules can chain.
+      const proto = actorSheetPf2eClass.prototype;
+      const _original = proto._handleDroppedItem;
+
+      /**
+       * Intercepts item drops onto pf2e actor sheets for proximity/lock/open
+       * gating on interactive container actors.
+       *
+       * @this {ActorSheetPF2e}
+       * @param {DragEvent} event
+       * @param {ItemPF2e} item
+       * @param {object} data
+       * @returns {Promise<ItemPF2e[]>}
+       */
+      proto._handleDroppedItem = async function (event, item, data) {
+        dbg("pf2e-hooks:registerContainerDropGate", this.actor?.id, item?.id);
+        // Determine if the drop lands on a pf2e inline container row.
+        const containerEl = event?.target?.closest?.("li[data-is-container]");
+        const containerItemId = containerEl?.dataset?.itemId ?? null;
+        const destContainer = containerItemId
+          ? (this.actor?.items?.get(containerItemId) ?? null)
+          : null;
+        const destActor = this.actor;
+
+        // Only gate if a pf2e container row is targeted OR the actor type is
+        // "loot" (which pf2e uses as a world-item-container actor type).
+        if (destContainer !== null || destActor?.type === "loot") {
+          const proceed = await callback({
+            actor: destActor,
+            item: destContainer,
+            sheet: this,
+            data
+          });
+          if (proceed === false) return;
+        }
+
+        return _original.call(this, event, item, data);
+      };
+    });
+  },
+
+  /**
+   * Register an item-context-menu extension for pf2e actor inventory rows.
+   *
+   * pf2e has no `pf2e.getItemContextOptions` hook and does not expose a named
+   * context-menu builder method on ActorSheetPF2e that is stable across
+   * versions. Rather than wrapping an undocumented internal method (which would
+   * be fragile), we inject menu items via DOM manipulation after each actor
+   * sheet render. This mirrors the approach used by some pf2e modules and is
+   * the safest option for Phase 6 compatibility.
+   *
+   * Note: Context menus in pf2e are built by ContextMenu instances attached
+   * during `_activateListeners`. We cannot intercept those without libWrapper
+   * on internal methods that have no stable public name. The render-hook DOM
+   * approach appends `<li>` elements to existing `ContextMenu` containers if
+   * already present, or patches via the module's own `ContextMenu` call if
+   * pf2e exposes it in the future.
+   *
+   * For Phase 6, this implementation installs a `contextmenu` event listener
+   * on the rendered inventory list that fires the `extender` callback when a
+   * right-click targets an item row. This gives the module a chance to inject
+   * entries into whatever context menu pf2e is about to show by listening to
+   * `getActorSheetContext` or a similar Foundry core hook if available.
+   *
+   * Current status: pf2e 8.1.0 does not fire a hookable context-menu event
+   * that modules can extend cleanly. This method registers a no-op for Phase 6
+   * and emits a console warning directing Phase 7 implementers to revisit when
+   * pf2e exposes a suitable hook or when a tested libWrapper target is
+   * confirmed.
+   *
+   * @param {(item: Item, menuItems: object[]) => void} extender
+   */
+  registerItemContextMenu(extender) {
+    // No stable pf2e hook for context-menu extension was found in 8.1.0.
+    // A libWrapper target for the internal ContextMenu builder was not
+    // confirmed against the source — wrapping an unverified method would risk
+    // breaking pf2e's own context menus.
+    //
+    // Phase 7: once a stable target is identified (either a future pf2e hook
+    // or a confirmed libWrapper path), replace this with the real integration.
+    console.warn(
+      "pick-up-stix | pf2e: registerItemContextMenu — no stable pf2e hook found in 8.1.0. " +
+      "Context menu extension for pf2e inventory rows is deferred to Phase 7."
+    );
+  },
+
+  /**
+   * Register handlers for "an interactive container's contents view was
+   * rendered" on pf2e.
+   *
+   * pf2e containers render inline on actor sheets rather than in a dedicated
+   * ContainerSheet window. In Phase 7 a dedicated pick-up-stix ContainerView
+   * ApplicationV2 will replace this; for Phase 6 this is a no-op so that the
+   * four decorator callbacks (`injectHeaderControls`, `maybeHideContents`,
+   * `installActorDropListener`, `injectItemRowControls`) do not throw, and so
+   * that Phase 7 can wire them up to `renderPfContainerView` cleanly.
+   *
+   * @param {object} handlers
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectHeaderControls]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.maybeHideContents]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.installActorDropListener]
+   * @param {(ctx: {actor: Actor, app: Application, html: HTMLElement}) => void} [handlers.injectItemRowControls]
+   */
+  registerContainerViewHooks(handlers) {
+    // Phase 6: no-op. Phase 7 replaces this with Hooks.on("renderPfContainerView", ...)
+    // when the dedicated ContainerView ApplicationV2 is introduced.
+    dbg("pf2e-hooks:registerContainerViewHooks", "no-op in Phase 6 — deferred to Phase 7");
+  }
+};

--- a/scripts/adapter/pf2e/identification.mjs
+++ b/scripts/adapter/pf2e/identification.mjs
@@ -111,61 +111,127 @@ export const Pf2eIdentification = {
   },
 
   /**
-   * pf2e item sheets bind the name input to `item._source.name` regardless
-   * of identification state. When the GM edits that input we route the
-   * change to the wrapping actor:
-   *   identified   → actor.name (canonical real name)
-   *   unidentified → actor.system.unidentifiedName (mystified label)
+   * Translate a pf2e item changeset into the corresponding actor update so
+   * the wrapping interactive actor stays the source of truth for both the
+   * identified and mystified presentations.
    *
-   * The downstream `updateActor` flow propagates further: identified writes
-   * fan out to the prototype/synthetic token name, unidentified writes flow
-   * through `buildItemIdentificationUpdate` to update
-   * `system.identification.unidentified.name` on the embedded item.
+   * Three field categories are routed:
+   *   1. Main sheet "Name" input (`_source.name`):
+   *        identified   → actor.name
+   *        unidentified → actor.system.unidentifiedName
+   *   2. Mystification tab "Display Details" name input
+   *      (`system.identification.unidentified.name`)
+   *        → actor.system.unidentifiedName
+   *   3. Mystification tab description editor
+   *      (`system.identification.unidentified.data.description.value`)
+   *        → actor.system.unidentifiedDescription
+   *
+   * Mystification-block changes are skipped when the changeset also
+   * contains `system.identification.status` — that means the update
+   * originates from `setIdentificationStatus` writing the auto-generated
+   * `getMystifiedData("unidentified")` block, and we don't want to
+   * persist pf2e's "Unusual {Type}" fallback as the actor's explicit
+   * unidentified name.
    *
    * Returns `{}` when nothing needs to change so the caller can skip the
-   * update (also avoids needless hook fan-out).
+   * actor update (also avoids needless hook fan-out).
    */
-  parseEmbeddedItemNameChange(item, changes, actor) {
-    if (!("name" in changes)) return {};
-    const newName = changes.name;
-    if (typeof newName !== "string") return {};
-    const isIdentified = actor.system.isIdentified;
-    if (isIdentified) {
-      if (actor.name === newName) return {};
-      return { name: newName };
+  parseEmbeddedItemChanges(item, changes, actor) {
+    const update = {};
+
+    // 1. Main "Name" input.
+    if ("name" in changes && typeof changes.name === "string") {
+      const newName = changes.name;
+      if (actor.system.isIdentified) {
+        if (actor.name !== newName) update.name = newName;
+      } else if (actor.system.unidentifiedName !== newName) {
+        update["system.unidentifiedName"] = newName;
+      }
     }
-    if (actor.system.unidentifiedName === newName) return {};
-    return { "system.unidentifiedName": newName };
+
+    // 2 & 3. Mystification tab name and description inputs — skip when
+    //        status is also changing (setIdentificationStatus side effect).
+    if (!foundry.utils.hasProperty(changes, "system.identification.status")) {
+      const unidName = foundry.utils.getProperty(
+        changes, "system.identification.unidentified.name"
+      );
+      if (typeof unidName === "string"
+          && actor.system.unidentifiedName !== unidName) {
+        update["system.unidentifiedName"] = unidName;
+      }
+      const unidDesc = foundry.utils.getProperty(
+        changes, "system.identification.unidentified.data.description.value"
+      );
+      if (typeof unidDesc === "string"
+          && actor.system.unidentifiedDescription !== unidDesc) {
+        update["system.unidentifiedDescription"] = unidDesc;
+      }
+    }
+
+    // 4. Main Description tab editor (system.description.value) — pf2e's
+    //    prepareDerivedData overwrites this field with the active state's
+    //    description, so an edit while mystified must route to the actor's
+    //    unidentifiedDescription, not the canonical description.
+    const descChange = foundry.utils.getProperty(changes, "system.description.value");
+    if (typeof descChange === "string") {
+      if (actor.system.isIdentified) {
+        if (actor.system.description !== descChange) {
+          update["system.description"] = descChange;
+        }
+      } else if (actor.system.unidentifiedDescription !== descChange) {
+        update["system.unidentifiedDescription"] = descChange;
+      }
+    }
+
+    return update;
   },
 
   buildEmbeddedItemSourceUpdate(actor, isIdentified) {
     const item = actor.system.embeddedItem;
     if (!item) return {};
-    let desired;
+
+    // Resolve the desired display name and description for the active state.
+    // Names fall back through unidentifiedName → generateUnidentifiedName →
+    // actor.name; descriptions fall back to empty.
+    let desiredName, desiredDesc;
     if (isIdentified) {
-      desired = actor.name;
+      desiredName = actor.name;
+      desiredDesc = actor.system.description ?? "";
     } else {
-      desired = actor.system.unidentifiedName
+      desiredName = actor.system.unidentifiedName
         || (typeof item.generateUnidentifiedName === "function"
             ? item.generateUnidentifiedName()
             : "")
         || actor.name;
+      desiredDesc = actor.system.unidentifiedDescription ?? "";
     }
-    if (!desired) return {};
+    if (!desiredName) return {};
 
-    // Mirror the desired value into both `_source.name` (the in-sheet input)
-    // and pf2e's per-state cache. pf2e populates
+    // Mirror desired values into both _source (so the in-sheet inputs read
+    // the right text) and the per-state caches. pf2e populates
     // `system.identification.identified` once via `??=` from the initial
-    // source name, then relies on `getMystifiedData(status)` to drive
-    // `this.name` in `prepareDerivedData`. Without updating the cache, a
-    // later identify cycle resurrects the stale original name.
+    // source values, then reads `getMystifiedData(status)` in
+    // `prepareDerivedData` to drive `this.name` and `this.system.description.value`.
+    // Without updating the caches, a later identify cycle resurrects the
+    // stale original name/description.
     const update = {};
-    if (item._source?.name !== desired) update.name = desired;
-    const cachePath = isIdentified
-      ? "system.identification.identified.name"
-      : "system.identification.unidentified.name";
-    const currentCache = foundry.utils.getProperty(item._source ?? {}, cachePath);
-    if (currentCache !== desired) update[cachePath] = desired;
+    const src = item._source ?? {};
+
+    if (src.name !== desiredName) update.name = desiredName;
+    if ((src.system?.description?.value ?? "") !== desiredDesc) {
+      update["system.description.value"] = desiredDesc;
+    }
+
+    const stateKey = isIdentified ? "identified" : "unidentified";
+    const cacheNamePath = `system.identification.${stateKey}.name`;
+    const cacheDescPath = `system.identification.${stateKey}.data.description.value`;
+    if (foundry.utils.getProperty(src, cacheNamePath) !== desiredName) {
+      update[cacheNamePath] = desiredName;
+    }
+    if ((foundry.utils.getProperty(src, cacheDescPath) ?? "") !== desiredDesc) {
+      update[cacheDescPath] = desiredDesc;
+    }
+
     return update;
   },
 

--- a/scripts/adapter/pf2e/identification.mjs
+++ b/scripts/adapter/pf2e/identification.mjs
@@ -111,6 +111,34 @@ export const Pf2eIdentification = {
   },
 
   /**
+   * pf2e binds the in-sheet name input to `item._source.name`, which
+   * `setIdentificationStatus` does not touch. To make the input reflect the
+   * current identification state we explicitly sync it here:
+   *   identified   → actor.name (the canonical real name)
+   *   unidentified → actor.system.unidentifiedName, or pf2e's own
+   *                  `generateUnidentifiedName()` ("Unusual {ItemType}") when
+   *                  the GM hasn't supplied an explicit override.
+   *
+   * Returns `{}` when nothing needs to change so the caller can skip the update.
+   */
+  buildEmbeddedItemSourceUpdate(actor, isIdentified) {
+    const item = actor.system.embeddedItem;
+    if (!item) return {};
+    let desired;
+    if (isIdentified) {
+      desired = actor.name;
+    } else {
+      desired = actor.system.unidentifiedName
+        || (typeof item.generateUnidentifiedName === "function"
+            ? item.generateUnidentifiedName()
+            : "")
+        || actor.name;
+    }
+    if (!desired || item._source?.name === desired) return {};
+    return { name: desired };
+  },
+
+  /**
    * Stamp identification status onto raw item data prior to `createDocuments`.
    * Used when initialising a freshly-dropped pf2e item. Sets
    * `system.identification.status` to the appropriate enum string.

--- a/scripts/adapter/pf2e/identification.mjs
+++ b/scripts/adapter/pf2e/identification.mjs
@@ -190,9 +190,12 @@ export const Pf2eIdentification = {
     const item = actor.system.embeddedItem;
     if (!item) return {};
 
-    // Resolve the desired display name and description for the active state.
-    // Names fall back through unidentifiedName → generateUnidentifiedName →
-    // actor.name; descriptions fall back to empty.
+    // Resolve the desired display name, description, and image for the
+    // active state. Names fall back through unidentifiedName →
+    // generateUnidentifiedName → actor.name; descriptions fall back to
+    // empty; images use the model's resolveImage which already handles
+    // unidentifiedImage / actor.img precedence — passing a boolean
+    // overrides the model's live isIdentified read.
     let desiredName, desiredDesc;
     if (isIdentified) {
       desiredName = actor.name;
@@ -206,27 +209,34 @@ export const Pf2eIdentification = {
       desiredDesc = actor.system.unidentifiedDescription ?? "";
     }
     if (!desiredName) return {};
+    const desiredImg = actor.system.resolveImage(isIdentified);
 
     // Mirror desired values into both _source (so the in-sheet inputs read
     // the right text) and the per-state caches. pf2e populates
     // `system.identification.identified` once via `??=` from the initial
     // source values, then reads `getMystifiedData(status)` in
-    // `prepareDerivedData` to drive `this.name` and `this.system.description.value`.
-    // Without updating the caches, a later identify cycle resurrects the
-    // stale original name/description.
+    // `prepareDerivedData` to drive `this.name`, `this.img`, and
+    // `this.system.description.value`. Without updating the cached image,
+    // pf2e falls back to `getUnidentifiedPlaceholderImage` and the token
+    // / sheet shows a generic mystery icon.
     const update = {};
     const src = item._source ?? {};
 
     if (src.name !== desiredName) update.name = desiredName;
+    if (desiredImg && src.img !== desiredImg) update.img = desiredImg;
     if ((src.system?.description?.value ?? "") !== desiredDesc) {
       update["system.description.value"] = desiredDesc;
     }
 
     const stateKey = isIdentified ? "identified" : "unidentified";
     const cacheNamePath = `system.identification.${stateKey}.name`;
+    const cacheImgPath = `system.identification.${stateKey}.img`;
     const cacheDescPath = `system.identification.${stateKey}.data.description.value`;
     if (foundry.utils.getProperty(src, cacheNamePath) !== desiredName) {
       update[cacheNamePath] = desiredName;
+    }
+    if (desiredImg && foundry.utils.getProperty(src, cacheImgPath) !== desiredImg) {
+      update[cacheImgPath] = desiredImg;
     }
     if ((foundry.utils.getProperty(src, cacheDescPath) ?? "") !== desiredDesc) {
       update[cacheDescPath] = desiredDesc;

--- a/scripts/adapter/pf2e/identification.mjs
+++ b/scripts/adapter/pf2e/identification.mjs
@@ -111,16 +111,33 @@ export const Pf2eIdentification = {
   },
 
   /**
-   * pf2e binds the in-sheet name input to `item._source.name`, which
-   * `setIdentificationStatus` does not touch. To make the input reflect the
-   * current identification state we explicitly sync it here:
-   *   identified   → actor.name (the canonical real name)
-   *   unidentified → actor.system.unidentifiedName, or pf2e's own
-   *                  `generateUnidentifiedName()` ("Unusual {ItemType}") when
-   *                  the GM hasn't supplied an explicit override.
+   * pf2e item sheets bind the name input to `item._source.name` regardless
+   * of identification state. When the GM edits that input we route the
+   * change to the wrapping actor:
+   *   identified   → actor.name (canonical real name)
+   *   unidentified → actor.system.unidentifiedName (mystified label)
    *
-   * Returns `{}` when nothing needs to change so the caller can skip the update.
+   * The downstream `updateActor` flow propagates further: identified writes
+   * fan out to the prototype/synthetic token name, unidentified writes flow
+   * through `buildItemIdentificationUpdate` to update
+   * `system.identification.unidentified.name` on the embedded item.
+   *
+   * Returns `{}` when nothing needs to change so the caller can skip the
+   * update (also avoids needless hook fan-out).
    */
+  parseEmbeddedItemNameChange(item, changes, actor) {
+    if (!("name" in changes)) return {};
+    const newName = changes.name;
+    if (typeof newName !== "string") return {};
+    const isIdentified = actor.system.isIdentified;
+    if (isIdentified) {
+      if (actor.name === newName) return {};
+      return { name: newName };
+    }
+    if (actor.system.unidentifiedName === newName) return {};
+    return { "system.unidentifiedName": newName };
+  },
+
   buildEmbeddedItemSourceUpdate(actor, isIdentified) {
     const item = actor.system.embeddedItem;
     if (!item) return {};
@@ -134,8 +151,22 @@ export const Pf2eIdentification = {
             : "")
         || actor.name;
     }
-    if (!desired || item._source?.name === desired) return {};
-    return { name: desired };
+    if (!desired) return {};
+
+    // Mirror the desired value into both `_source.name` (the in-sheet input)
+    // and pf2e's per-state cache. pf2e populates
+    // `system.identification.identified` once via `??=` from the initial
+    // source name, then relies on `getMystifiedData(status)` to drive
+    // `this.name` in `prepareDerivedData`. Without updating the cache, a
+    // later identify cycle resurrects the stale original name.
+    const update = {};
+    if (item._source?.name !== desired) update.name = desired;
+    const cachePath = isIdentified
+      ? "system.identification.identified.name"
+      : "system.identification.unidentified.name";
+    const currentCache = foundry.utils.getProperty(item._source ?? {}, cachePath);
+    if (currentCache !== desired) update[cachePath] = desired;
+    return update;
   },
 
   /**

--- a/scripts/adapter/pf2e/identification.mjs
+++ b/scripts/adapter/pf2e/identification.mjs
@@ -1,0 +1,183 @@
+/**
+ * pf2e identification methods for the SystemAdapter contract.
+ *
+ * pf2e stores identification state as an enum string `system.identification.status`
+ * on physical items ("identified" | "unidentified"), and stores unidentified
+ * presentation data under `system.identification.unidentified.{name, img,
+ * data.description.value}`.
+ *
+ * Verified against pf2e 8.1.0 source (pf2e.mjs):
+ * - `system.identification.status` — "identified" | "unidentified"
+ * - `item.setIdentificationStatus(status)` — sets status and backfills mystifiedData
+ * - `system.identification.unidentified.name` — unidentified display name
+ * - `system.identification.unidentified.img` — unidentified display image
+ * - `system.identification.unidentified.data.description.value` — unidentified
+ *   description HTML (confirmed via the enrichHTML call in PhysicalItemSheetPF2e)
+ *
+ * These methods are mixed into `Pf2eAdapter` in `pf2e/index.mjs`.
+ */
+import { Pf2eIdentifyPopup } from "./IdentifyPopup.mjs";
+
+export const Pf2eIdentification = {
+
+  /**
+   * True if the item is currently identified. pf2e uses an enum string:
+   * "identified" | "unidentified".
+   *
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  isItemIdentified(item) {
+    return item?.system?.identification?.status === "identified";
+  },
+
+  /**
+   * Persist a new identification status on an existing item. Uses pf2e's
+   * native `setIdentificationStatus` method which fills in mystified data and
+   * fires expected hooks. Falls back to a direct `item.update` if the method
+   * is absent (defensive guard for future pf2e API changes).
+   *
+   * @param {Item} item
+   * @param {boolean} isIdentified
+   * @returns {Promise<Item>}
+   */
+  async setItemIdentified(item, isIdentified) {
+    const status = isIdentified ? "identified" : "unidentified";
+    if (typeof item.setIdentificationStatus === "function") {
+      return item.setIdentificationStatus(status);
+    }
+    // Fallback: direct field update if the method is unavailable.
+    console.warn("pick-up-stix | pf2e: setIdentificationStatus not found on item; falling back to direct update");
+    return item.update({ "system.identification.status": status });
+  },
+
+  /**
+   * Read the unidentified display name on the item (or null).
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedName(item) {
+    return item?.system?.identification?.unidentified?.name ?? null;
+  },
+
+  /**
+   * Read the unidentified description (HTML string) on the item (or null).
+   * pf2e nests this at `system.identification.unidentified.data.description.value`.
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedDescription(item) {
+    return item?.system?.identification?.unidentified?.data?.description?.value ?? null;
+  },
+
+  /**
+   * Read the unidentified image path on the item (or null). pf2e stores this at
+   * `system.identification.unidentified.img`.
+   *
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemUnidentifiedImage(item) {
+    return item?.system?.identification?.unidentified?.img ?? null;
+  },
+
+  /**
+   * Build the embedded-item update payload that mirrors the actor's identification
+   * state changes into the pf2e item's `system.identification.*` fields. `changes`
+   * is the `system` slice of an Actor#update changeset (so we can detect which
+   * fields actually changed).
+   *
+   * @param {Actor} actor - The interactive actor whose system fields changed.
+   * @param {object} changes - The `system` slice of the Actor#update changeset.
+   * @returns {object} A flat update object suitable for `item.update(...)`.
+   */
+  buildItemIdentificationUpdate(actor, changes) {
+    const u = {};
+    if ("isIdentified" in changes) {
+      u["system.identification.status"] = actor.system.isIdentified ? "identified" : "unidentified";
+    }
+    if ("unidentifiedName" in changes) {
+      u["system.identification.unidentified.name"] = actor.system.unidentifiedName || "";
+    }
+    if ("description" in changes) {
+      u["system.description.value"] = actor.system.description || "";
+    }
+    if ("unidentifiedDescription" in changes) {
+      u["system.identification.unidentified.data.description.value"] = actor.system.unidentifiedDescription || "";
+    }
+    return u;
+  },
+
+  /**
+   * Stamp identification status onto raw item data prior to `createDocuments`.
+   * Used when initialising a freshly-dropped pf2e item. Sets
+   * `system.identification.status` to the appropriate enum string.
+   *
+   * @param {object} itemData - Plain item data object (mutated in-place).
+   * @param {boolean} isIdentified
+   * @returns {object} The mutated itemData.
+   */
+  stampNewItemIdentified(itemData, isIdentified) {
+    itemData.system = itemData.system ?? {};
+    itemData.system.identification = itemData.system.identification ?? {};
+    itemData.system.identification.status = isIdentified ? "identified" : "unidentified";
+    return itemData;
+  },
+
+  /**
+   * True if the updateItem changeset contains pf2e's identification block.
+   * pf2e stores identification state at system.identification.status and
+   * updates arrive as changes.system.identification (a nested object).
+   *
+   * @param {Item} item
+   * @param {object} changes
+   * @returns {boolean}
+   */
+  isIdentificationChange(item, changes) {
+    return changes.system?.identification !== undefined;
+  },
+
+  /**
+   * Return the icon/label configuration for the identify toggle button using
+   * pf2e's own Mystify / Identify iconography:
+   *   Identified   → hollow circle-question (fa-regular) = "Mystify" action
+   *   Unidentified → solid question-circle  (fa-solid)   = "Identify" action
+   *
+   * @param {boolean} isIdentified - Current identification state.
+   * @returns {{ iconOn: string, iconFamilyOn: string, labelOnKey: string,
+   *             iconOff: string, iconFamilyOff: string, labelOffKey: string }}
+   */
+  getIdentifyButtonConfig(_isIdentified) {
+    return {
+      // pf2e inventory row uses fa-regular fa-circle-question (Mystify) and
+      // fa-solid fa-circle-question (Identify). Both use the same FA6 icon name;
+      // only the weight (regular = outline, solid = filled) differs.
+      iconOn: "fa-circle-question",
+      iconFamilyOn: "fa-regular",
+      labelOnKey: "PF2E.identification.Mystify",
+      iconOff: "fa-circle-question",
+      iconFamilyOff: "fa-solid",
+      labelOffKey: "PF2E.identification.Identify"
+    };
+  },
+
+  /**
+   * Toggle identification on a pf2e item following pf2e's native inventory-row
+   * behavior:
+   *   Identified   → call `item.setIdentificationStatus("unidentified")` (Mystify).
+   *   Unidentified → open `Pf2eIdentifyPopup` (the DC dialog), same as clicking
+   *                  the toggle-identified button on a character sheet.
+   *
+   * @param {Item} item - The live embedded Item document to act on.
+   * @returns {Promise<void>}
+   */
+  async performIdentifyToggle(item) {
+    if (this.isItemIdentified(item)) {
+      await item.setIdentificationStatus("unidentified");
+    } else {
+      new Pf2eIdentifyPopup(item).render(true);
+    }
+  }
+};

--- a/scripts/adapter/pf2e/index.mjs
+++ b/scripts/adapter/pf2e/index.mjs
@@ -73,19 +73,19 @@ export default class Pf2eAdapter extends SystemAdapter {
 
   /**
    * CSS class names for controls injected into pf2e AppV1 item sheet headers
-   * and inventory rows. pf2e AppV1 sheets use the standard Foundry AppV1
-   * `.header-button` class for window-header controls.
+   * and inventory rows. pf2e AppV1 sheets use `<a class="header-button">` for
+   * window-header controls — `headerElementType: "a"` tells the shared button
+   * factory to produce anchors instead of `<button>` elements.
    *
-   * @returns {{ stateToggle: string, configButton: string, rowControl: string }}
+   * @returns {{ stateToggle: string, configButton: string, rowControl: string,
+   *             headerElementType: "button"|"a" }}
    */
   get cssClasses() {
     return {
-      /** Standard AppV1 header button class used by pf2e item sheets. */
       stateToggle: "header-button",
-      /** Standard AppV1 header button class used by pf2e item sheets. */
       configButton: "header-button",
-      /** pf2e inventory row control class. */
-      rowControl: "item-control"
+      rowControl: "item-control",
+      headerElementType: "a"
     };
   }
 

--- a/scripts/adapter/pf2e/index.mjs
+++ b/scripts/adapter/pf2e/index.mjs
@@ -1,0 +1,100 @@
+import SystemAdapter from "../SystemAdapter.mjs";
+import Pf2eInteractiveItemModel from "./model.mjs";
+import { Pf2eIdentification } from "./identification.mjs";
+import { Pf2eContainer } from "./container.mjs";
+import { Pf2eSheets } from "./sheets.mjs";
+import { Pf2eHooks } from "./hooks.mjs";
+
+/**
+ * Concrete SystemAdapter implementation for the pf2e game system.
+ *
+ * All method bodies are provided by the four sub-module mixins
+ * (Pf2eIdentification, Pf2eContainer, Pf2eSheets, Pf2eHooks) which are
+ * assigned onto the prototype below. This keeps each concern in its own file
+ * without requiring class inheritance per concern.
+ *
+ * Capability flags reflect what pf2e 8.1.0 actually provides:
+ * - pf2e DOES expose a per-item unidentified image field
+ *   (`system.identification.unidentified.img`).
+ * - pf2e does NOT fire `pf2e.dropItemSheetData` or `pf2e.getItemContextOptions`
+ *   hooks; the adapter substitutes libWrapper / hook-based equivalents.
+ * - pf2e has no window-style ContainerSheet; containers render inline on the
+ *   actor sheet. Phase 7 will introduce a pick-up-stix-owned ContainerView.
+ * - pf2e has no `Item5e.createWithContents` equivalent; the adapter walks
+ *   `system.contents` manually in `createItemsWithContents`.
+ */
+export default class Pf2eAdapter extends SystemAdapter {
+
+  /** @type {string} */
+  static SYSTEM_ID = "pf2e";
+
+  constructor() {
+    super();
+    // Register the pf2e-aware data model so that pf2e's prepareBaseData chain
+    // finds the stub fields it reads (system.details.level.value / details.alliance)
+    // before ActorPF2e / TokenDocumentPF2e crash on them. Must run before the
+    // LootPF2e registry entry below so both registries are coherent at init time.
+    CONFIG.Actor.dataModels["pick-up-stix.interactiveItem"] = Pf2eInteractiveItemModel;
+
+    // pf2e's ActorProxyPF2e rejects any actor type not in its closed class
+    // registry (CONFIG.PF2E.Actor.documentClasses). The registry is populated
+    // during pf2e's Hooks.once("init"), which runs before the module's init,
+    // so we can read LootPF2e from it here and register our sub-type against
+    // it. Foundry core still uses Pf2eInteractiveItemModel (from
+    // CONFIG.Actor.dataModels) for actor.system.* — the two registries are
+    // independent. Using LootPF2e as the base means pf2e's own actor internals
+    // (allowedItemTypes: physical, canAct: false, etc.) work correctly.
+
+    const LootPF2e = CONFIG.PF2E?.Actor?.documentClasses?.loot;
+    if (LootPF2e) {
+      CONFIG.PF2E.Actor.documentClasses["pick-up-stix.interactiveItem"] = LootPF2e;
+    } else {
+      console.warn(
+        "pick-up-stix | pf2e: LootPF2e not found in CONFIG.PF2E.Actor.documentClasses — " +
+        "actor creation will fail. This likely indicates a pf2e version mismatch (target: 8.x)."
+      );
+    }
+  }
+
+  capabilities = {
+    /** pf2e stores an unidentified image at system.identification.unidentified.img. */
+    hasUnidentifiedItemImage: true,
+    /** pf2e has no drop-item hook; the adapter wraps _handleDroppedItem via libWrapper. */
+    hasItemDropSheetHook: false,
+    /** pf2e has no item-context-menu hook; extension deferred to Phase 7. */
+    hasItemContextMenuHook: false,
+    /** pf2e has no window-style ContainerSheet; Phase 7 provides a custom view. */
+    hasNativeContainerWindow: false,
+    /** pf2e has no createWithContents equivalent; the adapter walks manually. */
+    hasNativeDeepCreate: false,
+    /** pf2e renders toggle-identified controls natively on every inventory row. */
+    hasNativeInventoryIdentify: true
+  };
+
+  /**
+   * CSS class names for controls injected into pf2e AppV1 item sheet headers
+   * and inventory rows. pf2e AppV1 sheets use the standard Foundry AppV1
+   * `.header-button` class for window-header controls.
+   *
+   * @returns {{ stateToggle: string, configButton: string, rowControl: string }}
+   */
+  get cssClasses() {
+    return {
+      /** Standard AppV1 header button class used by pf2e item sheets. */
+      stateToggle: "header-button",
+      /** Standard AppV1 header button class used by pf2e item sheets. */
+      configButton: "header-button",
+      /** pf2e inventory row control class. */
+      rowControl: "item-control"
+    };
+  }
+
+  // containerItemType and defaultLootItemType come from Pf2eContainer (assigned below).
+}
+
+// Assign sub-module methods directly onto the prototype so that `this` inside
+// each method correctly refers to the Pf2eAdapter instance.
+Object.assign(Pf2eAdapter.prototype, Pf2eIdentification);
+Object.assign(Pf2eAdapter.prototype, Pf2eContainer);
+Object.assign(Pf2eAdapter.prototype, Pf2eSheets);
+Object.assign(Pf2eAdapter.prototype, Pf2eHooks);

--- a/scripts/adapter/pf2e/index.mjs
+++ b/scripts/adapter/pf2e/index.mjs
@@ -18,8 +18,8 @@ import { Pf2eHooks } from "./hooks.mjs";
  *   (`system.identification.unidentified.img`).
  * - pf2e does NOT fire `pf2e.dropItemSheetData` or `pf2e.getItemContextOptions`
  *   hooks; the adapter substitutes libWrapper / hook-based equivalents.
- * - pf2e has no window-style ContainerSheet; containers render inline on the
- *   actor sheet. Phase 7 will introduce a pick-up-stix-owned ContainerView.
+ * - pf2e has no window-style actor ContainerSheet; the adapter opens the
+ *   embedded backpack item's native ContainerSheetPF2e instead.
  * - pf2e has no `Item5e.createWithContents` equivalent; the adapter walks
  *   `system.contents` manually in `createItemsWithContents`.
  */
@@ -63,7 +63,7 @@ export default class Pf2eAdapter extends SystemAdapter {
     hasItemDropSheetHook: false,
     /** pf2e has no item-context-menu hook; extension deferred to Phase 7. */
     hasItemContextMenuHook: false,
-    /** pf2e has no window-style ContainerSheet; Phase 7 provides a custom view. */
+    /** pf2e has no window-style actor ContainerSheet; the embedded backpack item's ContainerSheetPF2e is opened instead. */
     hasNativeContainerWindow: false,
     /** pf2e has no createWithContents equivalent; the adapter walks manually. */
     hasNativeDeepCreate: false,

--- a/scripts/adapter/pf2e/model.mjs
+++ b/scripts/adapter/pf2e/model.mjs
@@ -1,0 +1,43 @@
+/**
+ * pf2e-compatible data model for the interactiveItem actor sub-type.
+ *
+ * Extends InteractiveItemModel with the minimum stub fields that pf2e's own
+ * prepareBaseData chain reads before pick-up-stix has a chance to intervene:
+ *
+ *   ActorPF2e.prepareBaseData  → reads system.details.level.value, system.traits
+ *   TokenDocumentPF2e.prepareBaseData → reads actor.system.details.alliance
+ *
+ * The remaining pf2e fields accessed in prepareBaseData are written transiently
+ * by the pf2e chain itself and do not need schema entries:
+ *   - LootPF2e.prepareBaseData writes system.attributes = {} before calling super
+ *   - ActorPF2e.prepareBaseData writes system.autoChanges = {}
+ *   - system.traits is accessed via traits?.size (optional chain, safe when absent)
+ *
+ * This model is registered on CONFIG.Actor.dataModels in place of the generic
+ * InteractiveItemModel when the active game system is pf2e.
+ */
+
+import InteractiveItemModel from "../../models/InteractiveItemModel.mjs";
+
+const fields = foundry.data.fields;
+
+export default class Pf2eInteractiveItemModel extends InteractiveItemModel {
+
+  static defineSchema() {
+    return {
+      ...super.defineSchema(),
+      /**
+       * Stub for pf2e's actor.system.details block.
+       * ActorPF2e.prepareBaseData reads details.level.value (clamped to integer).
+       * TokenDocumentPF2e.prepareBaseData reads details.alliance to set token
+       * disposition (party→FRIENDLY, opposition→HOSTILE, null→NEUTRAL).
+       */
+      details: new fields.SchemaField({
+        level: new fields.SchemaField({
+          value: new fields.NumberField({ required: true, initial: 0, integer: true, min: 0 })
+        }),
+        alliance: new fields.StringField({ required: false, initial: null, nullable: true })
+      })
+    };
+  }
+}

--- a/scripts/adapter/pf2e/sheets.mjs
+++ b/scripts/adapter/pf2e/sheets.mjs
@@ -1,35 +1,44 @@
 /**
  * pf2e sheet-delegation methods for the SystemAdapter contract.
  *
- * pf2e ships per-type item sheets (WeaponSheetPF2e, EquipmentSheetPF2e, etc.)
- * but has no window-style ContainerSheet equivalent — containers render inline
- * on actor sheets. A dedicated ContainerView application for pf2e is planned
- * for Phase 7; until then `renderContainerView` returns a placeholder warning.
+ * pf2e ships per-type item sheets (WeaponSheetPF2e, EquipmentSheetPF2e, etc.).
+ * For container actors, `renderContainerView` opens the embedded backpack item's
+ * native pf2e sheet (ContainerSheetPF2e), consistent with pf2e's own AppV1
+ * conventions.
  *
  * These methods are mixed into `Pf2eAdapter` in `pf2e/index.mjs`.
  */
+
+import { dbg } from "../../utils/debugLog.mjs";
+
 export const Pf2eSheets = {
 
   /**
-   * Render the container view for an interactive container actor.
+   * Open the pf2e ContainerSheetPF2e for an interactive container actor.
    *
-   * Phase 7 builds the dedicated pf2e ContainerView application. Until then
-   * this method warns and returns null so that Phase 1–5 dnd5e regression
-   * testing remains clean and the empty code path is explicit rather than
-   * silently broken.
+   * pf2e has no standalone window-style container view — containers are shown
+   * inline on actor sheets. We open the embedded backpack item's own native
+   * pf2e sheet, which follows pf2e's AppV1 conventions and gives GMs/players
+   * the familiar pf2e item sheet UX.
    *
-   * @param {Actor} _actor
-   * @param {object} [_options]
-   * @returns {Promise<null>}
+   * @param {Actor} actor - The interactive container actor.
+   * @param {object} [options] - Options forwarded to `item.sheet.render(...)`.
+   * @returns {Promise<Application|null>}
    */
-  async renderContainerView(_actor, _options = {}) {
-    ui.notifications.warn("Container view for pf2e is not yet wired (Phase 7).");
-    return null;
+  async renderContainerView(actor, options = {}) {
+    // InteractiveItemSheet.render(options) may receive a boolean force flag from
+    // callers using the AppV2 render(true) pattern — normalize to a plain object.
+    if (typeof options !== "object" || options === null) options = {};
+    const containerItem = actor.system?.containerItem;
+    if (!containerItem) return null;
+    dbg("pf2e-sheets:renderContainerView", { actorName: actor?.name, containerItemId: containerItem?.id });
+    return containerItem.sheet.render({ force: true, ...options });
   },
 
   /**
    * Open the pf2e per-type item sheet for an item-mode interactive actor.
-   * Item-mode actors carry exactly one embedded item; `item.sheet` resolves to
+   *
+   * Item-mode actors carry exactly one embedded item. `item.sheet` resolves to
    * the sheet class registered by pf2e for that item type (e.g. WeaponSheetPF2e
    * for "weapon", EquipmentSheetPF2e for "equipment", ContainerSheetPF2e for
    * "backpack", etc.).
@@ -39,8 +48,10 @@ export const Pf2eSheets = {
    * @returns {Promise<Application|null>}
    */
   async renderItemView(actor, options = {}) {
+    if (typeof options !== "object" || options === null) options = {};
     const item = actor.items.contents[0];
     if (!item) return null;
+    dbg("pf2e-sheets:renderItemView", { actorName: actor?.name, itemType: item.type });
     return item.sheet.render({ force: true, ...options });
   },
 

--- a/scripts/adapter/pf2e/sheets.mjs
+++ b/scripts/adapter/pf2e/sheets.mjs
@@ -1,0 +1,60 @@
+/**
+ * pf2e sheet-delegation methods for the SystemAdapter contract.
+ *
+ * pf2e ships per-type item sheets (WeaponSheetPF2e, EquipmentSheetPF2e, etc.)
+ * but has no window-style ContainerSheet equivalent — containers render inline
+ * on actor sheets. A dedicated ContainerView application for pf2e is planned
+ * for Phase 7; until then `renderContainerView` returns a placeholder warning.
+ *
+ * These methods are mixed into `Pf2eAdapter` in `pf2e/index.mjs`.
+ */
+export const Pf2eSheets = {
+
+  /**
+   * Render the container view for an interactive container actor.
+   *
+   * Phase 7 builds the dedicated pf2e ContainerView application. Until then
+   * this method warns and returns null so that Phase 1–5 dnd5e regression
+   * testing remains clean and the empty code path is explicit rather than
+   * silently broken.
+   *
+   * @param {Actor} _actor
+   * @param {object} [_options]
+   * @returns {Promise<null>}
+   */
+  async renderContainerView(_actor, _options = {}) {
+    ui.notifications.warn("Container view for pf2e is not yet wired (Phase 7).");
+    return null;
+  },
+
+  /**
+   * Open the pf2e per-type item sheet for an item-mode interactive actor.
+   * Item-mode actors carry exactly one embedded item; `item.sheet` resolves to
+   * the sheet class registered by pf2e for that item type (e.g. WeaponSheetPF2e
+   * for "weapon", EquipmentSheetPF2e for "equipment", ContainerSheetPF2e for
+   * "backpack", etc.).
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderItemView(actor, options = {}) {
+    const item = actor.items.contents[0];
+    if (!item) return null;
+    return item.sheet.render({ force: true, ...options });
+  },
+
+  /**
+   * Convenience wrapper used by limited-dialog promotion: opens the container
+   * view or item sheet depending on whether the actor is in container mode.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderEmbeddedSheet(actor, options = {}) {
+    return actor.system.isContainer
+      ? this.renderContainerView(actor, options)
+      : this.renderItemView(actor, options);
+  }
+};

--- a/scripts/adapter/pf2e/sheets.mjs
+++ b/scripts/adapter/pf2e/sheets.mjs
@@ -79,6 +79,10 @@ export const Pf2eSheets = {
    * @returns {Promise<Application|null>}
    */
   async renderConfigSheet(actor, options = {}) {
+    // V1 sheet.render signature is (force, options) where options is an object
+    // Foundry mutates (e.g. options.editable). Coerce defensively in case the
+    // caller forwarded a boolean from the legacy AppV1 force flag.
+    if (typeof options !== "object" || options === null) options = {};
     const { default: Pf2eInteractiveItemConfigSheet } = await import("./configSheet.mjs");
     const sheet = Pf2eInteractiveItemConfigSheet.forActor(actor);
     sheet.render(true, options);

--- a/scripts/adapter/pf2e/sheets.mjs
+++ b/scripts/adapter/pf2e/sheets.mjs
@@ -67,5 +67,21 @@ export const Pf2eSheets = {
     return actor.system.isContainer
       ? this.renderContainerView(actor, options)
       : this.renderItemView(actor, options);
+  },
+
+  /**
+   * Open the pf2e GM config sheet (ApplicationV1). pf2e's own actor and item
+   * sheets are V1; the config dialog follows the same convention. The sheet
+   * class is imported lazily so the adapter file remains cheap to evaluate.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application|null>}
+   */
+  async renderConfigSheet(actor, options = {}) {
+    const { default: Pf2eInteractiveItemConfigSheet } = await import("./configSheet.mjs");
+    const sheet = Pf2eInteractiveItemConfigSheet.forActor(actor);
+    sheet.render(true, options);
+    return sheet;
   }
 };

--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -7,6 +7,7 @@ import { dbg } from "../utils/debugLog.mjs";
 import { dragModifiersHeld } from "../utils/dragModifier.mjs";
 import { findCanvasDropTargets, promptDropChoice, PLACE_ON_CANVAS } from "../utils/canvasDropTargets.mjs";
 import { hasLevels, getViewedLevelId, getTokenLevelId } from "../utils/levels.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 
 const MODULE_ID = "pick-up-stix";
 
@@ -69,7 +70,9 @@ async function _handleItemDrop(data) {
   }
 
   const hasSource = !!item.flags?.["pick-up-stix"]?.sourceActorId;
-  const isContainer = item.type === "container";
+  // Delegate item-type check to the adapter so the literal "container" is not
+  // hard-coded to the dnd5e vocabulary.
+  const isContainer = getAdapter().isContainerItem(item);
   const isWorldItem = !item.actor; // From Items directory, no parent actor
 
   let ephemeral = false;
@@ -278,8 +281,9 @@ async function depositActorToTarget(droppedActor, targetToken) {
   }
 
   if (targetActor.system?.isContainer && targetActor.system.containerItem) {
-    itemData.system = itemData.system ?? {};
-    itemData.system.container = targetActor.system.containerItem.id;
+    // Delegate container-parent field write to the adapter so the field path
+    // is not hard-coded to dnd5e's `system.container`.
+    getAdapter().setItemContainerId(itemData, targetActor.system.containerItem.id);
   }
 
   if (game.user.isGM) {
@@ -315,8 +319,9 @@ async function depositCanvasTokenToTarget(tokenDoc, targetToken) {
   }
 
   if (targetActor.system?.isContainer && targetActor.system.containerItem) {
-    itemData.system = itemData.system ?? {};
-    itemData.system.container = targetActor.system.containerItem.id;
+    // Delegate container-parent field write to the adapter so the field path
+    // is not hard-coded to dnd5e's `system.container`.
+    getAdapter().setItemContainerId(itemData, targetActor.system.containerItem.id);
   }
 
   dbg("place:depositCanvasTokenToTarget", "creating item on target, deleting source token");
@@ -400,7 +405,9 @@ async function createInteractiveToken(item, x, y, { ephemeral = false, level = n
   x = snapped.x;
   y = snapped.y;
 
-  const isContainer = item.type === "container";
+  // Delegate item-type check to the adapter so the literal "container" is not
+  // hard-coded to the dnd5e vocabulary.
+  const isContainer = getAdapter().isContainerItem(item);
   const img = item.img || "icons/svg/item-bag.svg";
 
   if (isContainer) ephemeral = false; // containers always use templates
@@ -463,14 +470,15 @@ async function createInteractiveToken(item, x, y, { ephemeral = false, level = n
       dbg("place:createInteractiveToken", "new template actor created", { actorId: actor?.id, actorImg: actor?.img });
 
       if (isContainer) {
-        const newContainerItem = actor.items.find(i => i.type === "container");
+        // Delegate item-type check and container-parent field write to the adapter
+        // so neither is hard-coded to the dnd5e vocabulary.
+        const newContainerItem = actor.items.find(i => getAdapter().isContainerItem(i));
         if (newContainerItem && item.system.contents?.size > 0) {
           const toCreate = await CONFIG.Item.documentClass.createWithContents(
             Array.from(item.system.contents)
           );
           toCreate.forEach(i => {
-            i.system = i.system ?? {};
-            i.system.container = newContainerItem.id;
+            getAdapter().setItemContainerId(i, newContainerItem.id);
           });
           dbg("place:createInteractiveToken", "copying container contents", { contentCount: toCreate.length });
           if (toCreate.length > 0) {
@@ -620,13 +628,20 @@ class PlacementDialog extends foundry.applications.api.DialogV2 {
             const centerX = x;
             const centerY = y;
 
+            // Use the adapter for item type literals so the placement dialog creates
+            // items using the active system's vocabulary rather than dnd5e hard-codes.
+            // `objectType` is a picker-dialog token ("container" | "item") — not an
+            // item type — so the `objectType === "container"` comparisons stay as-is.
+            const fakeItemType = objectType === "container"
+              ? getAdapter().containerItemType
+              : getAdapter().defaultLootItemType;
             const fakeItem = {
               name,
-              type: objectType === "container" ? "container" : "loot",
+              type: fakeItemType,
               img: objectType === "container" ? "icons/svg/chest.svg" : "icons/svg/item-bag.svg",
               toObject: () => ({
                 name,
-                type: objectType === "container" ? "container" : "loot",
+                type: fakeItemType,
                 img: objectType === "container" ? "icons/svg/chest.svg" : "icons/svg/item-bag.svg"
               }),
               system: { description: { value: "" }, contents: { size: 0 } }

--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -439,15 +439,20 @@ async function createInteractiveToken(item, x, y, { ephemeral = false, level = n
 
       // Inline items on Actor.create so createActor hook sees them and skips its
       // empty-container auto-creation path.
+      // Always strip the system's container-parent pointer via the adapter:
+      // the embedded item is becoming the top-level item of a new interactive
+      // actor, so any stale pointer from its prior life would mis-classify it
+      // as a child item in `topLevelItems`.
       const initialItems = [];
       if (isContainer) {
         const containerData = item.toObject();
         delete containerData._id;
-        delete containerData.system?.container;
+        getAdapter().setItemContainerId(containerData, null);
         initialItems.push(containerData);
       } else {
         const itemData = item.toObject();
         delete itemData._id;
+        getAdapter().setItemContainerId(itemData, null);
         initialItems.push(itemData);
       }
 
@@ -510,6 +515,9 @@ async function createInteractiveToken(item, x, y, { ephemeral = false, level = n
 
     const itemData = item.toObject();
     delete itemData._id;
+    // Strip stale container-parent pointer — the embedded item becomes the
+    // top-level item of this ephemeral actor.
+    getAdapter().setItemContainerId(itemData, null);
     dbg("place:createInteractiveToken", "creating embedded item on ephemeral actor", { itemName: itemData.name, itemImg: itemData.img });
     await actor.createEmbeddedDocuments("Item", [itemData]);
   }

--- a/scripts/hud/InteractiveTokenHUD.mjs
+++ b/scripts/hud/InteractiveTokenHUD.mjs
@@ -145,7 +145,7 @@ function onRenderTokenHUD(app, html, context, options) {
         { sceneId, tokenId, itemId, targetActorId: targetActor.id },
         async () => pickupItem(sceneId, tokenId, itemId, targetActor.id)
       );
-      if (!isGM) notifyItemAction("PickedUp", itemName);
+      if (!game.user.isGM) notifyItemAction("PickedUp", itemName);
       canvas.tokens.hud.close();
     }
   );
@@ -210,23 +210,29 @@ function onRenderTokenHUD(app, html, context, options) {
 
   if (isGM) {
     const identified = system.isIdentified;
-    const identifyBtn = createHUDButton(
-      "fa-wand-sparkles",
-      game.i18n.localize(identified
-        ? "INTERACTIVE_ITEMS.HUD.Unidentify"
-        : "INTERACTIVE_ITEMS.HUD.Identify"),
-      async () => {
-        dbg("hud:identify", { actorName: actor.name, currentIdentified: identified });
-        const item = system.embeddedItem;
-        if (!item) {
-          dbg("hud:identify", "no embeddedItem, bail");
-          return;
-        }
-        dbg("hud:identify", "toggling identification via adapter", { from: identified, to: !identified, itemId: item.id });
-        // Route through the adapter so the correct system field is updated.
-        await getAdapter().setItemIdentified(item, !identified);
+    const adapter = getAdapter();
+    const identCfg = adapter.getIdentifyButtonConfig(identified);
+    const icon = identified ? identCfg.iconOn : identCfg.iconOff;
+    const iconFamily = identified ? identCfg.iconFamilyOn : identCfg.iconFamilyOff;
+    const labelKey = identified ? identCfg.labelOnKey : identCfg.labelOffKey;
+    const identifyBtn = document.createElement("div");
+    identifyBtn.classList.add("control-icon");
+    // Override to flex so the icon centers correctly regardless of FA weight
+    // (fa-regular icons have different line metrics than fa-solid).
+    identifyBtn.style.cssText = "display:flex;align-items:center;justify-content:center;";
+    identifyBtn.title = game.i18n.localize(labelKey);
+    identifyBtn.innerHTML = `<i class="${iconFamily} ${icon}"></i>`;
+    identifyBtn.addEventListener("click", async () => {
+      dbg("hud:identify", { actorName: actor.name, currentIdentified: identified });
+      const item = system.embeddedItem;
+      if (!item) {
+        dbg("hud:identify", "no embeddedItem, bail");
+        return;
       }
-    );
+      dbg("hud:identify", "toggling identification via adapter", { from: identified, to: !identified, itemId: item.id });
+      // Route through the adapter — pf2e opens a DC dialog for unidentified items.
+      await adapter.performIdentifyToggle(item);
+    });
     if (identified) identifyBtn.classList.add("ii-hud-active");
     col.appendChild(identifyBtn);
   }

--- a/scripts/hud/InteractiveTokenHUD.mjs
+++ b/scripts/hud/InteractiveTokenHUD.mjs
@@ -1,4 +1,5 @@
 import { pickupItem, checkProximity, setContainerOpen, toggleContainerLocked } from "../transfer/ItemTransfer.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 import { isInteractiveActor } from "../utils/actorHelpers.mjs";
 import { dispatchGM } from "../utils/gmDispatch.mjs";
 import { notifyItemAction } from "../utils/notify.mjs";
@@ -217,12 +218,13 @@ function onRenderTokenHUD(app, html, context, options) {
       async () => {
         dbg("hud:identify", { actorName: actor.name, currentIdentified: identified });
         const item = system.embeddedItem;
-        if (!item || item.system?.identified === undefined) {
-          dbg("hud:identify", "no embeddedItem or identified field, bail");
+        if (!item) {
+          dbg("hud:identify", "no embeddedItem, bail");
           return;
         }
-        dbg("hud:identify", "toggling item.system.identified", { from: identified, to: !identified, itemId: item.id });
-        await item.update({ "system.identified": !identified });
+        dbg("hud:identify", "toggling identification via adapter", { from: identified, to: !identified, itemId: item.id });
+        // Route through the adapter so the correct system field is updated.
+        await getAdapter().setItemIdentified(item, !identified);
       }
     );
     if (identified) identifyBtn.classList.add("ii-hud-active");

--- a/scripts/models/InteractiveItemModel.mjs
+++ b/scripts/models/InteractiveItemModel.mjs
@@ -1,4 +1,5 @@
 import InteractiveModelMixin from "./InteractiveModelMixin.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 import { dbg } from "../utils/debugLog.mjs";
 
 const { TypeDataModel } = foundry.abstract;
@@ -67,10 +68,9 @@ export default class InteractiveItemModel extends InteractiveModelMixin(TypeData
 
   get isIdentified() {
     const item = this.embeddedItem;
-    if (item?.system?.identified !== undefined) {
-      return item.system.identified !== false;
-    }
-    return false;
+    // Delegate to the active system adapter so the identification field path
+    // is not hard-coded to dnd5e's `system.identified` boolean.
+    return item ? getAdapter().isItemIdentified(item) : false;
   }
 
   get lockedDisplayMessage() {

--- a/scripts/models/InteractiveItemModel.mjs
+++ b/scripts/models/InteractiveItemModel.mjs
@@ -55,11 +55,15 @@ export default class InteractiveItemModel extends InteractiveModelMixin(TypeData
   }
 
   get isContainer() {
-    return this.parent.items.some(i => i.type === "container");
+    // Delegate item-type check to the adapter so the literal "container" is not
+    // hard-coded to the dnd5e vocabulary.
+    return this.parent.items.some(i => getAdapter().isContainerItem(i));
   }
 
   get containerItem() {
-    return this.parent.items.find(i => i.type === "container") ?? null;
+    // Delegate item-type check to the adapter so the literal "container" is not
+    // hard-coded to the dnd5e vocabulary.
+    return this.parent.items.find(i => getAdapter().isContainerItem(i)) ?? null;
   }
 
   get embeddedItem() {

--- a/scripts/models/InteractiveModelMixin.mjs
+++ b/scripts/models/InteractiveModelMixin.mjs
@@ -34,10 +34,12 @@ export default function InteractiveModelMixin(Base) {
         const baseItemIds = baseActor ? new Set(baseActor.items.keys()) : new Set();
         const allowed = snapshotIds ? new Set(snapshotIds) : new Set();
         return this.parent.items.filter(i =>
-          (allowed.has(i.id) || !baseItemIds.has(i.id)) && !i.system.container
+          (allowed.has(i.id) || !baseItemIds.has(i.id)) && !getAdapter().getItemContainerId(i)
         );
       }
-      return this.parent.items.filter(i => !i.system.container);
+      // Delegate container-parent field access to the adapter so the field path
+      // is not hard-coded to dnd5e's `system.container`.
+      return this.parent.items.filter(i => !getAdapter().getItemContainerId(i));
     }
   };
 }

--- a/scripts/models/InteractiveModelMixin.mjs
+++ b/scripts/models/InteractiveModelMixin.mjs
@@ -1,4 +1,5 @@
 import { isModuleGM } from "../utils/playerView.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 
 export default function InteractiveModelMixin(Base) {
   return class extends Base {
@@ -17,9 +18,9 @@ export default function InteractiveModelMixin(Base) {
       const identified = isIdentified ?? this.isIdentified;
       if (!identified) {
         if (this.unidentifiedName) return this.unidentifiedName;
-        // Fall back to the embedded item's dnd5e unidentified.name so the
-        // token tracks names set via dnd5e's native sheet too.
-        const itemName = this.embeddedItem?.system?.unidentified?.name;
+        // Fall back to the embedded item's system-specific unidentified name so
+        // the token tracks names set via the native item sheet too.
+        const itemName = getAdapter().getItemUnidentifiedName(this.embeddedItem);
         if (itemName) return itemName;
       }
       return this.parent.name;

--- a/scripts/models/InteractiveModelMixin.mjs
+++ b/scripts/models/InteractiveModelMixin.mjs
@@ -27,6 +27,16 @@ export default function InteractiveModelMixin(Base) {
     }
 
     get topLevelItems() {
+      // An item is "top-level" when its container-parent pointer is null OR
+      // points to a sibling that doesn't exist in this actor. The latter
+      // catches stale pointers preserved from a prior inventory life — without
+      // this, an item dragged out of a container and re-wrapped as an
+      // interactive actor would be filtered out as a phantom child.
+      const localIds = new Set(this.parent.items.map(i => i.id));
+      const isTopLevel = (i) => {
+        const cid = getAdapter().getItemContainerId(i);
+        return !cid || !localIds.has(cid);
+      };
       const tokenDoc = this.parent.token;
       if (tokenDoc) {
         const snapshotIds = tokenDoc.flags?.["pick-up-stix"]?.snapshotItemIds;
@@ -34,12 +44,10 @@ export default function InteractiveModelMixin(Base) {
         const baseItemIds = baseActor ? new Set(baseActor.items.keys()) : new Set();
         const allowed = snapshotIds ? new Set(snapshotIds) : new Set();
         return this.parent.items.filter(i =>
-          (allowed.has(i.id) || !baseItemIds.has(i.id)) && !getAdapter().getItemContainerId(i)
+          (allowed.has(i.id) || !baseItemIds.has(i.id)) && isTopLevel(i)
         );
       }
-      // Delegate container-parent field access to the adapter so the field path
-      // is not hard-coded to dnd5e's `system.container`.
-      return this.parent.items.filter(i => !getAdapter().getItemContainerId(i));
+      return this.parent.items.filter(isTopLevel);
     }
   };
 }

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -57,7 +57,8 @@ Hooks.once("init", async () => {
   });
 
   foundry.applications.handlebars.loadTemplates({
-    "pick-up-stix.config-fields": "modules/pick-up-stix/templates/partials/config-fields.hbs"
+    "pick-up-stix.config-fields": "modules/pick-up-stix/templates/partials/config-fields.hbs",
+    "pick-up-stix.config-fields-v1": "modules/pick-up-stix/templates/partials/config-fields-v1.hbs"
   });
 
   game.settings.register(MODULE_ID, "debugLogging", {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -986,7 +986,15 @@ function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {})
   const isLocked = !!item.flags?.["pick-up-stix"]?.tokenState?.system?.isLocked;
   controls.append(_buildContentRowControl(
     isLocked ? "fa-lock" : "fa-lock-open",
-    "INTERACTIVE_ITEMS.Sheet." + (isLocked ? "StateLocked" : "StateUnlocked")
+    "INTERACTIVE_ITEMS.Sheet." + (isLocked ? "StateLocked" : "StateUnlocked"),
+    "fa-solid",
+    async () => {
+      if (!game.user.isGM) return;
+      dbg("contents:lockRow", { itemName: item.name, itemId: item.id, currentlyLocked: isLocked });
+      // Lock state lives in the same flag the dnd5e ContainerSheet row controls
+      // use, keeping the per-item lock semantics consistent across systems.
+      await item.update({ "flags.pick-up-stix.tokenState.system.isLocked": !isLocked });
+    }
   ));
 
   const isIdentified = adapter.isItemIdentified(item);
@@ -1677,6 +1685,20 @@ Hooks.on("createItem", (item) => {
 Hooks.on("deleteItem", (item) => {
   const actor = item.parent;
   if (actor) _rerenderContainerViews(actor);
+});
+
+// Re-render container views when a deposited item's lock flag flips so the
+// Contents-tab row icon and tooltip refresh. Scoped narrowly: deposited items
+// (i.e. *not* the wrapping container's embedded backpack) on interactive
+// container actors. The main updateItem hook below handles identification
+// changes for the wrapped item.
+Hooks.on("updateItem", (item, changes) => {
+  const actor = item.parent;
+  if (!isInteractiveActor(actor) || !actor.system?.isContainer) return;
+  if (item.id === actor.system.embeddedItem?.id) return;
+  if (!foundry.utils.hasProperty(changes, "flags.pick-up-stix.tokenState.system.isLocked")) return;
+  dbg("hook:updateItem:lockRowRerender", { itemName: item.name, itemId: item.id });
+  _rerenderContainerViews(actor);
 });
 
 Hooks.on("updateItem", async (item, changes, options, userId) => {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -1644,33 +1644,37 @@ Hooks.on("updateActor", async (actor, changes, options, userId) => {
 
   const unidentifiedNameChanged = "unidentifiedName" in systemChanges;
   const nameChanged = "name" in changes;
-  if (!unidentifiedNameChanged && !nameChanged) return;
+  const descriptionChanged = "description" in systemChanges;
+  const unidentifiedDescriptionChanged = "unidentifiedDescription" in systemChanges;
+  if (!unidentifiedNameChanged && !nameChanged
+      && !descriptionChanged && !unidentifiedDescriptionChanged) return;
 
   const system = actor.system;
-  const protoName = system.resolveTokenName();
-  const protoUpdates = { "prototypeToken.name": protoName };
 
-  await actor.update(protoUpdates, { noHook: true });
-
-  // Each token may have its own identification state via delta.
-  const tokens = canvas.scene?.tokens.filter(t => t.actorId === actor.id) ?? [];
-  for (const token of tokens) {
-    const tokenSystem = token.actor?.system;
-    if (!tokenSystem) continue;
-    const tokenName = tokenSystem.resolveTokenName();
-    await token.update({ name: tokenName });
+  // Token nameplate sync is needed only when the *display name* changes.
+  if (nameChanged || unidentifiedNameChanged) {
+    const protoName = system.resolveTokenName();
+    await actor.update({ "prototypeToken.name": protoName }, { noHook: true });
+    const tokens = canvas.scene?.tokens.filter(t => t.actorId === actor.id) ?? [];
+    for (const token of tokens) {
+      const tokenSystem = token.actor?.system;
+      if (!tokenSystem) continue;
+      const tokenName = tokenSystem.resolveTokenName();
+      await token.update({ name: tokenName });
+    }
   }
 
-  // Propagate the name change to the embedded item's source-level fields
-  // so the system's native sheet input stays in sync (and on pf2e, the
-  // per-state cache `system.identification.{identified|unidentified}.name`
-  // is updated — otherwise prepareDerivedData resurrects the stale original
-  // name on the next identify cycle). Adapter returns {} when no sync needed.
+  // Propagate name and description changes to the embedded item's
+  // source-level fields so the system's native sheet inputs stay in sync.
+  // On pf2e this also writes the per-state caches
+  // (`system.identification.{identified|unidentified}.{name,data.description.value}`),
+  // otherwise prepareDerivedData resurrects the stale original values on
+  // the next identify cycle. Adapter returns {} when no sync needed.
   const item = system.embeddedItem;
   if (item) {
     const sourceUpdate = getAdapter().buildEmbeddedItemSourceUpdate(actor, system.isIdentified);
     if (Object.keys(sourceUpdate).length > 0) {
-      dbg("hook:updateActor", "propagating actor name change to embedded item", { sourceUpdate });
+      dbg("hook:updateActor", "propagating actor name/description change to embedded item", { sourceUpdate });
       await item.update(sourceUpdate, { pickUpStix: { internalSourceSync: true } });
     }
   }
@@ -1770,31 +1774,31 @@ Hooks.on("updateItem", (item, changes) => {
   _rerenderContainerViews(actor);
 });
 
-// Route name edits made on the embedded item's native sheet back to the
-// wrapping actor's identified/unidentified fields. The adapter decides which
-// field receives the new value (pf2e: actor.name when identified,
-// actor.system.unidentifiedName when unidentified; dnd5e: no-op since its
-// sheet routes name edits internally by identification state).
+// Route edits made on the embedded item's native sheet back to the wrapping
+// actor's identified/unidentified fields. Covers both the main sheet name
+// input and (on pf2e) the Mystification tab's name and description inputs.
+// The adapter decides which actor fields to set; dnd5e returns {} since its
+// sheet routes edits through the system's own identification field paths.
 //
 // Skipped when the update originated from our own source-sync write
 // (`buildEmbeddedItemSourceUpdate`) — that flag prevents the round-trip
-// loop where mystifying writes a generated name to _source.name and then
-// this hook would persist that auto-generated label as unidentifiedName.
+// where mystifying writes a generated name to _source.name and this hook
+// would otherwise persist that auto-generated label as unidentifiedName.
 Hooks.on("updateItem", async (item, changes, options, userId) => {
   if (!game.user.isGM) return;
   if (options?.pickUpStix?.internalSourceSync) return;
-  if (!("name" in changes)) return;
 
   const actor = item.actor;
   if (!isInteractiveActor(actor)) return;
   if (item.id !== actor.system.embeddedItem?.id) return;
 
-  const actorUpdate = getAdapter().parseEmbeddedItemNameChange(item, changes, actor);
+  const actorUpdate = getAdapter().parseEmbeddedItemChanges(item, changes, actor);
   if (Object.keys(actorUpdate).length === 0) return;
 
-  dbg("hook:updateItem:nameToActor", {
-    itemName: item.name, newName: changes.name,
-    isIdentified: actor.system.isIdentified, actorUpdate
+  dbg("hook:updateItem:itemToActor", {
+    itemName: item.name,
+    isIdentified: actor.system.isIdentified,
+    actorUpdate
   });
   await actor.update(actorUpdate);
 });

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -736,6 +736,20 @@ function _hideContainerSheetContents({ actor, app, html }) {
 }
 
 /**
+ * Per-app tracking for whether the user is currently viewing the injected
+ * Contents tab. Needed because Foundry V1's `_activateCoreListeners` calls
+ * `Tabs.bind()` *before* our render-hook decorator runs, so `Tabs.activate`
+ * can't see our injected nav link and falls back to the first tab —
+ * silently corrupting `Tabs.active` to `"description"`. We restore the
+ * user's intent post-injection by checking this map.
+ *
+ * Keyed by the app instance (WeakMap so entries clear when sheets close).
+ *
+ * @type {WeakMap<Application, boolean>}
+ */
+const _activeContentsTabByApp = new WeakMap();
+
+/**
  * Inject a "Contents" tab into the system's container item-sheet between the
  * native Description and Details tabs, then render deposited inventory rows
  * inside it. Targets pf2e's tab markup (`<nav class="sheet-tabs">
@@ -743,10 +757,8 @@ function _hideContainerSheetContents({ actor, app, html }) {
  * dnd5e (which has no matching selector) so the native dnd5e contents grid is
  * untouched.
  *
- * The nav link and section element are created once and reused on re-render
- * so Foundry's Tabs controller doesn't lose its `.active` state. The row
- * list inside the section is rebuilt every render so items added/removed via
- * createItem/deleteItem hooks reflect immediately.
+ * Re-activates the Contents tab after injection when the user was previously
+ * viewing it — see `_activeContentsTabByApp` for the rationale.
  *
  * @param {object} ctx
  * @param {Actor} ctx.actor - The interactive container actor owning the container item.
@@ -792,6 +804,36 @@ function _injectContainerContentsTab({ actor, app, html }) {
   }
 
   _renderContainerContents(section, actor, app.item);
+
+  // Track which tab the user is on. The nav was rebuilt by V1's _replaceHTML,
+  // so we (re)attach a delegated click handler each render. The previous nav
+  // (and its handler) was discarded with the old DOM, so no leak.
+  tabsNav.addEventListener("click", (event) => {
+    const tab = event.target.closest("a[data-tab]");
+    if (!tab) return;
+    if (tab.dataset.tab === "ii-contents") {
+      _activeContentsTabByApp.set(app, true);
+    } else {
+      _activeContentsTabByApp.delete(app);
+    }
+  });
+
+  // Restore Contents activation when the user was viewing it before re-render.
+  // pf2e's Tabs.bind() ran before us with our nav link absent, so it activated
+  // "description" as a fallback. Now that our nav link exists, switch back.
+  if (_activeContentsTabByApp.get(app)) {
+    const primaryTabs = app._tabs?.[0];
+    if (primaryTabs) {
+      primaryTabs.activate("ii-contents");
+    } else {
+      tabsNav.querySelectorAll('a[data-tab]').forEach(a =>
+        a.classList.toggle("active", a.dataset.tab === "ii-contents")
+      );
+      sheetBody.querySelectorAll('section.tab[data-tab]').forEach(s =>
+        s.classList.toggle("active", s.dataset.tab === "ii-contents")
+      );
+    }
+  }
 }
 
 /**
@@ -816,6 +858,10 @@ function _renderContainerContents(section, actor, containerItem) {
     return adapter.getItemContainerId(i) === containerItem.id;
   });
 
+  // Column headers above the list. Image and controls columns get blank
+  // spacers so the header text aligns with the data rows below.
+  section.append(_buildContainerContentsHeader());
+
   const list = document.createElement("ol");
   list.className = "ii-contents-list";
 
@@ -832,6 +878,43 @@ function _renderContainerContents(section, actor, containerItem) {
     list.append(_buildContainerContentRow(item, adapter));
   }
   section.append(list);
+}
+
+/**
+ * Build the column-header row that sits above the contents list. Reuses the
+ * row's flex layout so columns line up — empty spacers fill the image and
+ * controls columns.
+ *
+ * @returns {HTMLDivElement}
+ */
+function _buildContainerContentsHeader() {
+  const header = document.createElement("div");
+  header.className = "ii-contents-row ii-contents-header";
+
+  const imgSpacer = document.createElement("span");
+  imgSpacer.className = "ii-contents-img-spacer";
+  header.append(imgSpacer);
+
+  const name = document.createElement("span");
+  name.className = "ii-contents-name";
+  name.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Name");
+  header.append(name);
+
+  const qty = document.createElement("span");
+  qty.className = "ii-contents-quantity";
+  qty.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Quantity");
+  header.append(qty);
+
+  const bulk = document.createElement("span");
+  bulk.className = "ii-contents-bulk";
+  bulk.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Bulk");
+  header.append(bulk);
+
+  const controlsSpacer = document.createElement("span");
+  controlsSpacer.className = "ii-contents-controls-spacer";
+  header.append(controlsSpacer);
+
+  return header;
 }
 
 /**

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -376,15 +376,27 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   root.querySelector?.(".mode-slider")?.remove();
 
   // Remove any existing module toggles so the rebuild produces a stable order.
+  // The native identify button (if any) is intentionally NOT in this list —
+  // we relocate it into the canonical slot below rather than recreating it.
   header.querySelectorAll(".ii-open-toggle-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-configure-btn")
     .forEach(el => el.remove());
 
   const adapter = getAdapter();
   const sys = configActor.system;
-  const buttons = [];
+
+  // If the system already provides a header-level identify control (e.g.
+  // dnd5e's `.toggle-identified` button) reuse it in our canonical slot
+  // instead of injecting a duplicate. Moving the live element preserves
+  // its event listeners.
+  const nativeIdentifySelector = adapter.nativeIdentifyHeaderSelector;
+  const nativeIdentifyBtn = nativeIdentifySelector
+    ? header.querySelector(nativeIdentifySelector)
+    : null;
+
+  const orderedNodes = [];
 
   if (sys.isContainer) {
-    buttons.push(createAdapterHeaderButton({
+    orderedNodes.push(createAdapterHeaderButton({
       adapter,
       extraClass: "ii-open-toggle-btn",
       active: sys.isOpen,
@@ -399,7 +411,7 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
     }));
   }
 
-  buttons.push(createAdapterHeaderButton({
+  orderedNodes.push(createAdapterHeaderButton({
     adapter,
     extraClass: "ii-lock-toggle-btn",
     active: sys.isLocked,
@@ -413,28 +425,33 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
     }
   }));
 
-  const identCfg = adapter.getIdentifyButtonConfig(sys.isIdentified);
-  buttons.push(createAdapterHeaderButton({
-    adapter,
-    extraClass: "ii-identify-toggle-btn",
-    active: sys.isIdentified,
-    iconOn: identCfg.iconOn,
-    iconFamilyOn: identCfg.iconFamilyOn,
-    iconOff: identCfg.iconOff,
-    iconFamilyOff: identCfg.iconFamilyOff,
-    labelOnKey: identCfg.labelOnKey,
-    labelOffKey: identCfg.labelOffKey,
-    onClick: async (ev) => {
-      ev.preventDefault();
-      const embeddedItem = configActor.system.embeddedItem;
-      if (!embeddedItem) return;
-      // Route through the adapter — pf2e opens a DC dialog for unidentified
-      // items rather than flipping the flag directly.
-      await adapter.performIdentifyToggle(embeddedItem);
-    }
-  }));
+  if (nativeIdentifyBtn) {
+    // Relocate the system's button into our canonical position.
+    orderedNodes.push(nativeIdentifyBtn);
+  } else {
+    const identCfg = adapter.getIdentifyButtonConfig(sys.isIdentified);
+    orderedNodes.push(createAdapterHeaderButton({
+      adapter,
+      extraClass: "ii-identify-toggle-btn",
+      active: sys.isIdentified,
+      iconOn: identCfg.iconOn,
+      iconFamilyOn: identCfg.iconFamilyOn,
+      iconOff: identCfg.iconOff,
+      iconFamilyOff: identCfg.iconFamilyOff,
+      labelOnKey: identCfg.labelOnKey,
+      labelOffKey: identCfg.labelOffKey,
+      onClick: async (ev) => {
+        ev.preventDefault();
+        const embeddedItem = configActor.system.embeddedItem;
+        if (!embeddedItem) return;
+        // Route through the adapter — pf2e opens a DC dialog for unidentified
+        // items rather than flipping the flag directly.
+        await adapter.performIdentifyToggle(embeddedItem);
+      }
+    }));
+  }
 
-  buttons.push(createAdapterHeaderButton({
+  orderedNodes.push(createAdapterHeaderButton({
     adapter,
     kind: "config",
     extraClass: "ii-configure-btn",
@@ -450,9 +467,11 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   // Insert immediately after the title so buttons sit left of system-injected
   // header controls (Sheet/Prototype Token/Close on pf2e; ellipsis/Close on
   // dnd5e V2). The header's flex layout pushes system buttons to the far right.
+  // For the native identify button, `.after(...)` moves it from its previous
+  // slot into the canonical position rather than cloning it.
   const title = header.querySelector(".window-title");
-  if (title) title.after(...buttons);
-  else header.prepend(...buttons);
+  if (title) title.after(...orderedNodes);
+  else header.prepend(...orderedNodes);
 }
 
 /**

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -323,7 +323,7 @@ function _injectItemSheetHeaderControls({ app, html }) {
   const header = html.querySelector(".window-header");
   if (!header) return;
   html.querySelector(".mode-slider")?.remove();
-  const closeBtn = header.querySelector("button.close, [data-action='close']");
+  const closeBtn = header.querySelector("button.close, a.close, [data-action='close']");
 
   header.querySelector(".ii-identify-toggle-btn")?.remove();
   const _adapter = getAdapter();
@@ -396,7 +396,7 @@ function _injectContainerSheetHeaderControls({ actor, app, html }) {
   const header = html.querySelector(".window-header");
   if (!header) return;
   html.querySelector(".mode-slider")?.remove();
-  const closeBtn = header.querySelector("button.close, [data-action='close']");
+  const closeBtn = header.querySelector("button.close, a.close, [data-action='close']");
 
   // Remove existing to refresh state on re-render.
   header.querySelector(".ii-open-toggle-btn")?.remove();

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -380,7 +380,7 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   // Remove any existing module toggles so the rebuild produces a stable order.
   // The native identify button (if any) is intentionally NOT in this list —
   // we relocate it into the canonical slot below rather than recreating it.
-  header.querySelectorAll(".ii-open-toggle-btn, .ii-pickup-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-configure-btn")
+  header.querySelectorAll(".ii-open-toggle-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-configure-btn")
     .forEach(el => el.remove());
 
   const adapter = getAdapter();
@@ -412,42 +412,6 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
       }
     }));
 
-    // Pickup glyph — token-only (synthetic actor). The base actor sheet in the
-    // sidebar wraps the *template* and isn't a thing you can "pick up", so the
-    // icon is suppressed there. No behaviour wired yet — visual placeholder.
-    //
-    // Detect the token case via several fallbacks: pf2e's synthetic actor
-    // resolution can yield references whose getter side-effects (`isToken`)
-    // haven't fired yet by the time the render hook runs, so we also check
-    // `actor.token`, `actor.parent` document type, and `app.token` directly.
-    const isTokenActor = !!(
-      configActor.isToken
-      ?? configActor.token
-      ?? (configActor.parent && configActor.parent.documentName === "Token")
-      ?? app?.token
-    );
-    dbg("inject:headerControls", {
-      actorName: configActor.name,
-      actorType: configActor.type,
-      isContainer: sys.isContainer,
-      isTokenViaIsToken: configActor.isToken,
-      isTokenViaToken: !!configActor.token,
-      parentDoc: configActor.parent?.documentName,
-      appHasToken: !!app?.token,
-      resolvedIsTokenActor: isTokenActor
-    });
-    if (isTokenActor) {
-      orderedNodes.push(createAdapterHeaderButton({
-        adapter,
-        extraClass: "ii-pickup-btn",
-        iconOn: "fa-hand",
-        labelOnKey: "INTERACTIVE_ITEMS.HUD.PickUp",
-        // Empty onClick still attaches our listener so the V1 anchor calls
-        // stopImmediatePropagation — without it, clicks would fall through to
-        // Foundry's `.header-button` delegated handler and crash.
-        onClick: () => {}
-      }));
-    }
   }
 
   orderedNodes.push(createAdapterHeaderButton({
@@ -511,16 +475,6 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   const title = header.querySelector(".window-title");
   if (title) title.after(...orderedNodes);
   else header.prepend(...orderedNodes);
-
-  // Post-insert diagnostic — confirms what actually landed in the DOM rather
-  // than just whether the code path ran.
-  const pickup = header.querySelector(".ii-pickup-btn");
-  dbg("inject:headerControls:after", {
-    pickupInDom: !!pickup,
-    pickupOuter: pickup?.outerHTML?.slice(0, 200),
-    pickupRect: pickup ? pickup.getBoundingClientRect() : null,
-    headerChildren: Array.from(header.children).map(c => `${c.tagName}.${(c.className || "").trim().split(/\s+/).join(".")}`).join(" | ")
-  });
 }
 
 /**
@@ -905,9 +859,16 @@ function _renderContainerContents(section, actor, containerItem) {
     return adapter.getItemContainerId(i) === containerItem.id;
   });
 
+  // Pickup is only meaningful on placed-token sheets — the hand glyph is
+  // rendered on rows when the wrapping actor is synthetic. The base-actor
+  // sheet in the sidebar holds the *template* of a container, so picking up
+  // a row from there has no game-world meaning. The header's controls-spacer
+  // width also depends on this so the columns line up with the data rows.
+  const isTokenActor = !!(actor.isToken ?? actor.token ?? (actor.parent?.documentName === "Token"));
+
   // Column headers above the list. Image and controls columns get blank
   // spacers so the header text aligns with the data rows below.
-  section.append(_buildContainerContentsHeader());
+  section.append(_buildContainerContentsHeader({ isTokenActor }));
 
   const list = document.createElement("ol");
   list.className = "ii-contents-list";
@@ -922,7 +883,7 @@ function _renderContainerContents(section, actor, containerItem) {
   }
 
   for (const item of containedItems) {
-    list.append(_buildContainerContentRow(item, adapter));
+    list.append(_buildContainerContentRow(item, adapter, { isTokenActor }));
   }
   section.append(list);
 }
@@ -930,11 +891,15 @@ function _renderContainerContents(section, actor, containerItem) {
 /**
  * Build the column-header row that sits above the contents list. Reuses the
  * row's flex layout so columns line up — empty spacers fill the image and
- * controls columns.
+ * controls columns. The controls spacer's width is selected via the modifier
+ * class `.is-token` (4 icons) vs default (3 icons) so the data columns
+ * remain aligned across token-sheet vs actor-sheet renders.
  *
+ * @param {object} [options]
+ * @param {boolean} [options.isTokenActor=false]
  * @returns {HTMLDivElement}
  */
-function _buildContainerContentsHeader() {
+function _buildContainerContentsHeader({ isTokenActor = false } = {}) {
   const header = document.createElement("div");
   header.className = "ii-contents-row ii-contents-header";
 
@@ -958,7 +923,7 @@ function _buildContainerContentsHeader() {
   header.append(bulk);
 
   const controlsSpacer = document.createElement("span");
-  controlsSpacer.className = "ii-contents-controls-spacer";
+  controlsSpacer.className = `ii-contents-controls-spacer${isTokenActor ? " is-token" : ""}`;
   header.append(controlsSpacer);
 
   return header;
@@ -973,7 +938,7 @@ function _buildContainerContentsHeader() {
  * @param {SystemAdapter} adapter
  * @returns {HTMLLIElement}
  */
-function _buildContainerContentRow(item, adapter) {
+function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {}) {
   const row = document.createElement("li");
   row.className = "ii-contents-row";
   row.dataset.itemId = item.id;
@@ -1006,8 +971,18 @@ function _buildContainerContentRow(item, adapter) {
   const controls = document.createElement("span");
   controls.className = "ii-contents-controls";
 
-  // Lock / identify / config / delete — visual only for now. Lock and identify
-  // reflect the live state on the item; config/delete are static glyphs.
+  // Pickup glyph — token-only. Sits left of the lock icon. Visual placeholder
+  // for now (no behaviour wired) — clicks should eventually offer to take the
+  // row's item out of the container into a player's inventory.
+  if (isTokenActor) {
+    controls.append(_buildContentRowControl(
+      "fa-hand",
+      "INTERACTIVE_ITEMS.HUD.PickUp"
+    ));
+  }
+
+  // Lock / identify / delete — Lock and identify reflect the live state on
+  // the item; delete is wired below.
   const isLocked = !!item.flags?.["pick-up-stix"]?.tokenState?.system?.isLocked;
   controls.append(_buildContentRowControl(
     isLocked ? "fa-lock" : "fa-lock-open",

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -1660,6 +1660,20 @@ Hooks.on("updateActor", async (actor, changes, options, userId) => {
     const tokenName = tokenSystem.resolveTokenName();
     await token.update({ name: tokenName });
   }
+
+  // Propagate the name change to the embedded item's source-level fields
+  // so the system's native sheet input stays in sync (and on pf2e, the
+  // per-state cache `system.identification.{identified|unidentified}.name`
+  // is updated — otherwise prepareDerivedData resurrects the stale original
+  // name on the next identify cycle). Adapter returns {} when no sync needed.
+  const item = system.embeddedItem;
+  if (item) {
+    const sourceUpdate = getAdapter().buildEmbeddedItemSourceUpdate(actor, system.isIdentified);
+    if (Object.keys(sourceUpdate).length > 0) {
+      dbg("hook:updateActor", "propagating actor name change to embedded item", { sourceUpdate });
+      await item.update(sourceUpdate, { pickUpStix: { internalSourceSync: true } });
+    }
+  }
 });
 
 Hooks.on("updateActor", (actor, changes) => {
@@ -1756,6 +1770,35 @@ Hooks.on("updateItem", (item, changes) => {
   _rerenderContainerViews(actor);
 });
 
+// Route name edits made on the embedded item's native sheet back to the
+// wrapping actor's identified/unidentified fields. The adapter decides which
+// field receives the new value (pf2e: actor.name when identified,
+// actor.system.unidentifiedName when unidentified; dnd5e: no-op since its
+// sheet routes name edits internally by identification state).
+//
+// Skipped when the update originated from our own source-sync write
+// (`buildEmbeddedItemSourceUpdate`) — that flag prevents the round-trip
+// loop where mystifying writes a generated name to _source.name and then
+// this hook would persist that auto-generated label as unidentifiedName.
+Hooks.on("updateItem", async (item, changes, options, userId) => {
+  if (!game.user.isGM) return;
+  if (options?.pickUpStix?.internalSourceSync) return;
+  if (!("name" in changes)) return;
+
+  const actor = item.actor;
+  if (!isInteractiveActor(actor)) return;
+  if (item.id !== actor.system.embeddedItem?.id) return;
+
+  const actorUpdate = getAdapter().parseEmbeddedItemNameChange(item, changes, actor);
+  if (Object.keys(actorUpdate).length === 0) return;
+
+  dbg("hook:updateItem:nameToActor", {
+    itemName: item.name, newName: changes.name,
+    isIdentified: actor.system.isIdentified, actorUpdate
+  });
+  await actor.update(actorUpdate);
+});
+
 Hooks.on("updateItem", async (item, changes, options, userId) => {
   dbg("hook:updateItem", {
     itemName: item.name,
@@ -1847,7 +1890,9 @@ Hooks.on("updateItem", async (item, changes, options, userId) => {
   });
   if (Object.keys(sourceUpdate).length > 0) {
     dbg("hook:updateItem", "applying embedded item source update", { sourceUpdate });
-    await item.update(sourceUpdate);
+    // Tag this update so the inverse-direction name-sync hook
+    // (`hook:updateItem:nameToActor`) can recognise our own write and skip.
+    await item.update(sourceUpdate, { pickUpStix: { internalSourceSync: true } });
   }
 
   if (!isContainer) {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -511,6 +511,16 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   const title = header.querySelector(".window-title");
   if (title) title.after(...orderedNodes);
   else header.prepend(...orderedNodes);
+
+  // Post-insert diagnostic — confirms what actually landed in the DOM rather
+  // than just whether the code path ran.
+  const pickup = header.querySelector(".ii-pickup-btn");
+  dbg("inject:headerControls:after", {
+    pickupInDom: !!pickup,
+    pickupOuter: pickup?.outerHTML?.slice(0, 200),
+    pickupRect: pickup ? pickup.getBoundingClientRect() : null,
+    headerChildren: Array.from(header.children).map(c => `${c.tagName}.${(c.className || "").trim().split(/\s+/).join(".")}`).join(" | ")
+  });
 }
 
 /**

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -998,7 +998,15 @@ function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {})
   controls.append(_buildContentRowControl(
     identIcon,
     isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey,
-    identFamily
+    identFamily,
+    async () => {
+      if (!game.user.isGM) return;
+      dbg("contents:identifyRow", { itemName: item.name, itemId: item.id, currentlyIdentified: isIdentified });
+      // Adapter routing handles pf2e's mystify-popup vs direct setIdentified
+      // distinction; the updateItem hook re-renders the container sheet so
+      // the row's icon and tooltip refresh with the new state.
+      await adapter.performIdentifyToggle(item);
+    }
   ));
 
   // Delete is the only currently-active control on contents rows. GM-only —
@@ -1691,6 +1699,19 @@ Hooks.on("updateItem", async (item, changes, options, userId) => {
   }
   if (!getAdapter().isIdentificationChange(item, changes)) {
     dbg("hook:updateItem", "not an identification change, bail");
+    return;
+  }
+
+  // The rest of this handler is dedicated to the *wrapped* item — the one
+  // whose identification mirrors the actor's `system.isIdentified`. For
+  // *deposited* items (children of a container actor whose containerId
+  // points at the wrapped backpack), just refresh open container views so
+  // the row's identify icon / tooltip update; do not touch the wrapping
+  // actor's identification state.
+  const embeddedItemId = actor.system.embeddedItem?.id;
+  if (embeddedItemId && item.id !== embeddedItemId) {
+    dbg("hook:updateItem", "deposited-item identify change, just re-render container views");
+    _rerenderContainerViews(actor);
     return;
   }
 

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -25,14 +25,18 @@ const CHEST_CLOSED = `modules/${MODULE_ID}/icons/treasure-chest-closed.png`;
 const CHEST_OPEN = `modules/${MODULE_ID}/icons/treasure-chest-open.png`;
 
 Hooks.once("init", async () => {
+  // Register the base data model first so it is in place before loadAdapter()
+  // runs. The active system's adapter may overwrite this entry with a more
+  // specific subclass (e.g. Pf2eInteractiveItemModel for pf2e) during its
+  // constructor, which runs synchronously inside loadAdapter().
+  Object.assign(CONFIG.Actor.dataModels, {
+    "pick-up-stix.interactiveItem": InteractiveItemModel
+  });
+
   // game.system is available from this point on; dynamically import only the
   // active system's adapter so pf2e users never fetch dnd5e code and vice versa.
   await loadAdapter();
   console.log(`${MODULE_ID} | Initializing Pick-Up-Stix module`);
-
-  Object.assign(CONFIG.Actor.dataModels, {
-    "pick-up-stix.interactiveItem": InteractiveItemModel
-  });
 
   const originalGetDefaultArtwork = CONFIG.Actor.documentClass.getDefaultArtwork;
   CONFIG.Actor.documentClass.getDefaultArtwork = function(actorData) {
@@ -258,6 +262,10 @@ function _injectItemContextMenuEntries(item, menuItems) {
  */
 function _injectActorInventoryIdentifyToggles(app, html) {
   if (!game.user.isGM) return;
+  // pf2e (and other systems with hasNativeInventoryIdentify) already render
+  // toggle-identified controls on every inventory row — skip ours to avoid
+  // duplicating the control.
+  if (getAdapter().capabilities.hasNativeInventoryIdentify) return;
   if (isInteractiveActor(app.actor)) return;
   const root = html instanceof HTMLElement ? html : html?.[0];
   if (!root) return;
@@ -315,6 +323,29 @@ function _injectItemSheetHeaderControls({ app, html }) {
   if (!header) return;
   html.querySelector(".mode-slider")?.remove();
   const closeBtn = header.querySelector("button.close, [data-action='close']");
+
+  header.querySelector(".ii-identify-toggle-btn")?.remove();
+  const _adapter = getAdapter();
+  const identCfg = _adapter.getIdentifyButtonConfig(configActor.system.isIdentified);
+  const identifyToggle = createStateToggleButton({
+    extraClass: "ii-identify-toggle-btn",
+    active: configActor.system.isIdentified,
+    iconOn: identCfg.iconOn,
+    iconFamilyOn: identCfg.iconFamilyOn,
+    iconOff: identCfg.iconOff,
+    iconFamilyOff: identCfg.iconFamilyOff,
+    labelOnKey: identCfg.labelOnKey,
+    labelOffKey: identCfg.labelOffKey,
+    onClick: async (ev) => {
+      ev.preventDefault();
+      const embeddedItem = configActor.system.embeddedItem;
+      if (!embeddedItem) return;
+      // Route through the adapter — pf2e opens a DC dialog for unidentified
+      // items rather than flipping the flag directly.
+      await _adapter.performIdentifyToggle(embeddedItem);
+    }
+  });
+  insertHeaderButton(header, identifyToggle, closeBtn);
 
   header.querySelector(".ii-lock-toggle-btn")?.remove();
   const lockToggle = createStateToggleButton({
@@ -459,7 +490,7 @@ function _injectContainerSheetRowControls({ actor, app, html }) {
             { sceneId, tokenId, itemId, targetActorId: targetActor.id },
             async () => pickupItem(sceneId, tokenId, itemId, targetActor.id)
           );
-          if (isPlayerView() && item) notifyItemAction("PickedUp", item.name);
+          if (!game.user.isGM && item) notifyItemAction("PickedUp", item.name);
         }
       });
       target.appendChild(pickupBtn);
@@ -1148,8 +1179,7 @@ Hooks.on("updateItem", async (item, changes, options, userId) => {
     itemId: item.id,
     itemImg: item.img,
     actorName: item.actor?.name,
-    identifiedInChanges: "identified" in (changes.system ?? {}),
-    changedIdentifiedValue: changes.system?.identified,
+    isIdentificationChange: getAdapter().isIdentificationChange(item, changes),
     systemChangeKeys: Object.keys(changes.system ?? {})
   });
   if (!game.user.isGM) {
@@ -1161,8 +1191,8 @@ Hooks.on("updateItem", async (item, changes, options, userId) => {
     dbg("hook:updateItem", "actor is not interactive, bail", { actorName: actor?.name });
     return;
   }
-  if (!("identified" in (changes.system ?? {}))) {
-    dbg("hook:updateItem", "identified not in changes, bail");
+  if (!getAdapter().isIdentificationChange(item, changes)) {
+    dbg("hook:updateItem", "not an identification change, bail");
     return;
   }
 

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -1,3 +1,4 @@
+import { loadAdapter } from "./adapter/index.mjs";
 import InteractiveItemModel from "./models/InteractiveItemModel.mjs";
 import InteractiveItemSheet from "./sheets/InteractiveItemSheet.mjs";
 import { registerTokenHUD } from "./hud/InteractiveTokenHUD.mjs";
@@ -23,7 +24,10 @@ const DEFAULT_ICON = `modules/${MODULE_ID}/icons/interactive-item-icon.svg`;
 const CHEST_CLOSED = `modules/${MODULE_ID}/icons/treasure-chest-closed.png`;
 const CHEST_OPEN = `modules/${MODULE_ID}/icons/treasure-chest-open.png`;
 
-Hooks.once("init", () => {
+Hooks.once("init", async () => {
+  // game.system is available from this point on; dynamically import only the
+  // active system's adapter so pf2e users never fetch dnd5e code and vice versa.
+  await loadAdapter();
   console.log(`${MODULE_ID} | Initializing Pick-Up-Stix module`);
 
   Object.assign(CONFIG.Actor.dataModels, {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -995,7 +995,6 @@ function _buildContainerContentRow(item, adapter) {
     identFamily
   ));
 
-  controls.append(_buildContentRowControl("fa-gear", "INTERACTIVE_ITEMS.Sheet.ConfigureHUD"));
   // Delete is the only currently-active control on contents rows. GM-only —
   // players see the icon but the click no-ops for them. The deleteItem hook
   // re-renders the container sheet automatically, so the row disappears.

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -411,6 +411,22 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
         await setContainerOpen(configActor, !configActor.system.isOpen);
       }
     }));
+
+    // Pickup glyph — token-only (synthetic actor). The base actor sheet in the
+    // sidebar wraps the *template* and isn't a thing you can "pick up", so the
+    // icon is suppressed there. No behaviour wired yet — visual placeholder.
+    if (configActor.isToken) {
+      orderedNodes.push(createAdapterHeaderButton({
+        adapter,
+        extraClass: "ii-pickup-btn",
+        iconOn: "fa-hand",
+        labelOnKey: "INTERACTIVE_ITEMS.HUD.PickUp",
+        // Empty onClick still attaches our listener so the V1 anchor calls
+        // stopImmediatePropagation — without it, clicks would fall through to
+        // Foundry's `.header-button` delegated handler and crash.
+        onClick: () => {}
+      }));
+    }
   }
 
   orderedNodes.push(createAdapterHeaderButton({

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -1169,8 +1169,62 @@ Hooks.on("updateActor", (actor, changes) => {
     return;
   }
   dbg("hook:updateActor:rerender", { name: actor.name, id: actor.id, isLocked: sys.isLocked, isOpen: sys.isOpen, sheetRendered: !!actor.system.embeddedItem?.sheet?.rendered });
+
+  // Re-render the embedded item's native sheet (dnd5e ContainerSheet / pf2e item sheets).
   const item = actor.system.embeddedItem;
   if (item?.sheet?.rendered) item.sheet.render();
+
+  // Also re-render any open apps (AppV1 via ui.windows, AppV2 via foundry.applications.instances)
+  // that own this actor (actor-document match) or whose item belongs to this actor
+  // (item-sheet match, e.g. pf2e ContainerSheetPF2e) so header toggles stay in sync.
+  for (const app of Object.values(ui.windows)) {
+    if (!app.rendered) continue;
+    const matchesActor = app.document?.id === actor.id || app.item?.actor?.id === actor.id;
+    if (!matchesActor) continue;
+    if (app === item?.sheet) continue;
+    dbg("hook:updateActor:rerender", "re-rendering AppV1 app", { appId: app.appId, actorName: actor.name });
+    app.render(true);
+  }
+  for (const app of foundry.applications.instances.values()) {
+    if (!app.rendered) continue;
+    const matchesActor = app.document?.id === actor.id || app.item?.actor?.id === actor.id;
+    if (!matchesActor) continue;
+    if (app === item?.sheet) continue;
+    dbg("hook:updateActor:rerender", "re-rendering AppV2 app", { appId: app.id, actorName: actor.name });
+    app.render();
+  }
+});
+
+// Re-render any open container views (AppV1 or AppV2) whose document or item's
+// actor matches the given actor. AppV1 apps live in ui.windows; AppV2 in
+// foundry.applications.instances. Item sheets (e.g. pf2e ContainerSheetPF2e)
+// are found via app.item?.actor rather than app.document.
+function _rerenderContainerViews(actor) {
+  if (!isInteractiveActor(actor) || !actor.system?.isContainer) return;
+  for (const app of Object.values(ui.windows)) {
+    if (!app.rendered) continue;
+    const matchesActor = app.document?.id === actor.id || app.item?.actor?.id === actor.id;
+    if (!matchesActor) continue;
+    dbg("hook:createDeleteItem:rerender", { appId: app.appId, actorName: actor.name });
+    app.render(true);
+  }
+  for (const app of foundry.applications.instances.values()) {
+    if (!app.rendered) continue;
+    const matchesActor = app.document?.id === actor.id || app.item?.actor?.id === actor.id;
+    if (!matchesActor) continue;
+    dbg("hook:createDeleteItem:rerender", { appId: app.id, actorName: actor.name });
+    app.render();
+  }
+}
+
+Hooks.on("createItem", (item) => {
+  const actor = item.parent;
+  if (actor) _rerenderContainerViews(actor);
+});
+
+Hooks.on("deleteItem", (item) => {
+  const actor = item.parent;
+  if (actor) _rerenderContainerViews(actor);
 });
 
 Hooks.on("updateItem", async (item, changes, options, userId) => {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -971,13 +971,41 @@ function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {})
   const controls = document.createElement("span");
   controls.className = "ii-contents-controls";
 
-  // Pickup glyph — token-only. Sits left of the lock icon. Visual placeholder
-  // for now (no behaviour wired) — clicks should eventually offer to take the
-  // row's item out of the container into a player's inventory.
+  // Pickup glyph — token-only. Sits left of the lock icon. Mirrors the
+  // pickup flow used by the dnd5e ContainerSheet row controls: proximity →
+  // container access (open/lock) → per-item lock → resolve the recipient
+  // (controlled token / assigned character) → route through the GM via
+  // socket if the clicker is a player.
   if (isTokenActor) {
+    const containerActor = item.actor;
     controls.append(_buildContentRowControl(
       "fa-hand",
-      "INTERACTIVE_ITEMS.HUD.PickUp"
+      "INTERACTIVE_ITEMS.HUD.PickUp",
+      "fa-solid",
+      async () => {
+        // Distance is the most actionable failure for players to understand,
+        // so check it first.
+        if (!checkProximity(containerActor)) return;
+        // Container open is implied (the row only shows when the sheet is
+        // open) but the lock state still needs gating.
+        if (!validateContainerAccess(containerActor, { checkOpen: false })) return;
+        const currentItem = containerActor.items.get(item.id);
+        if (!validateItemAccess(currentItem)) return;
+
+        const targetActor = await resolvePickupTarget(containerActor);
+        if (!targetActor) return;
+        const tokenDoc = containerActor.token;
+        if (!tokenDoc) return;
+        const sceneId = tokenDoc.parent.id;
+        const tokenId = tokenDoc.id;
+        dbg("contents:pickupRow", { itemName: item.name, itemId: item.id, sceneId, tokenId, targetActorId: targetActor.id });
+        await dispatchGM(
+          "pickupItem",
+          { sceneId, tokenId, itemId: item.id, targetActorId: targetActor.id },
+          async () => pickupItem(sceneId, tokenId, item.id, targetActor.id)
+        );
+        if (!game.user.isGM) notifyItemAction("PickedUp", item.name);
+      }
     ));
   }
 

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -1832,6 +1832,24 @@ Hooks.on("updateItem", async (item, changes, options, userId) => {
     await actor.update({ "system.isIdentified": newIdentified }, { noHook: true });
   }
 
+  // Some systems (pf2e) bind sheet inputs to `item._source.name`, which
+  // setIdentificationStatus doesn't touch. Ask the adapter for any
+  // source-level updates needed so the in-sheet name field reflects the new
+  // identification state. dnd5e's adapter returns {} (no-op).
+  const sourceUpdate = getAdapter().buildEmbeddedItemSourceUpdate(actor, newIdentified);
+  dbg("hook:updateItem", "embedded item source update probe", {
+    actorName: actor.name,
+    actorUnidentifiedName: actor.system.unidentifiedName,
+    itemSourceName: item._source?.name,
+    itemLiveName: item.name,
+    newIdentified,
+    sourceUpdate
+  });
+  if (Object.keys(sourceUpdate).length > 0) {
+    dbg("hook:updateItem", "applying embedded item source update", { sourceUpdate });
+    await item.update(sourceUpdate);
+  }
+
   if (!isContainer) {
     const newImg = actor.system.resolveImage(newIdentified);
     dbg("hook:updateItem", "item image sync", {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -155,368 +155,19 @@ Hooks.once("init", async () => {
     default: false
   });
 
-  Hooks.on("dnd5e.getItemContextOptions", (item, menuItems) => {
-    if (!item.actor) return;
+  getAdapter().registerItemContextMenu(_injectItemContextMenuEntries);
 
-    if (!isInteractiveActor(item.actor)) {
-      menuItems.push({
-        name: "INTERACTIVE_ITEMS.Context.DropItem",
-        icon: '<i class="fa-solid fa-arrow-down fa-fw"></i>',
-        group: "action",
-        condition: () => !!canvas.scene,
-        callback: () => _dropItemOnCanvas(item)
-      });
-    }
+  getAdapter().registerActorInventoryHooks(_injectActorInventoryIdentifyToggles);
 
-    if (!game.user.isGM) return;
-    const iiFlags = getItemIIFlags(item);
-    if (!iiFlags?.sourceActorId) return;
-    const sourceActorId = getItemSourceActorId(item);
+  getAdapter().registerItemSheetHooks({ injectHeaderControls: _injectItemSheetHeaderControls });
 
-    const isIdentified = isItemIdentified(item);
-    menuItems.push({
-      name: isIdentified
-        ? "INTERACTIVE_ITEMS.Context.HideItem"
-        : "INTERACTIVE_ITEMS.Context.RevealItem",
-      icon: `<i class="fa-solid fa-wand-sparkles fa-fw"></i>`,
-      group: "action",
-      callback: () => toggleItemIdentification(item)
-    });
+  getAdapter().registerContainerDropGate(_gateContainerDrop);
 
-    // Override dnd5e's "Edit" to open our config sheet instead.
-    const editEntry = menuItems.find(e => e.name === "DND5E.ContextMenuActionEdit");
-    if (editEntry) {
-      editEntry.callback = () => {
-        const sourceActor = game.actors.get(sourceActorId);
-        if (sourceActor?.sheet?.renderConfig) sourceActor.sheet.renderConfig();
-      };
-    }
-  });
-
-  // dnd5e uses both `<img class="item-image">` (raster) and `<dnd5e-icon class="item-image">` (SVG);
-  // both share the class so the querySelector catches either.
-  const _injectIdentifyToggles = (app, html) => {
-    if (!game.user.isGM) return;
-    if (isInteractiveActor(app.actor)) return;
-    const root = html instanceof HTMLElement ? html : html?.[0];
-    if (!root) return;
-
-    root.querySelectorAll("[data-item-id]").forEach(el => {
-      const itemId = el.dataset.itemId;
-      const item = app.actor.items.get(itemId);
-      if (!item) return;
-      const iiFlags = getItemIIFlags(item);
-      if (!iiFlags?.sourceActorId) return;
-
-      if (el.querySelector(".pick-up-stix-identify-toggle")) return;
-
-      const isIdentified = isItemIdentified(item);
-      const toggle = document.createElement("a");
-      toggle.className = `pick-up-stix-identify-toggle ii-row-control${isIdentified ? " active" : ""}`;
-      toggle.title = game.i18n.localize(isIdentified
-        ? "INTERACTIVE_ITEMS.Context.HideItem"
-        : "INTERACTIVE_ITEMS.Context.RevealItem");
-      toggle.innerHTML = `<i class="fas fa-wand-sparkles"></i>`;
-      toggle.addEventListener("click", async (ev) => {
-        ev.preventDefault();
-        ev.stopPropagation();
-        await toggleItemIdentification(item);
-      });
-
-      const itemRow = el.querySelector(".item-row");
-      (itemRow ?? el).appendChild(toggle);
-    });
-  };
-
-  Hooks.on("renderActorSheet", _injectIdentifyToggles);
-  Hooks.on("renderCharacterActorSheet", _injectIdentifyToggles);
-  Hooks.on("renderNPCActorSheet", _injectIdentifyToggles);
-
-  Hooks.on("renderItemSheet5e", (app, html) => {
-    if (!game.user.isGM) return;
-    const item = app.item;
-    const actor = item?.actor;
-
-    let configActor = null;
-    if (isInteractiveActor(actor)) {
-      configActor = actor;
-    } else {
-      const sourceActorId = getItemSourceActorId(item);
-      if (sourceActorId) configActor = game.actors.get(sourceActorId);
-    }
-    if (!configActor) return;
-
-    const header = html.querySelector(".window-header");
-    if (!header) return;
-    html.querySelector(".mode-slider")?.remove();
-    const closeBtn = header.querySelector("button.close, [data-action='close']");
-
-    header.querySelector(".ii-lock-toggle-btn")?.remove();
-    const lockToggle = createStateToggleButton({
-      extraClass: "ii-lock-toggle-btn",
-      active: configActor.system.isLocked,
-      iconOn: "fa-lock",
-      iconOff: "fa-lock-open",
-      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
-      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
-      onClick: (ev) => {
-        ev.preventDefault();
-        toggleContainerLocked(configActor);
-      }
-    });
-    insertHeaderButton(header, lockToggle, closeBtn);
-
-    if (!header.querySelector(".ii-configure-btn")) {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "header-control-button ii-configure-btn";
-      btn.dataset.tooltip = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.ConfigureHUD");
-      btn.innerHTML = '<i class="fa-solid fa-gear"></i>';
-      btn.addEventListener("click", async (ev) => {
-        ev.preventDefault();
-        await app.close();
-        configActor.sheet.renderConfig();
-      });
-
-      if (closeBtn) closeBtn.before(btn);
-      else header.appendChild(btn);
-    }
-  });
-
-  Hooks.on("renderContainerSheet", (app, html) => {
-    if (isPlayerView()) return;
-    const actor = app.item?.actor;
-    if (!isInteractiveContainer(actor)) return;
-
-    const header = html.querySelector(".window-header");
-    if (!header) return;
-    html.querySelector(".mode-slider")?.remove();
-    const closeBtn = header.querySelector("button.close, [data-action='close']");
-
-    // Remove existing to refresh state on re-render.
-    header.querySelector(".ii-open-toggle-btn")?.remove();
-
-    const openBtn = createStateToggleButton({
-      extraClass: "ii-open-toggle-btn",
-      active: actor.system.isOpen,
-      iconOn: "fa-box-open",
-      iconOff: "fa-box",
-      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
-      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
-      onClick: async (ev) => {
-        ev.preventDefault();
-        await setContainerOpen(actor, !actor.system.isOpen);
-      }
-    });
-    insertHeaderButton(header, openBtn, closeBtn);
-
-    header.querySelector(".ii-lock-toggle-btn")?.remove();
-    const lockBtn = createStateToggleButton({
-      extraClass: "ii-lock-toggle-btn",
-      active: actor.system.isLocked,
-      iconOn: "fa-lock",
-      iconOff: "fa-lock-open",
-      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
-      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
-      onClick: (ev) => {
-        ev.preventDefault();
-        toggleContainerLocked(actor);
-      }
-    });
-    insertHeaderButton(header, lockBtn, closeBtn);
-
-    if (!header.querySelector(".ii-configure-btn")) {
-      const cfgBtn = document.createElement("button");
-      cfgBtn.type = "button";
-      cfgBtn.className = "header-control-button ii-configure-btn";
-      cfgBtn.dataset.tooltip = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.ConfigureHUD");
-      cfgBtn.innerHTML = '<i class="fa-solid fa-gear"></i>';
-      cfgBtn.addEventListener("click", async (ev) => {
-        ev.preventDefault();
-        await app.close();
-        actor.sheet.renderConfig();
-      });
-
-      if (closeBtn) closeBtn.before(cfgBtn);
-      else header.appendChild(cfgBtn);
-    }
-  });
-
-  Hooks.on("dnd5e.dropItemSheetData", (item, sheet, data) => {
-    const actor = item.actor;
-    if (!isInteractiveContainer(actor)) return;
-
-    if (isPlayerView()) {
-      if (!validateContainerAccess(actor, { checkProximity: true })) return false;
-
-      // Players can't create items on OBSERVER-level actors — route through socket.
-      // Fire async then return false synchronously to cancel dnd5e's native handling.
-      (async () => {
-        const droppedItem = await fromUuid(data.uuid);
-        if (!droppedItem) return;
-        const sourceActor = droppedItem.actor;
-        if (!sourceActor) return;
-        const tokenDoc = actor.token;
-        if (!tokenDoc) return;
-        dispatchGM(
-          "depositItem",
-          { sourceActorId: sourceActor.id, itemId: droppedItem.id, sceneId: tokenDoc.parent.id, tokenId: tokenDoc.id },
-          () => {} // unreachable: isGM is false in this branch
-        );
-        notifyItemAction("Deposited", droppedItem.name);
-      })();
-      return false;
-    }
-  });
-
-  Hooks.on("renderContainerSheet", (app, html) => {
-    const actor = app.item?.actor;
-    if (!isInteractiveContainer(actor)) return;
-
-    html.querySelectorAll(".item-list [data-item-id]").forEach(row => {
-      const itemId = row.dataset.itemId;
-      if (row.querySelector(".ii-row-control, .ii-pickup-btn")) return;
-
-      const item = actor.items.get(itemId);
-      const itemRow = row.querySelector(".item-row");
-      const target = itemRow || row;
-
-      if (actor.token) {
-        const pickupBtn = createRowControl({
-          iconClass: "fa-solid fa-hand",
-          titleKey: "INTERACTIVE_ITEMS.HUD.PickUp",
-          extraClass: "ii-pickup-btn",
-          onClick: async () => {
-            // Check proximity before lock — distance is more actionable to players.
-            if (!checkProximity(actor)) return;
-            // Open is not checked: the row only renders while the container is open.
-            if (!validateContainerAccess(actor, { checkOpen: false })) return;
-            const currentItem = actor.items.get(itemId);
-            if (!validateItemAccess(currentItem)) return;
-
-            const targetActor = await resolvePickupTarget(actor);
-            if (!targetActor) return;
-            const tokenDoc = actor.token;
-            if (!tokenDoc) return;
-            const sceneId = tokenDoc.parent.id;
-            const tokenId = tokenDoc.id;
-            await dispatchGM(
-              "pickupItem",
-              { sceneId, tokenId, itemId, targetActorId: targetActor.id },
-              async () => pickupItem(sceneId, tokenId, itemId, targetActor.id)
-            );
-            if (isPlayerView() && item) notifyItemAction("PickedUp", item.name);
-          }
-        });
-        target.appendChild(pickupBtn);
-      }
-
-      if (isModuleGM() && item) {
-        const isInteractive = !!getItemSourceActorId(item);
-
-        if (isInteractive) {
-          const isLocked = isItemLocked(item);
-          target.appendChild(createRowControl({
-            iconClass: `fas ${isLocked ? "fa-lock" : "fa-lock-open"}`,
-            titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleLock",
-            onClick: async () => {
-              await item.update({
-                "flags.pick-up-stix.tokenState.system.isLocked": !isLocked
-              });
-            }
-          }));
-
-          target.appendChild(createRowControl({
-            iconClass: "fa-solid fa-wand-sparkles",
-            titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleIdentified",
-            active: getAdapter().isItemIdentified(item),
-            onClick: async () => { await toggleItemIdentification(item); }
-          }));
-        }
-
-        // Delete applies to all items, not just interactive ones.
-        target.appendChild(createRowControl({
-          iconClass: "fa-solid fa-trash-can",
-          titleKey: "INTERACTIVE_ITEMS.Sheet.DeleteItem",
-          onClick: async () => { await item.delete({ deleteContents: true }); }
-        }));
-      }
-    });
-  });
-
-  // dnd5e's native _onDrop only handles Item and Folder types; Actor drops need
-  // this separate listener on the ContainerSheet.
-  Hooks.on("renderContainerSheet", (app, html) => {
-    const destContainerItem = app.item;
-    // Delegate item-type check to the adapter so the literal "container" is not
-    // hard-coded to the dnd5e vocabulary.
-    if (!destContainerItem || !getAdapter().isContainerItem(destContainerItem)) return;
-
-    if (html.dataset.iiActorDropAttached) return;
-    html.dataset.iiActorDropAttached = "1";
-
-    html.addEventListener("drop", async (event) => {
-      const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-      if (data?.type !== "Actor") return;
-
-      const droppedActor = await fromUuid(data.uuid);
-      if (!isInteractiveActor(droppedActor)) return;
-
-      if (droppedActor.system.isContainer) {
-        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoContainerInContainer"));
-        return;
-      }
-
-      const destActor = destContainerItem.actor;
-      const destIsInteractive = isInteractiveContainer(destActor);
-
-      if (destIsInteractive && isPlayerView()) {
-        if (!validateContainerAccess(destActor, { checkProximity: true })) return;
-      }
-
-      // Players can't see sidebar actors, but gate explicitly in case that ever changes.
-      if (!destIsInteractive && isPlayerView()) return;
-
-      const itemData = buildInteractiveItemData(droppedActor);
-      if (!itemData) {
-        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotInitialized"));
-        return;
-      }
-
-      // Delegate container-parent field write to the adapter so the field path
-      // is not hard-coded to dnd5e's `system.container`.
-      getAdapter().setItemContainerId(itemData, destContainerItem.id);
-
-      if (destActor) {
-        await CONFIG.Item.documentClass.createDocuments([itemData], { parent: destActor, keepId: false });
-      } else {
-        await CONFIG.Item.documentClass.createDocuments([itemData], { keepId: false }); // world-level container
-      }
-      ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Notify.Deposited", { name: itemData.name }));
-    });
-  });
-
-  Hooks.on("renderContainerSheet", (app, html) => {
-    if (isModuleGM()) return;
-    const actor = app.item?.actor;
-    if (!isInteractiveContainer(actor)) return;
-
-    if (actor.system.isOpen && checkProximity(actor, { silent: true, range: "interaction" })) return;
-
-    // Target the outer `.items-list` wrapper — replacing its children hides all categories
-    // at once while preserving currency/search/encumbrance siblings and the description tab.
-    const list = html.querySelector('section.inventory.tab[data-tab="contents"] .items-list');
-    if (!list) return;
-
-    const message = actor.system.isOpen
-      ? game.i18n.localize("INTERACTIVE_ITEMS.Container.ContentsHidden")
-      : game.i18n.localize("INTERACTIVE_ITEMS.Notify.ContainerClosed");
-
-    list.replaceChildren();
-    const placeholder = document.createElement("div");
-    placeholder.className = "pick-up-stix-contents-hidden";
-    placeholder.textContent = message;
-    list.append(placeholder);
+  getAdapter().registerContainerViewHooks({
+    injectHeaderControls: _injectContainerSheetHeaderControls,
+    maybeHideContents: _hideContainerSheetContents,
+    installActorDropListener: _installContainerSheetActorDrop,
+    injectItemRowControls: _injectContainerSheetRowControls,
   });
 
   Hooks.on("dropActorSheetData", (actor, sheet, data) => {
@@ -547,6 +198,437 @@ Hooks.once("init", async () => {
   registerTokenHUD();
   registerPlacement();
 });
+
+/**
+ * Extends the dnd5e item context menu with pick-up-stix entries.
+ * Adds a "Drop Item" option for non-interactive actors and a
+ * "Reveal / Hide" identification toggle for GM users on interactive items.
+ *
+ * @param {Item} item - The item whose context menu is being built.
+ * @param {object[]} menuItems - The mutable array of menu entries to extend.
+ */
+function _injectItemContextMenuEntries(item, menuItems) {
+  if (!item.actor) return;
+
+  if (!isInteractiveActor(item.actor)) {
+    menuItems.push({
+      name: "INTERACTIVE_ITEMS.Context.DropItem",
+      icon: '<i class="fa-solid fa-arrow-down fa-fw"></i>',
+      group: "action",
+      condition: () => !!canvas.scene,
+      callback: () => _dropItemOnCanvas(item)
+    });
+  }
+
+  if (!game.user.isGM) return;
+  const iiFlags = getItemIIFlags(item);
+  if (!iiFlags?.sourceActorId) return;
+  const sourceActorId = getItemSourceActorId(item);
+
+  const isIdentified = isItemIdentified(item);
+  menuItems.push({
+    name: isIdentified
+      ? "INTERACTIVE_ITEMS.Context.HideItem"
+      : "INTERACTIVE_ITEMS.Context.RevealItem",
+    icon: `<i class="fa-solid fa-wand-sparkles fa-fw"></i>`,
+    group: "action",
+    callback: () => toggleItemIdentification(item)
+  });
+
+  // Override dnd5e's "Edit" to open our config sheet instead.
+  const editEntry = menuItems.find(e => e.name === "DND5E.ContextMenuActionEdit");
+  if (editEntry) {
+    editEntry.callback = () => {
+      const sourceActor = game.actors.get(sourceActorId);
+      if (sourceActor?.sheet?.renderConfig) sourceActor.sheet.renderConfig();
+    };
+  }
+}
+
+/**
+ * Injects a wand-icon identification toggle into each inventory row on dnd5e
+ * character/NPC sheets for items originating from interactive actors.
+ *
+ * dnd5e uses both `<img class="item-image">` (raster) and
+ * `<dnd5e-icon class="item-image">` (SVG); both share the class so the
+ * querySelector catches either.
+ *
+ * @param {ActorSheet} app - The rendered actor sheet application.
+ * @param {HTMLElement|jQuery} html - The sheet's root element.
+ */
+function _injectActorInventoryIdentifyToggles(app, html) {
+  if (!game.user.isGM) return;
+  if (isInteractiveActor(app.actor)) return;
+  const root = html instanceof HTMLElement ? html : html?.[0];
+  if (!root) return;
+
+  root.querySelectorAll("[data-item-id]").forEach(el => {
+    const itemId = el.dataset.itemId;
+    const item = app.actor.items.get(itemId);
+    if (!item) return;
+    const iiFlags = getItemIIFlags(item);
+    if (!iiFlags?.sourceActorId) return;
+
+    if (el.querySelector(".pick-up-stix-identify-toggle")) return;
+
+    const isIdentified = isItemIdentified(item);
+    const toggle = document.createElement("a");
+    toggle.className = `pick-up-stix-identify-toggle ii-row-control${isIdentified ? " active" : ""}`;
+    toggle.title = game.i18n.localize(isIdentified
+      ? "INTERACTIVE_ITEMS.Context.HideItem"
+      : "INTERACTIVE_ITEMS.Context.RevealItem");
+    toggle.innerHTML = `<i class="fas fa-wand-sparkles"></i>`;
+    toggle.addEventListener("click", async (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      await toggleItemIdentification(item);
+    });
+
+    const itemRow = el.querySelector(".item-row");
+    (itemRow ?? el).appendChild(toggle);
+  });
+}
+
+/**
+ * Injects GM-only lock and configure header buttons into the dnd5e item sheet
+ * rendered for an embedded item belonging to an interactive actor.
+ *
+ * @param {object} ctx
+ * @param {Application} ctx.app - The rendered ItemSheet5e application.
+ * @param {HTMLElement} ctx.html - The sheet's root element.
+ */
+function _injectItemSheetHeaderControls({ app, html }) {
+  if (!game.user.isGM) return;
+  const item = app.item;
+  const actor = item?.actor;
+
+  let configActor = null;
+  if (isInteractiveActor(actor)) {
+    configActor = actor;
+  } else {
+    const sourceActorId = getItemSourceActorId(item);
+    if (sourceActorId) configActor = game.actors.get(sourceActorId);
+  }
+  if (!configActor) return;
+
+  const header = html.querySelector(".window-header");
+  if (!header) return;
+  html.querySelector(".mode-slider")?.remove();
+  const closeBtn = header.querySelector("button.close, [data-action='close']");
+
+  header.querySelector(".ii-lock-toggle-btn")?.remove();
+  const lockToggle = createStateToggleButton({
+    extraClass: "ii-lock-toggle-btn",
+    active: configActor.system.isLocked,
+    iconOn: "fa-lock",
+    iconOff: "fa-lock-open",
+    labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
+    labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
+    onClick: (ev) => {
+      ev.preventDefault();
+      toggleContainerLocked(configActor);
+    }
+  });
+  insertHeaderButton(header, lockToggle, closeBtn);
+
+  if (!header.querySelector(".ii-configure-btn")) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "header-control-button ii-configure-btn";
+    btn.dataset.tooltip = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.ConfigureHUD");
+    btn.innerHTML = '<i class="fa-solid fa-gear"></i>';
+    btn.addEventListener("click", async (ev) => {
+      ev.preventDefault();
+      await app.close();
+      configActor.sheet.renderConfig();
+    });
+
+    if (closeBtn) closeBtn.before(btn);
+    else header.appendChild(btn);
+  }
+}
+
+/**
+ * Injects GM-only open/close, lock, and configure header buttons into the
+ * dnd5e ContainerSheet rendered for an interactive container actor.
+ *
+ * @param {object} ctx
+ * @param {Actor} ctx.actor - The interactive container actor owning the container item.
+ * @param {Application} ctx.app - The rendered ContainerSheet application.
+ * @param {HTMLElement} ctx.html - The sheet's root element.
+ */
+function _injectContainerSheetHeaderControls({ actor, app, html }) {
+  if (isPlayerView()) return;
+  if (!isInteractiveContainer(actor)) return;
+
+  const header = html.querySelector(".window-header");
+  if (!header) return;
+  html.querySelector(".mode-slider")?.remove();
+  const closeBtn = header.querySelector("button.close, [data-action='close']");
+
+  // Remove existing to refresh state on re-render.
+  header.querySelector(".ii-open-toggle-btn")?.remove();
+
+  const openBtn = createStateToggleButton({
+    extraClass: "ii-open-toggle-btn",
+    active: actor.system.isOpen,
+    iconOn: "fa-box-open",
+    iconOff: "fa-box",
+    labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
+    labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
+    onClick: async (ev) => {
+      ev.preventDefault();
+      await setContainerOpen(actor, !actor.system.isOpen);
+    }
+  });
+  insertHeaderButton(header, openBtn, closeBtn);
+
+  header.querySelector(".ii-lock-toggle-btn")?.remove();
+  const lockBtn = createStateToggleButton({
+    extraClass: "ii-lock-toggle-btn",
+    active: actor.system.isLocked,
+    iconOn: "fa-lock",
+    iconOff: "fa-lock-open",
+    labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
+    labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
+    onClick: (ev) => {
+      ev.preventDefault();
+      toggleContainerLocked(actor);
+    }
+  });
+  insertHeaderButton(header, lockBtn, closeBtn);
+
+  if (!header.querySelector(".ii-configure-btn")) {
+    const cfgBtn = document.createElement("button");
+    cfgBtn.type = "button";
+    cfgBtn.className = "header-control-button ii-configure-btn";
+    cfgBtn.dataset.tooltip = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.ConfigureHUD");
+    cfgBtn.innerHTML = '<i class="fa-solid fa-gear"></i>';
+    cfgBtn.addEventListener("click", async (ev) => {
+      ev.preventDefault();
+      await app.close();
+      actor.sheet.renderConfig();
+    });
+
+    if (closeBtn) closeBtn.before(cfgBtn);
+    else header.appendChild(cfgBtn);
+  }
+}
+
+/**
+ * Injects pickup, lock, identify, and delete row controls into each item row
+ * of the dnd5e ContainerSheet rendered for an interactive container actor.
+ *
+ * @param {object} ctx
+ * @param {Actor} ctx.actor - The interactive container actor owning the container item.
+ * @param {Application} ctx.app - The rendered ContainerSheet application.
+ * @param {HTMLElement} ctx.html - The sheet's root element.
+ */
+function _injectContainerSheetRowControls({ actor, app, html }) {
+  if (!isInteractiveContainer(actor)) return;
+
+  html.querySelectorAll(".item-list [data-item-id]").forEach(row => {
+    const itemId = row.dataset.itemId;
+    if (row.querySelector(".ii-row-control, .ii-pickup-btn")) return;
+
+    const item = actor.items.get(itemId);
+    const itemRow = row.querySelector(".item-row");
+    const target = itemRow || row;
+
+    if (actor.token) {
+      const pickupBtn = createRowControl({
+        iconClass: "fa-solid fa-hand",
+        titleKey: "INTERACTIVE_ITEMS.HUD.PickUp",
+        extraClass: "ii-pickup-btn",
+        onClick: async () => {
+          // Check proximity before lock — distance is more actionable to players.
+          if (!checkProximity(actor)) return;
+          // Open is not checked: the row only renders while the container is open.
+          if (!validateContainerAccess(actor, { checkOpen: false })) return;
+          const currentItem = actor.items.get(itemId);
+          if (!validateItemAccess(currentItem)) return;
+
+          const targetActor = await resolvePickupTarget(actor);
+          if (!targetActor) return;
+          const tokenDoc = actor.token;
+          if (!tokenDoc) return;
+          const sceneId = tokenDoc.parent.id;
+          const tokenId = tokenDoc.id;
+          await dispatchGM(
+            "pickupItem",
+            { sceneId, tokenId, itemId, targetActorId: targetActor.id },
+            async () => pickupItem(sceneId, tokenId, itemId, targetActor.id)
+          );
+          if (isPlayerView() && item) notifyItemAction("PickedUp", item.name);
+        }
+      });
+      target.appendChild(pickupBtn);
+    }
+
+    if (isModuleGM() && item) {
+      const isInteractive = !!getItemSourceActorId(item);
+
+      if (isInteractive) {
+        const isLocked = isItemLocked(item);
+        target.appendChild(createRowControl({
+          iconClass: `fas ${isLocked ? "fa-lock" : "fa-lock-open"}`,
+          titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleLock",
+          onClick: async () => {
+            await item.update({
+              "flags.pick-up-stix.tokenState.system.isLocked": !isLocked
+            });
+          }
+        }));
+
+        target.appendChild(createRowControl({
+          iconClass: "fa-solid fa-wand-sparkles",
+          titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleIdentified",
+          active: getAdapter().isItemIdentified(item),
+          onClick: async () => { await toggleItemIdentification(item); }
+        }));
+      }
+
+      // Delete applies to all items, not just interactive ones.
+      target.appendChild(createRowControl({
+        iconClass: "fa-solid fa-trash-can",
+        titleKey: "INTERACTIVE_ITEMS.Sheet.DeleteItem",
+        onClick: async () => { await item.delete({ deleteContents: true }); }
+      }));
+    }
+  });
+}
+
+/**
+ * Attaches a drop event listener to the dnd5e ContainerSheet that handles
+ * Actor drops onto the container. dnd5e's native _onDrop only handles Item and
+ * Folder types, so this listener handles the Actor case separately.
+ *
+ * @param {object} ctx
+ * @param {Actor} ctx.actor - The actor owning the container item (may be null for world-level containers).
+ * @param {Application} ctx.app - The rendered ContainerSheet application.
+ * @param {HTMLElement} ctx.html - The sheet's root element.
+ */
+function _installContainerSheetActorDrop({ actor, app, html }) {
+  const destContainerItem = app.item;
+  // Delegate item-type check to the adapter so the literal "container" is not
+  // hard-coded to the dnd5e vocabulary.
+  if (!destContainerItem || !getAdapter().isContainerItem(destContainerItem)) return;
+
+  if (html.dataset.iiActorDropAttached) return;
+  html.dataset.iiActorDropAttached = "1";
+
+  html.addEventListener("drop", async (event) => {
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    if (data?.type !== "Actor") return;
+
+    const droppedActor = await fromUuid(data.uuid);
+    if (!isInteractiveActor(droppedActor)) return;
+
+    if (droppedActor.system.isContainer) {
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoContainerInContainer"));
+      return;
+    }
+
+    const destActor = destContainerItem.actor;
+    const destIsInteractive = isInteractiveContainer(destActor);
+
+    if (destIsInteractive && isPlayerView()) {
+      if (!validateContainerAccess(destActor, { checkProximity: true })) return;
+    }
+
+    // Players can't see sidebar actors, but gate explicitly in case that ever changes.
+    if (!destIsInteractive && isPlayerView()) return;
+
+    const itemData = buildInteractiveItemData(droppedActor);
+    if (!itemData) {
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotInitialized"));
+      return;
+    }
+
+    // Delegate container-parent field write to the adapter so the field path
+    // is not hard-coded to dnd5e's `system.container`.
+    getAdapter().setItemContainerId(itemData, destContainerItem.id);
+
+    if (destActor) {
+      await CONFIG.Item.documentClass.createDocuments([itemData], { parent: destActor, keepId: false });
+    } else {
+      await CONFIG.Item.documentClass.createDocuments([itemData], { keepId: false }); // world-level container
+    }
+    ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Notify.Deposited", { name: itemData.name }));
+  });
+}
+
+/**
+ * Hides the contents list in the dnd5e ContainerSheet when a non-GM viewer is
+ * outside interaction range or the container is closed, replacing it with a
+ * placeholder message.
+ *
+ * Targets the outer `.items-list` wrapper — replacing its children hides all
+ * categories at once while preserving currency/search/encumbrance siblings and
+ * the description tab.
+ *
+ * @param {object} ctx
+ * @param {Actor} ctx.actor - The interactive container actor owning the container item.
+ * @param {Application} ctx.app - The rendered ContainerSheet application.
+ * @param {HTMLElement} ctx.html - The sheet's root element.
+ */
+function _hideContainerSheetContents({ actor, app, html }) {
+  if (isModuleGM()) return;
+  if (!isInteractiveContainer(actor)) return;
+
+  if (actor.system.isOpen && checkProximity(actor, { silent: true, range: "interaction" })) return;
+
+  const list = html.querySelector('section.inventory.tab[data-tab="contents"] .items-list');
+  if (!list) return;
+
+  const message = actor.system.isOpen
+    ? game.i18n.localize("INTERACTIVE_ITEMS.Container.ContentsHidden")
+    : game.i18n.localize("INTERACTIVE_ITEMS.Notify.ContainerClosed");
+
+  list.replaceChildren();
+  const placeholder = document.createElement("div");
+  placeholder.className = "pick-up-stix-contents-hidden";
+  placeholder.textContent = message;
+  list.append(placeholder);
+}
+
+/**
+ * Handles dnd5e's container-drop gate. Called when an item is dropped onto a
+ * ContainerSheet; routes player deposits through the socket and cancels dnd5e's
+ * native handling for player users.
+ *
+ * @param {object} ctx
+ * @param {Actor} ctx.actor - The actor owning the container item.
+ * @param {Item} ctx.item - The container item receiving the drop.
+ * @param {Application} ctx.sheet - The ContainerSheet application.
+ * @param {object} ctx.data - The drag event data payload.
+ * @returns {false|undefined} Returns `false` to cancel dnd5e's native drop handling for players.
+ */
+function _gateContainerDrop({ actor, item, sheet, data }) {
+  if (!isInteractiveContainer(actor)) return;
+
+  if (isPlayerView()) {
+    if (!validateContainerAccess(actor, { checkProximity: true })) return false;
+
+    // Players can't create items on OBSERVER-level actors — route through socket.
+    // Fire async then return false synchronously to cancel dnd5e's native handling.
+    (async () => {
+      const droppedItem = await fromUuid(data.uuid);
+      if (!droppedItem) return;
+      const sourceActor = droppedItem.actor;
+      if (!sourceActor) return;
+      const tokenDoc = actor.token;
+      if (!tokenDoc) return;
+      dispatchGM(
+        "depositItem",
+        { sourceActorId: sourceActor.id, itemId: droppedItem.id, sceneId: tokenDoc.parent.id, tokenId: tokenDoc.id },
+        () => {} // unreachable: isGM is false in this branch
+      );
+      notifyItemAction("Deposited", droppedItem.name);
+    })();
+    return false;
+  }
+}
 
 Hooks.on("renderSettingsConfig", (app, html) => {
   const input = html.querySelector(`[name="${MODULE_ID}.actorFolder"]`);

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -980,7 +980,19 @@ function _buildContainerContentRow(item, adapter) {
   ));
 
   controls.append(_buildContentRowControl("fa-gear", "INTERACTIVE_ITEMS.Sheet.ConfigureHUD"));
-  controls.append(_buildContentRowControl("fa-trash", "INTERACTIVE_ITEMS.Sheet.DeleteItem"));
+  // Delete is the only currently-active control on contents rows. GM-only —
+  // players see the icon but the click no-ops for them. The deleteItem hook
+  // re-renders the container sheet automatically, so the row disappears.
+  controls.append(_buildContentRowControl(
+    "fa-trash",
+    "INTERACTIVE_ITEMS.Sheet.DeleteItem",
+    "fa-solid",
+    async () => {
+      if (!game.user.isGM) return;
+      dbg("contents:deleteRow", { itemName: item.name, itemId: item.id, actorName: item.actor?.name });
+      await item.delete();
+    }
+  ));
 
   row.append(controls);
   return row;
@@ -992,15 +1004,25 @@ function _buildContainerContentRow(item, adapter) {
  * @param {string} icon - FontAwesome icon class (e.g. `fa-lock`).
  * @param {string} tooltipKey - i18n key for the hover tooltip.
  * @param {string} [family="fa-solid"] - FontAwesome family class.
+ * @param {((event: MouseEvent) => void)|null} [onClick=null] - Optional click handler.
+ *   When provided, the click event has `preventDefault` + `stopPropagation` called
+ *   on it before invocation so it doesn't bubble to pf2e's row-level handlers.
  * @returns {HTMLAnchorElement}
  */
-function _buildContentRowControl(icon, tooltipKey, family = "fa-solid") {
+function _buildContentRowControl(icon, tooltipKey, family = "fa-solid", onClick = null) {
   const a = document.createElement("a");
   a.className = "ii-contents-control";
   const tooltip = game.i18n.localize(tooltipKey);
   a.dataset.tooltip = tooltip;
   a.setAttribute("aria-label", tooltip);
   a.innerHTML = `<i class="${family} ${icon}"></i>`;
+  if (onClick) {
+    a.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      return onClick(event);
+    });
+  }
   return a;
 }
 

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -912,11 +912,6 @@ function _buildContainerContentsHeader({ isTokenActor = false } = {}) {
   name.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Name");
   header.append(name);
 
-  const qty = document.createElement("span");
-  qty.className = "ii-contents-quantity";
-  qty.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Quantity");
-  header.append(qty);
-
   const bulk = document.createElement("span");
   bulk.className = "ii-contents-bulk";
   bulk.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Bulk");
@@ -944,6 +939,18 @@ function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {})
   row.dataset.itemId = item.id;
   row.dataset.itemUuid = item.uuid;
 
+  // Native Foundry drag payload — destinations (canvas, character sheets,
+  // other containers) consume `{type:"Item", uuid}` and either move the item
+  // (sheet drops) or hand off to our `dropCanvasData` placement flow, which
+  // already deletes the source item from its actor after placement.
+  row.draggable = true;
+  row.addEventListener("dragstart", (event) => {
+    const payload = { type: "Item", uuid: item.uuid };
+    event.dataTransfer.setData("text/plain", JSON.stringify(payload));
+    event.dataTransfer.effectAllowed = "all";
+    dbg("contents:dragstart", { itemName: item.name, itemId: item.id, uuid: item.uuid });
+  });
+
   const img = document.createElement("img");
   img.className = "ii-contents-img";
   img.src = item.img;
@@ -954,14 +961,6 @@ function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {})
   name.className = "ii-contents-name";
   name.textContent = item.name;
   row.append(name);
-
-  const quantity = document.createElement("span");
-  quantity.className = "ii-contents-quantity";
-  // pf2e physical items expose `system.quantity` (number); some types may
-  // expose `{ value }` (legacy). Read both shapes defensively.
-  const q = item.system?.quantity;
-  quantity.textContent = (typeof q === "object" ? q?.value : q) ?? 1;
-  row.append(quantity);
 
   const bulk = document.createElement("span");
   bulk.className = "ii-contents-bulk";

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -13,7 +13,7 @@ import { dispatchGM } from "./utils/gmDispatch.mjs";
 import { notifyItemAction } from "./utils/notify.mjs";
 import { validateContainerAccess, validateItemAccess } from "./utils/containerAccess.mjs";
 import { resolvePickupTarget } from "./utils/pickupFlow.mjs";
-import { createStateToggleButton, createAdapterHeaderButton, insertHeaderButton, createRowControl } from "./utils/domButtons.mjs";
+import { createAdapterHeaderButton, createRowControl } from "./utils/domButtons.mjs";
 import { dbg } from "./utils/debugLog.mjs";
 import { findCanvasDropTargets } from "./utils/canvasDropTargets.mjs";
 import { isModuleGM, isPlayerView } from "./utils/playerView.mjs";
@@ -164,12 +164,16 @@ Hooks.once("init", async () => {
 
   getAdapter().registerActorInventoryHooks(_injectActorInventoryIdentifyToggles);
 
-  getAdapter().registerItemSheetHooks({ injectHeaderControls: _injectItemSheetHeaderControls });
+  // One unified header-controls decorator covers both item and container
+  // sheets. Both callbacks point at the same function — it's idempotent on
+  // re-render and on the container item sheet (where both hooks fire), it
+  // produces identical DOM either time.
+  getAdapter().registerItemSheetHooks({ injectHeaderControls: _injectInteractiveSheetHeaderControls });
 
   getAdapter().registerContainerDropGate(_gateContainerDrop);
 
   getAdapter().registerContainerViewHooks({
-    injectHeaderControls: _injectContainerSheetHeaderControls,
+    injectHeaderControls: _injectInteractiveSheetHeaderControls,
     maybeHideContents: _hideContainerSheetContents,
     installActorDropListener: _installContainerSheetActorDrop,
     injectItemRowControls: _injectContainerSheetRowControls,
@@ -299,52 +303,121 @@ function _injectActorInventoryIdentifyToggles(app, html) {
 }
 
 /**
- * Injects GM-only lock and configure header buttons into the dnd5e item sheet
- * rendered for an embedded item belonging to an interactive actor.
+ * Resolve the interactive actor associated with a sheet's `app.item`. When
+ * the item belongs directly to an interactive actor, that actor is the answer.
+ * When the item lives in a player's inventory but was picked up from one,
+ * resolve via the `sourceActorId` flag so configure/lock/identify still work
+ * on inventory items.
+ *
+ * @param {Application} app
+ * @returns {Actor|null}
+ */
+function _resolveInteractiveActor(app) {
+  const item = app?.item;
+  if (!item) return null;
+  if (isInteractiveActor(item.actor)) return item.actor;
+  const sourceActorId = getItemSourceActorId(item);
+  return sourceActorId ? game.actors.get(sourceActorId) : null;
+}
+
+/**
+ * Resolve the full window root element for a render-hook callback. Foundry V1
+ * fires render hooks with the inner `.window-content` jQuery on re-render
+ * (only the initial render passes the full window), so we fall back to
+ * `app.element[0]` (V1) or `app.element` (V2) when `.window-header` isn't
+ * reachable from the hook's html argument.
+ *
+ * @param {Application} app
+ * @param {HTMLElement|null} html
+ * @returns {HTMLElement|null}
+ */
+function _resolveSheetRoot(app, html) {
+  if (html?.querySelector?.(".window-header")) return html;
+  if (app?.element instanceof HTMLElement) return app.element;
+  return app?.element?.[0] ?? null;
+}
+
+/**
+ * Inject the module's header toggles — open/close (containers only), lock,
+ * identify, configure — into a system's native item or container sheet header.
+ *
+ * Always emits the four buttons in canonical left-to-right order
+ * (`open, lock, identify, configure`) regardless of which decorator callback
+ * triggered the render. Existing module buttons are removed and re-created on
+ * every call so the order stays stable across re-renders.
+ *
+ * Inserts the group immediately after `.window-title` so the buttons sit on
+ * the *left* of any system-injected header buttons (Sheet, Prototype Token,
+ * Close on pf2e; ellipsis menu, Close on dnd5e V2). The flex layout pushes
+ * system buttons to the far right, leaving our buttons grouped just to the
+ * right of the title.
+ *
+ * Idempotent — both `registerItemSheetHooks` and `registerContainerViewHooks`
+ * route here, so on container item sheets where both fire the second call
+ * produces the same DOM as the first.
  *
  * @param {object} ctx
- * @param {Application} ctx.app - The rendered ItemSheet5e application.
- * @param {HTMLElement} ctx.html - The sheet's root element.
+ * @param {Actor} [ctx.actor] - Pre-resolved interactive actor (container hook supplies this).
+ * @param {Application} ctx.app
+ * @param {HTMLElement} ctx.html
  */
-function _injectItemSheetHeaderControls({ app, html }) {
+function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   if (!game.user.isGM) return;
-  const item = app.item;
-  const actor = item?.actor;
 
-  let configActor = null;
-  if (isInteractiveActor(actor)) {
-    configActor = actor;
-  } else {
-    const sourceActorId = getItemSourceActorId(item);
-    if (sourceActorId) configActor = game.actors.get(sourceActorId);
-  }
+  const configActor = isInteractiveActor(actor) ? actor : _resolveInteractiveActor(app);
   if (!configActor) return;
 
-  // Foundry V1 fires the render hook with the *inner* (.window-content) HTML
-  // on re-render, so `.window-header` lives outside of it. Fall back to the
-  // app's own root element (V1: `app.element[0]`, V2: `app.element`) so the
-  // header is reachable on every render — not just the initial one.
-  let header = html?.querySelector?.(".window-header") ?? null;
-  if (!header) {
-    const root = app.element instanceof HTMLElement
-      ? app.element
-      : app.element?.[0] ?? null;
-    header = root?.querySelector?.(".window-header") ?? null;
-  }
+  const root = _resolveSheetRoot(app, html);
+  const header = root?.querySelector?.(".window-header");
   if (!header) return;
-  // mode-slider is a dnd5e-only header control inside the inner content; safe
-  // best-effort removal regardless of whether `html` is the inner or full root.
-  html?.querySelector?.(".mode-slider")?.remove();
-  const closeBtn = header.querySelector("button.close, a.close, [data-action='close']");
 
-  const _adapter = getAdapter();
+  // dnd5e injects a `.mode-slider` edit-mode toggle into the header on AppV2
+  // sheets — interactive object sheets shouldn't expose that to anyone.
+  root.querySelector?.(".mode-slider")?.remove();
 
-  header.querySelector(".ii-identify-toggle-btn")?.remove();
-  const identCfg = _adapter.getIdentifyButtonConfig(configActor.system.isIdentified);
-  const identifyToggle = createAdapterHeaderButton({
-    adapter: _adapter,
+  // Remove any existing module toggles so the rebuild produces a stable order.
+  header.querySelectorAll(".ii-open-toggle-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-configure-btn")
+    .forEach(el => el.remove());
+
+  const adapter = getAdapter();
+  const sys = configActor.system;
+  const buttons = [];
+
+  if (sys.isContainer) {
+    buttons.push(createAdapterHeaderButton({
+      adapter,
+      extraClass: "ii-open-toggle-btn",
+      active: sys.isOpen,
+      iconOn: "fa-box-open",
+      iconOff: "fa-box",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        await setContainerOpen(configActor, !configActor.system.isOpen);
+      }
+    }));
+  }
+
+  buttons.push(createAdapterHeaderButton({
+    adapter,
+    extraClass: "ii-lock-toggle-btn",
+    active: sys.isLocked,
+    iconOn: "fa-lock",
+    iconOff: "fa-lock-open",
+    labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
+    labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
+    onClick: (ev) => {
+      ev.preventDefault();
+      toggleContainerLocked(configActor);
+    }
+  }));
+
+  const identCfg = adapter.getIdentifyButtonConfig(sys.isIdentified);
+  buttons.push(createAdapterHeaderButton({
+    adapter,
     extraClass: "ii-identify-toggle-btn",
-    active: configActor.system.isIdentified,
+    active: sys.isIdentified,
     iconOn: identCfg.iconOn,
     iconFamilyOn: identCfg.iconFamilyOn,
     iconOff: identCfg.iconOff,
@@ -357,113 +430,29 @@ function _injectItemSheetHeaderControls({ app, html }) {
       if (!embeddedItem) return;
       // Route through the adapter — pf2e opens a DC dialog for unidentified
       // items rather than flipping the flag directly.
-      await _adapter.performIdentifyToggle(embeddedItem);
+      await adapter.performIdentifyToggle(embeddedItem);
     }
-  });
-  insertHeaderButton(header, identifyToggle, closeBtn);
+  }));
 
-  header.querySelector(".ii-lock-toggle-btn")?.remove();
-  const lockToggle = createAdapterHeaderButton({
-    adapter: _adapter,
-    extraClass: "ii-lock-toggle-btn",
-    active: configActor.system.isLocked,
-    iconOn: "fa-lock",
-    iconOff: "fa-lock-open",
-    labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
-    labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
-    onClick: (ev) => {
-      ev.preventDefault();
-      toggleContainerLocked(configActor);
-    }
-  });
-  insertHeaderButton(header, lockToggle, closeBtn);
-
-  if (!header.querySelector(".ii-configure-btn")) {
-    const cfgBtn = createAdapterHeaderButton({
-      adapter: _adapter,
-      kind: "config",
-      extraClass: "ii-configure-btn",
-      iconOn: "fa-gear",
-      labelOnKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
-      onClick: async (ev) => {
-        ev.preventDefault();
-        await app.close();
-        configActor.sheet.renderConfig();
-      }
-    });
-    insertHeaderButton(header, cfgBtn, closeBtn);
-  }
-}
-
-/**
- * Injects GM-only open/close, lock, and configure header buttons into the
- * dnd5e ContainerSheet rendered for an interactive container actor.
- *
- * @param {object} ctx
- * @param {Actor} ctx.actor - The interactive container actor owning the container item.
- * @param {Application} ctx.app - The rendered ContainerSheet application.
- * @param {HTMLElement} ctx.html - The sheet's root element.
- */
-function _injectContainerSheetHeaderControls({ actor, app, html }) {
-  if (isPlayerView()) return;
-  if (!isInteractiveContainer(actor)) return;
-
-  const header = html.querySelector(".window-header");
-  if (!header) return;
-  html.querySelector(".mode-slider")?.remove();
-  const closeBtn = header.querySelector("button.close, a.close, [data-action='close']");
-
-  const _adapter = getAdapter();
-
-  // Remove existing to refresh state on re-render.
-  header.querySelector(".ii-open-toggle-btn")?.remove();
-
-  const openBtn = createAdapterHeaderButton({
-    adapter: _adapter,
-    extraClass: "ii-open-toggle-btn",
-    active: actor.system.isOpen,
-    iconOn: "fa-box-open",
-    iconOff: "fa-box",
-    labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
-    labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
+  buttons.push(createAdapterHeaderButton({
+    adapter,
+    kind: "config",
+    extraClass: "ii-configure-btn",
+    iconOn: "fa-gear",
+    labelOnKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
     onClick: async (ev) => {
       ev.preventDefault();
-      await setContainerOpen(actor, !actor.system.isOpen);
+      await app.close();
+      configActor.sheet.renderConfig();
     }
-  });
-  insertHeaderButton(header, openBtn, closeBtn);
+  }));
 
-  header.querySelector(".ii-lock-toggle-btn")?.remove();
-  const lockBtn = createAdapterHeaderButton({
-    adapter: _adapter,
-    extraClass: "ii-lock-toggle-btn",
-    active: actor.system.isLocked,
-    iconOn: "fa-lock",
-    iconOff: "fa-lock-open",
-    labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
-    labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
-    onClick: (ev) => {
-      ev.preventDefault();
-      toggleContainerLocked(actor);
-    }
-  });
-  insertHeaderButton(header, lockBtn, closeBtn);
-
-  if (!header.querySelector(".ii-configure-btn")) {
-    const cfgBtn = createAdapterHeaderButton({
-      adapter: _adapter,
-      kind: "config",
-      extraClass: "ii-configure-btn",
-      iconOn: "fa-gear",
-      labelOnKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
-      onClick: async (ev) => {
-        ev.preventDefault();
-        await app.close();
-        actor.sheet.renderConfig();
-      }
-    });
-    insertHeaderButton(header, cfgBtn, closeBtn);
-  }
+  // Insert immediately after the title so buttons sit left of system-injected
+  // header controls (Sheet/Prototype Token/Close on pf2e; ellipsis/Close on
+  // dnd5e V2). The header's flex layout pushes system buttons to the far right.
+  const title = header.querySelector(".window-title");
+  if (title) title.after(...buttons);
+  else header.prepend(...buttons);
 }
 
 /**

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -176,6 +176,7 @@ Hooks.once("init", async () => {
     injectHeaderControls: _injectInteractiveSheetHeaderControls,
     maybeHideContents: _hideContainerSheetContents,
     installActorDropListener: _installContainerSheetActorDrop,
+    installItemDropListener: _installContainerSheetItemDrop,
     injectItemRowControls: _injectContainerSheetRowControls,
     injectContentsTab: _injectContainerContentsTab,
   });
@@ -568,6 +569,88 @@ function _injectContainerSheetRowControls({ actor, app, html }) {
  * @param {Application} ctx.app - The rendered ContainerSheet application.
  * @param {HTMLElement} ctx.html - The sheet's root element.
  */
+/**
+ * Wire an Item drop listener onto the container item sheet so dragging a
+ * physical item from anywhere (sidebar, character sheet, compendium) deposits
+ * it into the interactive container.
+ *
+ * Skipped on systems that already fire a native item-drop hook on container
+ * sheets (dnd5e fires `dnd5e.dropItemSheetData`, gated by `_gateContainerDrop`);
+ * pf2e's `ContainerSheetPF2e` has no equivalent so we attach the listener
+ * directly. Idempotent across re-renders via the `iiItemDropAttached` marker.
+ *
+ * Only non-container physical items are accepted — other types are rejected
+ * with a notification. Player drops also need open / unlocked / proximity.
+ *
+ * @param {object} ctx
+ * @param {Actor} ctx.actor - The interactive container actor.
+ * @param {Application} ctx.app - The rendered container item sheet.
+ * @param {HTMLElement} ctx.html - The sheet's root element.
+ */
+function _installContainerSheetItemDrop({ actor, app, html }) {
+  const adapter = getAdapter();
+  // dnd5e's own sheet drop hook handles this case; bail to avoid double-handling.
+  if (adapter.capabilities.hasItemDropSheetHook) return;
+  if (!isInteractiveContainer(actor)) return;
+
+  const destContainerItem = app.item;
+  if (!destContainerItem || !adapter.isContainerItem(destContainerItem)) return;
+
+  if (html.dataset.iiItemDropAttached) return;
+  html.dataset.iiItemDropAttached = "1";
+
+  html.addEventListener("drop", async (event) => {
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    if (data?.type !== "Item") return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const droppedItem = await fromUuid(data.uuid);
+    if (!droppedItem) {
+      dbg("place:_installContainerSheetItemDrop", "could not resolve dropped item", { uuid: data.uuid });
+      return;
+    }
+
+    if (!adapter.isPhysicalItem(droppedItem)) {
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotPhysical"));
+      return;
+    }
+    if (adapter.isContainerItem(droppedItem)) {
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoContainerInContainer"));
+      return;
+    }
+
+    if (isPlayerView() && !validateContainerAccess(actor, { checkOpen: true })) return;
+
+    // Only the GM can write to actors players don't own; route through the
+    // socket on the player path so the active GM creates the embedded item.
+    if (!game.user.isGM) {
+      // Fallback: ask GM via socket. For now players can't deposit on the
+      // sheet directly — this can be wired through gmDispatch later if needed.
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotPhysical"));
+      return;
+    }
+
+    const itemData = droppedItem.toObject();
+    delete itemData._id;
+    adapter.setItemContainerId(itemData, destContainerItem.id);
+
+    try {
+      await CONFIG.Item.documentClass.createDocuments([itemData], { parent: actor, keepId: false });
+      // Move semantics — if the drag had a source actor, remove the original
+      // so quantities don't double up. World items (no parent actor) and items
+      // already on this container actor are left alone.
+      if (droppedItem.actor && droppedItem.actor.id !== actor.id) {
+        await droppedItem.delete();
+      }
+      ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Notify.Deposited", { name: itemData.name }));
+    } catch (err) {
+      console.error("pick-up-stix | failed to deposit item on container sheet:", err);
+    }
+  });
+}
+
 function _installContainerSheetActorDrop({ actor, app, html }) {
   const destContainerItem = app.item;
   // Delegate item-type check to the adapter so the literal "container" is not
@@ -654,18 +737,16 @@ function _hideContainerSheetContents({ actor, app, html }) {
 
 /**
  * Inject a "Contents" tab into the system's container item-sheet between the
- * native Description and Details tabs. The tab body is intentionally blank
- * for now — a follow-up will populate it with the deposited inventory.
+ * native Description and Details tabs, then render deposited inventory rows
+ * inside it. Targets pf2e's tab markup (`<nav class="sheet-tabs">
+ * <div class="tabs" data-tab-container="primary">`); the function no-ops on
+ * dnd5e (which has no matching selector) so the native dnd5e contents grid is
+ * untouched.
  *
- * Targets pf2e's tab markup (`<nav class="sheet-tabs"><div class="tabs"
- * data-tab-container="primary"><a class="list-row" data-tab="...">`). On
- * dnd5e ContainerSheet that selector chain doesn't match, so the function
- * no-ops and the dnd5e contents grid is left untouched.
- *
- * Idempotent — checks for an existing `[data-tab="ii-contents"]` before
- * injecting so re-renders don't stack duplicates. The system's own Foundry
- * `Tabs` instance picks up the new nav item automatically because
- * `Tabs.activate` queries the live DOM (`querySelectorAll("[data-tab]")`).
+ * The nav link and section element are created once and reused on re-render
+ * so Foundry's Tabs controller doesn't lose its `.active` state. The row
+ * list inside the section is rebuilt every render so items added/removed via
+ * createItem/deleteItem hooks reflect immediately.
  *
  * @param {object} ctx
  * @param {Actor} ctx.actor - The interactive container actor owning the container item.
@@ -699,15 +780,161 @@ function _injectContainerContentsTab({ actor, app, html }) {
   const sheetBody = root.querySelector('.sheet-body');
   if (!sheetBody) return;
 
-  // Inject the matching content section if absent. The body remains empty —
-  // populated later when contents UX is implemented.
-  if (!sheetBody.querySelector('section.tab[data-tab="ii-contents"]')) {
+  // Reuse the section element across re-renders so Foundry's Tabs controller
+  // keeps tracking `.active` on it; only the inner row list is rebuilt.
+  let section = sheetBody.querySelector('section.tab[data-tab="ii-contents"]');
+  if (!section) {
     const descriptionSection = sheetBody.querySelector('section.tab[data-tab="description"]');
-    const section = document.createElement("section");
+    section = document.createElement("section");
     section.className = "tab ii-contents";
     section.dataset.tab = "ii-contents";
     descriptionSection?.after(section);
   }
+
+  _renderContainerContents(section, actor, app.item);
+}
+
+/**
+ * Build (or rebuild) the deposited-items list inside the Contents tab. Reads
+ * the live actor inventory and emits one row per child item whose
+ * `containerId` matches the wrapped container item.
+ *
+ * Row layout mirrors the pf2e inventory line: image, name, quantity, bulk,
+ * lock / identify / configure / delete controls. Controls have no behaviour
+ * yet — they're rendered for visual parity only.
+ *
+ * @param {HTMLElement} section - The `<section data-tab="ii-contents">` to fill.
+ * @param {Actor} actor - The interactive container actor.
+ * @param {Item} containerItem - The embedded backpack item whose id is the parent pointer.
+ */
+function _renderContainerContents(section, actor, containerItem) {
+  const adapter = getAdapter();
+  section.replaceChildren();
+
+  const containedItems = actor.items.filter(i => {
+    if (i.id === containerItem.id) return false;
+    return adapter.getItemContainerId(i) === containerItem.id;
+  });
+
+  const list = document.createElement("ol");
+  list.className = "ii-contents-list";
+
+  if (containedItems.length === 0) {
+    const empty = document.createElement("li");
+    empty.className = "ii-contents-empty";
+    empty.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Container.Empty");
+    list.append(empty);
+    section.append(list);
+    return;
+  }
+
+  for (const item of containedItems) {
+    list.append(_buildContainerContentRow(item, adapter));
+  }
+  section.append(list);
+}
+
+/**
+ * Build one inventory-style row representing an item inside the container.
+ * Icons (lock / identify / configure / delete) are decorative for now — the
+ * caller wires no click handlers per the current spec.
+ *
+ * @param {Item} item
+ * @param {SystemAdapter} adapter
+ * @returns {HTMLLIElement}
+ */
+function _buildContainerContentRow(item, adapter) {
+  const row = document.createElement("li");
+  row.className = "ii-contents-row";
+  row.dataset.itemId = item.id;
+  row.dataset.itemUuid = item.uuid;
+
+  const img = document.createElement("img");
+  img.className = "ii-contents-img";
+  img.src = item.img;
+  img.alt = item.name;
+  row.append(img);
+
+  const name = document.createElement("span");
+  name.className = "ii-contents-name";
+  name.textContent = item.name;
+  row.append(name);
+
+  const quantity = document.createElement("span");
+  quantity.className = "ii-contents-quantity";
+  // pf2e physical items expose `system.quantity` (number); some types may
+  // expose `{ value }` (legacy). Read both shapes defensively.
+  const q = item.system?.quantity;
+  quantity.textContent = (typeof q === "object" ? q?.value : q) ?? 1;
+  row.append(quantity);
+
+  const bulk = document.createElement("span");
+  bulk.className = "ii-contents-bulk";
+  bulk.textContent = _formatItemBulk(item);
+  row.append(bulk);
+
+  const controls = document.createElement("span");
+  controls.className = "ii-contents-controls";
+
+  // Lock / identify / config / delete — visual only for now. Lock and identify
+  // reflect the live state on the item; config/delete are static glyphs.
+  const isLocked = !!item.flags?.["pick-up-stix"]?.tokenState?.system?.isLocked;
+  controls.append(_buildContentRowControl(
+    isLocked ? "fa-lock" : "fa-lock-open",
+    "INTERACTIVE_ITEMS.Sheet." + (isLocked ? "StateLocked" : "StateUnlocked")
+  ));
+
+  const isIdentified = adapter.isItemIdentified(item);
+  const identCfg = adapter.getIdentifyButtonConfig(isIdentified);
+  const identIcon = isIdentified ? identCfg.iconOn : identCfg.iconOff;
+  const identFamily = isIdentified
+    ? (identCfg.iconFamilyOn ?? "fa-solid")
+    : (identCfg.iconFamilyOff ?? "fa-solid");
+  controls.append(_buildContentRowControl(
+    identIcon,
+    isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey,
+    identFamily
+  ));
+
+  controls.append(_buildContentRowControl("fa-gear", "INTERACTIVE_ITEMS.Sheet.ConfigureHUD"));
+  controls.append(_buildContentRowControl("fa-trash", "INTERACTIVE_ITEMS.Sheet.DeleteItem"));
+
+  row.append(controls);
+  return row;
+}
+
+/**
+ * Build a single inventory-row control glyph (anchor with FontAwesome icon).
+ *
+ * @param {string} icon - FontAwesome icon class (e.g. `fa-lock`).
+ * @param {string} tooltipKey - i18n key for the hover tooltip.
+ * @param {string} [family="fa-solid"] - FontAwesome family class.
+ * @returns {HTMLAnchorElement}
+ */
+function _buildContentRowControl(icon, tooltipKey, family = "fa-solid") {
+  const a = document.createElement("a");
+  a.className = "ii-contents-control";
+  const tooltip = game.i18n.localize(tooltipKey);
+  a.dataset.tooltip = tooltip;
+  a.setAttribute("aria-label", tooltip);
+  a.innerHTML = `<i class="${family} ${icon}"></i>`;
+  return a;
+}
+
+/**
+ * Format an item's bulk for display. pf2e uses `system.bulk.value` where 0
+ * means negligible and 0.1 means light ("L" in the rules). Numbers >= 1 are
+ * displayed as integers.
+ *
+ * @param {Item} item
+ * @returns {string}
+ */
+function _formatItemBulk(item) {
+  const v = item.system?.bulk?.value;
+  if (v == null) return "—";
+  if (v === 0) return "—";
+  if (v < 1) return "L";
+  return String(v);
 }
 
 /**

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -722,12 +722,22 @@ function _hideContainerSheetContents({ actor, app, html }) {
 
   if (actor.system.isOpen && checkProximity(actor, { silent: true, range: "interaction" })) return;
 
-  const list = html.querySelector('section.inventory.tab[data-tab="contents"] .items-list');
-  if (!list) return;
+  const tab = html.querySelector('section.inventory.tab[data-tab="contents"]');
+  if (!tab) return;
 
   const message = actor.system.isOpen
     ? game.i18n.localize("INTERACTIVE_ITEMS.Container.ContentsHidden")
     : game.i18n.localize("INTERACTIVE_ITEMS.Notify.ContainerClosed");
+
+  // dnd5e contents tab also exposes a treasure/currency row and a
+  // search/filter/sort bar above the items list — both leak inventory
+  // information when the player is out of interaction range, so hide them
+  // alongside the items grid.
+  tab.querySelector('section.currency')?.remove();
+  tab.querySelector('.middle')?.remove();
+
+  const list = tab.querySelector('.items-list');
+  if (!list) return;
 
   list.replaceChildren();
   const placeholder = document.createElement("div");

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -380,7 +380,7 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   // Remove any existing module toggles so the rebuild produces a stable order.
   // The native identify button (if any) is intentionally NOT in this list —
   // we relocate it into the canonical slot below rather than recreating it.
-  header.querySelectorAll(".ii-open-toggle-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-configure-btn")
+  header.querySelectorAll(".ii-open-toggle-btn, .ii-pickup-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-configure-btn")
     .forEach(el => el.remove());
 
   const adapter = getAdapter();
@@ -415,7 +415,28 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
     // Pickup glyph — token-only (synthetic actor). The base actor sheet in the
     // sidebar wraps the *template* and isn't a thing you can "pick up", so the
     // icon is suppressed there. No behaviour wired yet — visual placeholder.
-    if (configActor.isToken) {
+    //
+    // Detect the token case via several fallbacks: pf2e's synthetic actor
+    // resolution can yield references whose getter side-effects (`isToken`)
+    // haven't fired yet by the time the render hook runs, so we also check
+    // `actor.token`, `actor.parent` document type, and `app.token` directly.
+    const isTokenActor = !!(
+      configActor.isToken
+      ?? configActor.token
+      ?? (configActor.parent && configActor.parent.documentName === "Token")
+      ?? app?.token
+    );
+    dbg("inject:headerControls", {
+      actorName: configActor.name,
+      actorType: configActor.type,
+      isContainer: sys.isContainer,
+      isTokenViaIsToken: configActor.isToken,
+      isTokenViaToken: !!configActor.token,
+      parentDoc: configActor.parent?.documentName,
+      appHasToken: !!app?.token,
+      resolvedIsTokenActor: isTokenActor
+    });
+    if (isTokenActor) {
       orderedNodes.push(createAdapterHeaderButton({
         adapter,
         extraClass: "ii-pickup-btn",

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -854,6 +854,24 @@ function _renderContainerContents(section, actor, containerItem) {
   const adapter = getAdapter();
   section.replaceChildren();
 
+  // Mirror the dnd5e contents-hiding gate (`_hideContainerSheetContents`):
+  // non-GM viewers see a placeholder when the container is closed/locked OR
+  // when they're outside interaction range. The sheet remains accessible
+  // for description/details viewing as long as they're within inspection range.
+  if (!isModuleGM()) {
+    const open = actor.system.isOpen;
+    const inRange = checkProximity(actor, { silent: true, range: "interaction" });
+    if (!open || !inRange) {
+      const placeholder = document.createElement("div");
+      placeholder.className = "pick-up-stix-contents-hidden";
+      placeholder.textContent = open
+        ? game.i18n.localize("INTERACTIVE_ITEMS.Container.ContentsHidden")
+        : game.i18n.localize("INTERACTIVE_ITEMS.Notify.ContainerClosed");
+      section.append(placeholder);
+      return;
+    }
+  }
+
   const containedItems = actor.items.filter(i => {
     if (i.id === containerItem.id) return false;
     return adapter.getItemContainerId(i) === containerItem.id;
@@ -2093,7 +2111,14 @@ async function _deleteInteractiveActors(folderId, { ephemeralOnly = false } = {}
 }
 
 function _reevaluateInteractiveProximity() {
-  for (const app of foundry.applications.instances.values()) {
+  // Walk both registries so V1 sheets (pf2e ContainerSheetPF2e, native item
+  // sheets) close and re-render alongside V2 sheets (dnd5e ContainerSheet).
+  // Item-document sheets resolve their interactive actor via app.item?.actor.
+  const apps = [
+    ...Object.values(ui.windows ?? {}),
+    ...foundry.applications.instances.values()
+  ];
+  for (const app of apps) {
     if (!app.rendered) continue;
     const interactiveActor = app.actor ?? app.item?.actor ?? app.document?.actor;
     if (!isInteractiveActor(interactiveActor)) continue;

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -13,7 +13,7 @@ import { dispatchGM } from "./utils/gmDispatch.mjs";
 import { notifyItemAction } from "./utils/notify.mjs";
 import { validateContainerAccess, validateItemAccess } from "./utils/containerAccess.mjs";
 import { resolvePickupTarget } from "./utils/pickupFlow.mjs";
-import { createStateToggleButton, insertHeaderButton, createRowControl } from "./utils/domButtons.mjs";
+import { createStateToggleButton, createAdapterHeaderButton, insertHeaderButton, createRowControl } from "./utils/domButtons.mjs";
 import { dbg } from "./utils/debugLog.mjs";
 import { findCanvasDropTargets } from "./utils/canvasDropTargets.mjs";
 import { isModuleGM, isPlayerView } from "./utils/playerView.mjs";
@@ -325,10 +325,12 @@ function _injectItemSheetHeaderControls({ app, html }) {
   html.querySelector(".mode-slider")?.remove();
   const closeBtn = header.querySelector("button.close, a.close, [data-action='close']");
 
-  header.querySelector(".ii-identify-toggle-btn")?.remove();
   const _adapter = getAdapter();
+
+  header.querySelector(".ii-identify-toggle-btn")?.remove();
   const identCfg = _adapter.getIdentifyButtonConfig(configActor.system.isIdentified);
-  const identifyToggle = createStateToggleButton({
+  const identifyToggle = createAdapterHeaderButton({
+    adapter: _adapter,
     extraClass: "ii-identify-toggle-btn",
     active: configActor.system.isIdentified,
     iconOn: identCfg.iconOn,
@@ -349,7 +351,8 @@ function _injectItemSheetHeaderControls({ app, html }) {
   insertHeaderButton(header, identifyToggle, closeBtn);
 
   header.querySelector(".ii-lock-toggle-btn")?.remove();
-  const lockToggle = createStateToggleButton({
+  const lockToggle = createAdapterHeaderButton({
+    adapter: _adapter,
     extraClass: "ii-lock-toggle-btn",
     active: configActor.system.isLocked,
     iconOn: "fa-lock",
@@ -364,19 +367,19 @@ function _injectItemSheetHeaderControls({ app, html }) {
   insertHeaderButton(header, lockToggle, closeBtn);
 
   if (!header.querySelector(".ii-configure-btn")) {
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "header-control-button ii-configure-btn";
-    btn.dataset.tooltip = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.ConfigureHUD");
-    btn.innerHTML = '<i class="fa-solid fa-gear"></i>';
-    btn.addEventListener("click", async (ev) => {
-      ev.preventDefault();
-      await app.close();
-      configActor.sheet.renderConfig();
+    const cfgBtn = createAdapterHeaderButton({
+      adapter: _adapter,
+      kind: "config",
+      extraClass: "ii-configure-btn",
+      iconOn: "fa-gear",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        await app.close();
+        configActor.sheet.renderConfig();
+      }
     });
-
-    if (closeBtn) closeBtn.before(btn);
-    else header.appendChild(btn);
+    insertHeaderButton(header, cfgBtn, closeBtn);
   }
 }
 
@@ -398,10 +401,13 @@ function _injectContainerSheetHeaderControls({ actor, app, html }) {
   html.querySelector(".mode-slider")?.remove();
   const closeBtn = header.querySelector("button.close, a.close, [data-action='close']");
 
+  const _adapter = getAdapter();
+
   // Remove existing to refresh state on re-render.
   header.querySelector(".ii-open-toggle-btn")?.remove();
 
-  const openBtn = createStateToggleButton({
+  const openBtn = createAdapterHeaderButton({
+    adapter: _adapter,
     extraClass: "ii-open-toggle-btn",
     active: actor.system.isOpen,
     iconOn: "fa-box-open",
@@ -416,7 +422,8 @@ function _injectContainerSheetHeaderControls({ actor, app, html }) {
   insertHeaderButton(header, openBtn, closeBtn);
 
   header.querySelector(".ii-lock-toggle-btn")?.remove();
-  const lockBtn = createStateToggleButton({
+  const lockBtn = createAdapterHeaderButton({
+    adapter: _adapter,
     extraClass: "ii-lock-toggle-btn",
     active: actor.system.isLocked,
     iconOn: "fa-lock",
@@ -431,19 +438,19 @@ function _injectContainerSheetHeaderControls({ actor, app, html }) {
   insertHeaderButton(header, lockBtn, closeBtn);
 
   if (!header.querySelector(".ii-configure-btn")) {
-    const cfgBtn = document.createElement("button");
-    cfgBtn.type = "button";
-    cfgBtn.className = "header-control-button ii-configure-btn";
-    cfgBtn.dataset.tooltip = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.ConfigureHUD");
-    cfgBtn.innerHTML = '<i class="fa-solid fa-gear"></i>';
-    cfgBtn.addEventListener("click", async (ev) => {
-      ev.preventDefault();
-      await app.close();
-      actor.sheet.renderConfig();
+    const cfgBtn = createAdapterHeaderButton({
+      adapter: _adapter,
+      kind: "config",
+      extraClass: "ii-configure-btn",
+      iconOn: "fa-gear",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        await app.close();
+        actor.sheet.renderConfig();
+      }
     });
-
-    if (closeBtn) closeBtn.before(cfgBtn);
-    else header.appendChild(cfgBtn);
+    insertHeaderButton(header, cfgBtn, closeBtn);
   }
 }
 

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -320,9 +320,21 @@ function _injectItemSheetHeaderControls({ app, html }) {
   }
   if (!configActor) return;
 
-  const header = html.querySelector(".window-header");
+  // Foundry V1 fires the render hook with the *inner* (.window-content) HTML
+  // on re-render, so `.window-header` lives outside of it. Fall back to the
+  // app's own root element (V1: `app.element[0]`, V2: `app.element`) so the
+  // header is reachable on every render — not just the initial one.
+  let header = html?.querySelector?.(".window-header") ?? null;
+  if (!header) {
+    const root = app.element instanceof HTMLElement
+      ? app.element
+      : app.element?.[0] ?? null;
+    header = root?.querySelector?.(".window-header") ?? null;
+  }
   if (!header) return;
-  html.querySelector(".mode-slider")?.remove();
+  // mode-slider is a dnd5e-only header control inside the inner content; safe
+  // best-effort removal regardless of whether `html` is the inner or full root.
+  html?.querySelector?.(".mode-slider")?.remove();
   const closeBtn = header.querySelector("button.close, a.close, [data-action='close']");
 
   const _adapter = getAdapter();
@@ -1172,11 +1184,15 @@ Hooks.on("updateActor", (actor, changes) => {
 Hooks.on("updateActor", (actor, changes) => {
   if (!isInteractiveActor(actor)) return;
   const sys = changes.system ?? {};
-  if (!("isLocked" in sys) && !("isOpen" in sys)) {
-    dbg("hook:updateActor:rerender", { name: actor.name }, "no isLocked/isOpen change, bail");
+  // isIdentified must be in this set too — pf2e item/container sheets and our
+  // own config sheet inject identify toggles whose icon and tooltip have to
+  // refresh after a Mystify/Identify action; otherwise the visual stays stale
+  // even though the underlying data updated correctly.
+  if (!("isLocked" in sys) && !("isOpen" in sys) && !("isIdentified" in sys)) {
+    dbg("hook:updateActor:rerender", { name: actor.name }, "no isLocked/isOpen/isIdentified change, bail");
     return;
   }
-  dbg("hook:updateActor:rerender", { name: actor.name, id: actor.id, isLocked: sys.isLocked, isOpen: sys.isOpen, sheetRendered: !!actor.system.embeddedItem?.sheet?.rendered });
+  dbg("hook:updateActor:rerender", { name: actor.name, id: actor.id, isLocked: sys.isLocked, isOpen: sys.isOpen, isIdentified: sys.isIdentified, sheetRendered: !!actor.system.embeddedItem?.sheet?.rendered });
 
   // Re-render the embedded item's native sheet (dnd5e ContainerSheet / pf2e item sheets).
   const item = actor.system.embeddedItem;

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -447,7 +447,9 @@ Hooks.once("init", async () => {
   // this separate listener on the ContainerSheet.
   Hooks.on("renderContainerSheet", (app, html) => {
     const destContainerItem = app.item;
-    if (!destContainerItem || destContainerItem.type !== "container") return;
+    // Delegate item-type check to the adapter so the literal "container" is not
+    // hard-coded to the dnd5e vocabulary.
+    if (!destContainerItem || !getAdapter().isContainerItem(destContainerItem)) return;
 
     if (html.dataset.iiActorDropAttached) return;
     html.dataset.iiActorDropAttached = "1";
@@ -480,8 +482,9 @@ Hooks.once("init", async () => {
         return;
       }
 
-      itemData.system = itemData.system ?? {};
-      itemData.system.container = destContainerItem.id;
+      // Delegate container-parent field write to the adapter so the field path
+      // is not hard-coded to dnd5e's `system.container`.
+      getAdapter().setItemContainerId(itemData, destContainerItem.id);
 
       if (destActor) {
         await CONFIG.Item.documentClass.createDocuments([itemData], { parent: destActor, keepId: false });
@@ -825,10 +828,10 @@ Hooks.on("createActor", async (actor, options, userId) => {
   });
 
   if (actor.getFlag(MODULE_ID, "containerDefault")) {
-    if (!actor.items.some(i => i.type === "container")) {
-      // Use the adapter to stamp the identification field so the field path is
-      // not hard-coded to dnd5e's `system.identified` boolean.
-      const containerData = { name: actor.name, type: "container", img: actor.img };
+    if (!actor.items.some(i => getAdapter().isContainerItem(i))) {
+      // Use the adapter for both item type and identification field so neither
+      // is hard-coded to the dnd5e vocabulary or `system.identified` boolean.
+      const containerData = { name: actor.name, type: getAdapter().containerItemType, img: actor.img };
       getAdapter().stampNewItemIdentified(containerData, true);
       await actor.createEmbeddedDocuments("Item", [containerData]);
     }
@@ -861,9 +864,9 @@ Hooks.on("createActor", async (actor, options, userId) => {
       "system.openImage": openImg,
       [`flags.${MODULE_ID}.containerDefault`]: true
     });
-    // Use the adapter to stamp the identification field so the field path is
-    // not hard-coded to dnd5e's `system.identified` boolean.
-    const containerData = { name: actor.name, type: "container", img: closedImg };
+    // Use the adapter for both item type and identification field so neither
+    // is hard-coded to the dnd5e vocabulary or `system.identified` boolean.
+    const containerData = { name: actor.name, type: getAdapter().containerItemType, img: closedImg };
     getAdapter().stampNewItemIdentified(containerData, true);
     await actor.createEmbeddedDocuments("Item", [containerData]);
     actor.sheet?.render({ force: true });

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -1,4 +1,4 @@
-import { loadAdapter } from "./adapter/index.mjs";
+import { loadAdapter, getAdapter } from "./adapter/index.mjs";
 import InteractiveItemModel from "./models/InteractiveItemModel.mjs";
 import InteractiveItemSheet from "./sheets/InteractiveItemSheet.mjs";
 import { registerTokenHUD } from "./hud/InteractiveTokenHUD.mjs";
@@ -212,7 +212,7 @@ Hooks.once("init", async () => {
 
       const isIdentified = isItemIdentified(item);
       const toggle = document.createElement("a");
-      toggle.className = "pick-up-stix-identify-toggle ii-row-control";
+      toggle.className = `pick-up-stix-identify-toggle ii-row-control${isIdentified ? " active" : ""}`;
       toggle.title = game.i18n.localize(isIdentified
         ? "INTERACTIVE_ITEMS.Context.HideItem"
         : "INTERACTIVE_ITEMS.Context.RevealItem");
@@ -826,12 +826,11 @@ Hooks.on("createActor", async (actor, options, userId) => {
 
   if (actor.getFlag(MODULE_ID, "containerDefault")) {
     if (!actor.items.some(i => i.type === "container")) {
-      await actor.createEmbeddedDocuments("Item", [{
-        name: actor.name,
-        type: "container",
-        img: actor.img,
-        system: { identified: true }
-      }]);
+      // Use the adapter to stamp the identification field so the field path is
+      // not hard-coded to dnd5e's `system.identified` boolean.
+      const containerData = { name: actor.name, type: "container", img: actor.img };
+      getAdapter().stampNewItemIdentified(containerData, true);
+      await actor.createEmbeddedDocuments("Item", [containerData]);
     }
     return;
   }
@@ -862,12 +861,11 @@ Hooks.on("createActor", async (actor, options, userId) => {
       "system.openImage": openImg,
       [`flags.${MODULE_ID}.containerDefault`]: true
     });
-    await actor.createEmbeddedDocuments("Item", [{
-      name: actor.name,
-      type: "container",
-      img: closedImg,
-      system: { identified: true }
-    }]);
+    // Use the adapter to stamp the identification field so the field path is
+    // not hard-coded to dnd5e's `system.identified` boolean.
+    const containerData = { name: actor.name, type: "container", img: closedImg };
+    getAdapter().stampNewItemIdentified(containerData, true);
+    await actor.createEmbeddedDocuments("Item", [containerData]);
     actor.sheet?.render({ force: true });
   } else if (result === "item") {
     await actor.setFlag(MODULE_ID, "createKindConfirmed", true);
@@ -953,36 +951,19 @@ Hooks.on("updateActor", async (actor, changes, options, userId) => {
     });
 
     if (embeddedItem && (identifiedChanged || unidentifiedNameChanged || descChanged || unidentifiedDescChanged || nameChanged)) {
-      if ("identified" in (embeddedItem.system ?? {})) {
-        const itemUpdates = {};
+      // Build the system-specific update payload via the adapter so the field
+      // paths are not hard-coded to dnd5e's `system.identified` / `system.unidentified.*`.
+      const itemUpdates = getAdapter().buildItemIdentificationUpdate(actor, systemChanges);
+      if (nameChanged) {
+        itemUpdates.name = actor.name;
+      }
 
-        if (identifiedChanged) {
-          itemUpdates["system.identified"] = actor.system.isIdentified;
-        }
-        if (nameChanged) {
-          itemUpdates.name = actor.name;
-        }
-        if (unidentifiedNameChanged) {
-          itemUpdates["system.unidentified.name"] = actor.system.unidentifiedName || "";
-        }
-        // system.description is the identified description — syncs to item's description.value
-        if (descChanged) {
-          itemUpdates["system.description.value"] = actor.system.description || "";
-        }
-        // system.unidentifiedDescription → item's unidentified.description
-        if (unidentifiedDescChanged) {
-          itemUpdates["system.unidentified.description"] = actor.system.unidentifiedDescription || "";
-        }
-
-        if (Object.keys(itemUpdates).length > 0) {
-          dbg("hook:updateActor", "updating embeddedItem fields", { embeddedItemId: embeddedItem.id, itemUpdates });
-          await embeddedItem.update(itemUpdates);
-          if (embeddedItem.sheet?.rendered) embeddedItem.sheet.render();
-        } else {
-          dbg("hook:updateActor", "no item field changes needed");
-        }
+      if (Object.keys(itemUpdates).length > 0) {
+        dbg("hook:updateActor", "updating embeddedItem fields", { embeddedItemId: embeddedItem.id, itemUpdates });
+        await embeddedItem.update(itemUpdates);
+        if (embeddedItem.sheet?.rendered) embeddedItem.sheet.render();
       } else {
-        dbg("hook:updateActor", "embeddedItem has no identified field, skipping field sync");
+        dbg("hook:updateActor", "no item field changes needed");
       }
     } else if (!embeddedItem) {
       dbg("hook:updateActor", "no embeddedItem found, skipping field sync");
@@ -1099,7 +1080,9 @@ Hooks.on("updateItem", async (item, changes, options, userId) => {
     return;
   }
 
-  const newIdentified = item.system.identified !== false;
+  // Read identification state through the adapter so the field path is not
+  // hard-coded to dnd5e's `system.identified` boolean.
+  const newIdentified = getAdapter().isItemIdentified(item);
   const isContainer = actor.system.isContainer;
 
   dbg("hook:updateItem", "processing identification change", {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -429,6 +429,7 @@ Hooks.once("init", async () => {
           target.appendChild(createRowControl({
             iconClass: "fa-solid fa-wand-sparkles",
             titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleIdentified",
+            active: getAdapter().isItemIdentified(item),
             onClick: async () => { await toggleItemIdentification(item); }
           }));
         }

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -177,6 +177,7 @@ Hooks.once("init", async () => {
     maybeHideContents: _hideContainerSheetContents,
     installActorDropListener: _installContainerSheetActorDrop,
     injectItemRowControls: _injectContainerSheetRowControls,
+    injectContentsTab: _injectContainerContentsTab,
   });
 
   Hooks.on("dropActorSheetData", (actor, sheet, data) => {
@@ -649,6 +650,64 @@ function _hideContainerSheetContents({ actor, app, html }) {
   placeholder.className = "pick-up-stix-contents-hidden";
   placeholder.textContent = message;
   list.append(placeholder);
+}
+
+/**
+ * Inject a "Contents" tab into the system's container item-sheet between the
+ * native Description and Details tabs. The tab body is intentionally blank
+ * for now — a follow-up will populate it with the deposited inventory.
+ *
+ * Targets pf2e's tab markup (`<nav class="sheet-tabs"><div class="tabs"
+ * data-tab-container="primary"><a class="list-row" data-tab="...">`). On
+ * dnd5e ContainerSheet that selector chain doesn't match, so the function
+ * no-ops and the dnd5e contents grid is left untouched.
+ *
+ * Idempotent — checks for an existing `[data-tab="ii-contents"]` before
+ * injecting so re-renders don't stack duplicates. The system's own Foundry
+ * `Tabs` instance picks up the new nav item automatically because
+ * `Tabs.activate` queries the live DOM (`querySelectorAll("[data-tab]")`).
+ *
+ * @param {object} ctx
+ * @param {Actor} ctx.actor - The interactive container actor owning the container item.
+ * @param {Application} ctx.app - The rendered container item sheet application.
+ * @param {HTMLElement} ctx.html - The sheet's root element (or inner content on V1 re-render).
+ */
+function _injectContainerContentsTab({ actor, app, html }) {
+  if (!isInteractiveContainer(actor)) return;
+
+  const root = _resolveSheetRoot(app, html);
+  if (!root) return;
+
+  // Locate pf2e's primary tabs container. dnd5e's ContainerSheet uses a
+  // different markup, so this selector failing means we're on a non-pf2e
+  // container view and we silently no-op.
+  const tabsNav = root.querySelector('.sheet-tabs .tabs[data-tab-container="primary"]');
+  if (!tabsNav) return;
+
+  const descriptionLink = tabsNav.querySelector('a[data-tab="description"]');
+  if (!descriptionLink) return;
+
+  // Inject the nav link if it isn't already present (idempotent across re-renders).
+  if (!tabsNav.querySelector('a[data-tab="ii-contents"]')) {
+    const link = document.createElement("a");
+    link.className = "list-row";
+    link.dataset.tab = "ii-contents";
+    link.textContent = game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Tab.Contents");
+    descriptionLink.after(link);
+  }
+
+  const sheetBody = root.querySelector('.sheet-body');
+  if (!sheetBody) return;
+
+  // Inject the matching content section if absent. The body remains empty —
+  // populated later when contents UX is implemented.
+  if (!sheetBody.querySelector('section.tab[data-tab="ii-contents"]')) {
+    const descriptionSection = sheetBody.querySelector('section.tab[data-tab="description"]');
+    const section = document.createElement("section");
+    section.className = "tab ii-contents";
+    section.dataset.tab = "ii-contents";
+    descriptionSection?.after(section);
+  }
 }
 
 /**

--- a/scripts/sheets/InteractiveItemSheet.mjs
+++ b/scripts/sheets/InteractiveItemSheet.mjs
@@ -398,10 +398,11 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
     const item = this.actor.system.embeddedItem;
     const adapter = getAdapter();
     const currentIdentified = item ? adapter.isItemIdentified(item) : undefined;
-    dbg("sheet:#onToggleIdentified", { actorName: this.actor?.name, embeddedItemId: item?.id, currentIdentified, newIdentified: !currentIdentified });
+    dbg("sheet:#onToggleIdentified", { actorName: this.actor?.name, embeddedItemId: item?.id, currentIdentified });
     if (!item || currentIdentified === undefined) return;
-    // Route through the adapter so the update targets the correct system field.
-    await adapter.setItemIdentified(item, !currentIdentified);
+    // Route through the adapter — pf2e opens an IdentifyPopup for unidentified
+    // items rather than flipping the flag directly.
+    await adapter.performIdentifyToggle(item);
   }
 
   static async #onToggleLock(event, target) {
@@ -450,13 +451,16 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       action: "toggleLock"
     }));
 
+    const identCfg = getAdapter().getIdentifyButtonConfig(system.isIdentified);
     buttons.push(createStateToggleButton({
       extraClass: "ii-config-toggle",
       active: system.isIdentified,
-      iconOn: "fa-wand-sparkles",
-      iconOff: "fa-wand-sparkles",
-      labelOnKey: "INTERACTIVE_ITEMS.Sheet.Identified",
-      labelOffKey: "INTERACTIVE_ITEMS.Sheet.Unidentified",
+      iconOn: identCfg.iconOn,
+      iconFamilyOn: identCfg.iconFamilyOn,
+      iconOff: identCfg.iconOff,
+      iconFamilyOff: identCfg.iconFamilyOff,
+      labelOnKey: identCfg.labelOnKey,
+      labelOffKey: identCfg.labelOffKey,
       action: "toggleIdentified"
     }));
 

--- a/scripts/sheets/InteractiveItemSheet.mjs
+++ b/scripts/sheets/InteractiveItemSheet.mjs
@@ -152,6 +152,13 @@ export default class InteractiveItemSheet extends ActorSheetV2 {
    * not meant to display.
    */
   async render(options = {}, _options = {}) {
+    // Foundry's sidebar / older callers pass `true` as the first positional
+    // arg (legacy AppV1 force flag). Normalise so downstream adapter methods
+    // always receive a plain object — pf2e's V1 sheet treats this slot as the
+    // mutable `options` bag and crashes on a boolean.
+    if (options === true) options = { force: true };
+    else if (typeof options !== "object" || options === null) options = {};
+
     dbg("sheet:render", {
       actorName: this.actor?.name,
       actorId: this.actor?.id,

--- a/scripts/sheets/InteractiveItemSheet.mjs
+++ b/scripts/sheets/InteractiveItemSheet.mjs
@@ -1,26 +1,47 @@
-import { checkProximity, setContainerOpen, toggleContainerLocked } from "../transfer/ItemTransfer.mjs";
+/**
+ * InteractiveItemSheet — registered actor sheet for `pick-up-stix.interactiveItem`.
+ *
+ * Acts as a system-agnostic dispatcher: never renders its own UI. On `render()`
+ * it routes to one of:
+ *   - `getAdapter().renderConfigSheet(actor)` — base actor click or `renderConfig()` call
+ *   - `getAdapter().renderContainerView(actor)` — token click on a container actor
+ *   - `getAdapter().renderItemView(actor)` — token click on an item-mode actor
+ *   - `showLimitedDialog(actor)` — non-GM player outside inspection range
+ *
+ * The actual config-form UI lives in adapter-owned sheet classes
+ * (`Dnd5eInteractiveItemConfigSheet` V2 / `Pf2eInteractiveItemConfigSheet` V1)
+ * so each system can use its own ApplicationV1/V2 conventions.
+ *
+ * Static helpers `pendingPicker`, `limitedDialogs`, `showLimitedDialog`,
+ * `refreshLimitedDialog`, `promoteLimitedDialogsInRange` are kept here because
+ * they're system-agnostic and called from elsewhere in the module.
+ */
+
+import { checkProximity } from "../transfer/ItemTransfer.mjs";
 import { getAdapter } from "../adapter/index.mjs";
-import { createStateToggleButton } from "../utils/domButtons.mjs";
 import { dbg } from "../utils/debugLog.mjs";
 import { isModuleGM, isPlayerView } from "../utils/playerView.mjs";
 
-const { HandlebarsApplicationMixin } = foundry.applications.api;
 const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;
 
-export default class InteractiveItemSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
+export default class InteractiveItemSheet extends ActorSheetV2 {
 
+  /** Actors with a kind-picker dialog open — suppress the auto-render flash. */
   static pendingPicker = new Set();
 
+  /** Open limited-view dialogs keyed by actor UUID. */
   static limitedDialogs = new Map();
 
+  /**
+   * Render the limited-view dialog for an actor that the viewer is too far
+   * away to inspect properly. Closes any existing dialog for the same actor
+   * before opening the new one.
+   */
   static async showLimitedDialog(actor) {
     dbg("sheet:showLimitedDialog", { actorName: actor.name, actorUuid: actor.uuid, isContainer: actor.system.isContainer });
     const key = actor.uuid;
     const existing = InteractiveItemSheet.limitedDialogs.get(key);
-    if (existing) {
-      dbg("sheet:showLimitedDialog", "closing existing dialog for actor", { actorUuid: key });
-      await existing.close();
-    }
+    if (existing) await existing.close();
 
     const system = actor.system;
     const title = system.limitedDisplayName;
@@ -50,13 +71,14 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
     await dialog.render({ force: true });
   }
 
+  /**
+   * Update the title and body of an open limited-view dialog without closing
+   * and re-opening it (avoids losing the user's window position).
+   */
   static async refreshLimitedDialog(actor) {
     dbg("sheet:refreshLimitedDialog", { actorName: actor.name, actorUuid: actor.uuid, hasDialog: InteractiveItemSheet.limitedDialogs.has(actor.uuid) });
     const dialog = InteractiveItemSheet.limitedDialogs.get(actor.uuid);
-    if (!dialog?.element) {
-      dbg("sheet:refreshLimitedDialog", "no active dialog to refresh");
-      return;
-    }
+    if (!dialog?.element) return;
 
     const titleEl = dialog.element.querySelector(".window-title");
     if (titleEl) titleEl.textContent = actor.system.limitedDisplayName;
@@ -70,6 +92,12 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
     }
   }
 
+  /**
+   * Walk every open limited-view dialog and promote it to the actor's real
+   * sheet if the viewer has moved into inspection range. Preserves the
+   * dialog's on-screen position so the new sheet appears in roughly the same
+   * spot.
+   */
   static async promoteLimitedDialogsInRange() {
     dbg("sheet:promoteLimitedDialogsInRange", { openDialogCount: InteractiveItemSheet.limitedDialogs.size });
     // Snapshot — dialog.close() mutates the Map during iteration.
@@ -78,7 +106,6 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       const actor = dialog.interactiveActor;
       if (!actor) continue;
       const inRange = checkProximity(actor, { silent: true, range: "inspection" });
-      dbg("sheet:promoteLimitedDialogsInRange", { actorName: actor.name, inRange });
       if (!inRange) continue;
 
       const rect = dialog.element?.getBoundingClientRect();
@@ -86,9 +113,6 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
 
       dialog.close();
 
-      // Open the embedded item's sheet via the adapter — bypasses our actor sheet
-      // gates which would re-block the render. The renderContainerSheet hook
-      // hides contents when the container is inaccessible.
       if (!actor.system.embeddedItem) continue;
       const renderedSheet = await getAdapter().renderEmbeddedSheet(actor, { force: true });
 
@@ -106,47 +130,27 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
     }
   }
 
+  /** True when the next render() should open the GM config sheet. */
   #configMode = false;
 
-  #editingDescriptionTarget = null;
-
-  #expandedSections = {};
-
   static DEFAULT_OPTIONS = {
-    classes: ["pick-up-stix", "interactive-item-sheet", "dnd5e2", "sheet", "item", "standard-form"],
-    position: { width: 400, height: "auto" },
-    window: { resizable: true },
-    form: { submitOnChange: true },
-    actions: {
-      openItemSheet: InteractiveItemSheet.#onOpenItemSheet,
-      openContainerSheet: InteractiveItemSheet.#onOpenContainerSheet,
-      editActorImage: InteractiveItemSheet.#onEditActorImage,
-      toggleOpen: InteractiveItemSheet.#onToggleOpen,
-      toggleIdentified: InteractiveItemSheet.#onToggleIdentified,
-      toggleLock: InteractiveItemSheet.#onToggleLock,
-      editDescription: InteractiveItemSheet.#onEditDescription,
-      toggleCollapsed: InteractiveItemSheet.#onToggleCollapsed
-    }
+    classes: ["pick-up-stix", "interactive-item-sheet-dispatcher"],
+    // Keep a tiny window footprint just in case Foundry forces a render of
+    // this dispatcher (it should never visually appear).
+    position: { width: 100, height: 100 },
+    window: { resizable: false }
   };
-
-  static PARTS = {
-    config: {
-      template: "modules/pick-up-stix/templates/item-config.hbs"
-    }
-  };
-
-  get title() {
-    return `${game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Configure")}: ${this.actor.system.displayName}`;
-  }
-
-  get containerItem() {
-    return this.actor.system.containerItem;
-  }
 
   get _tokenDoc() {
     return this.actor.token ?? null;
   }
 
+  /**
+   * Dispatch entry point. Inspects actor / mode / viewer state and routes to
+   * the correct adapter-owned sheet (config / container / item) or to the
+   * limited-view dialog. Never calls `super.render()` — this class itself is
+   * not meant to display.
+   */
   async render(options = {}, _options = {}) {
     dbg("sheet:render", {
       actorName: this.actor?.name,
@@ -173,9 +177,13 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       if (!hasMarker) return this;
     }
 
+    const adapter = getAdapter();
+
     if (this.#configMode || !this._tokenDoc) {
-      dbg("sheet:render", "config mode or base actor → rendering config form");
-      return super.render(options, _options);
+      dbg("sheet:render", "config mode or base actor → adapter.renderConfigSheet");
+      this.#configMode = false;
+      await adapter.renderConfigSheet(this.actor, options);
+      return this;
     }
 
     const system = this.actor.system;
@@ -186,10 +194,10 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
         InteractiveItemSheet.showLimitedDialog(this.actor);
         return this;
       }
-      const item = this.containerItem;
+      const item = system.containerItem;
       if (item) {
         dbg("sheet:render", "container: delegating to adapter.renderContainerView", { itemId: item.id, itemName: item.name });
-        await getAdapter().renderContainerView(this.actor, options);
+        await adapter.renderContainerView(this.actor, options);
         return this;
       }
     } else {
@@ -200,363 +208,26 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       }
       const item = this.actor.items.contents[0];
       if (item) {
-        dbg("sheet:render", "item: delegating to adapter.renderItemView", { itemId: item.id, itemName: item.name, itemImg: item.img });
-        await this.#syncItemImage(item);
-        await getAdapter().renderItemView(this.actor, options);
+        dbg("sheet:render", "item: delegating to adapter.renderItemView", { itemId: item.id, itemName: item.name });
+        await adapter.renderItemView(this.actor, options);
         return this;
       }
     }
 
-    dbg("sheet:render", "no embedded item → falling back to config form");
-    return super.render(options, _options);
+    dbg("sheet:render", "no embedded item → falling back to config sheet");
+    await adapter.renderConfigSheet(this.actor, options);
+    return this;
   }
 
-  async close(options = {}) {
-    dbg("sheet:close", { actorName: this.actor?.name, actorId: this.actor?.id, configMode: this.#configMode });
-    const actor = this.actor;
-    this.#configMode = false;
-    const result = await super.close(options);
-
-    // Item-kind actors abandoned in the picker (no item ever dropped) — delete.
-    const MODULE_ID = "pick-up-stix";
-    if (actor && game.actors.has(actor.id) && !actor.token && game.user.isGM
-      && actor.getFlag(MODULE_ID, "createKindConfirmed")
-      && actor.items.size === 0) {
-      await actor.delete();
-    }
-    return result;
-  }
-
+  /**
+   * Open the GM config sheet. Sets the dispatcher's #configMode flag so the
+   * subsequent render() call routes to `adapter.renderConfigSheet()` even when
+   * a token document is present (which would otherwise route to the system's
+   * native sheet).
+   */
   renderConfig() {
     dbg("sheet:renderConfig", { actorName: this.actor?.name, actorId: this.actor?.id });
     this.#configMode = true;
-    return super.render({ force: true });
-  }
-
-  async _prepareContext(options) {
-    const context = await super._prepareContext(options);
-    const system = this.actor.system;
-    context.actor = this.actor;
-    context.system = system;
-    context.isEditable = this.isEditable;
-    context.isContainer = system.isContainer;
-    context.needsItem = this.actor.items.size === 0 && !this._tokenDoc;
-    context.isIdentified = system.isIdentified;
-    context.displayName = system.displayName;
-
-    if (system.isContainer) {
-      const item = this.containerItem;
-      context.hasContainerItem = !!item;
-      context.containerName = system.resolveTokenName();
-      context.containerImg = (system.isOpen && system.openImage)
-        ? system.openImage
-        : (item?.img ?? this.actor.img);
-    } else {
-      const item = this.actor.items.contents[0];
-      context.hasItem = !!item;
-      context.itemName = system.resolveTokenName();
-      context.itemImg = system.resolveImage();
-    }
-
-    if (this.isEditable) {
-      context.source = this.actor._source;
-    }
-    context.editingDescriptionTarget = this.#editingDescriptionTarget;
-    context.expanded = this.#expandedSections;
-    context.descriptionEnriched = !!system.description;
-    context.unidentifiedDescriptionEnriched = !!system.unidentifiedDescription;
-    context.limitedDescriptionEnriched = !!system.limitedDescription;
-
-    if (this.#editingDescriptionTarget) {
-      const parts = this.#editingDescriptionTarget.split(".");
-      let value = this.actor._source;
-      for (const part of parts) value = value?.[part];
-      context.editingDescriptionValue = value ?? "";
-    }
-    return context;
-  }
-
-  _onRender(context, options) {
-    super._onRender(context, options);
-    this.element.querySelectorAll("prose-mirror").forEach(editor => {
-      editor.addEventListener("save", () => {
-        this.#editingDescriptionTarget = null;
-        this.render();
-      });
-    });
-
-    if (this.isEditable) {
-      const header = this.element.querySelector(".window-header");
-      if (header) {
-        const closeBtn = header.querySelector("button.close, [data-action='close']");
-        this.#injectHeaderToggles(header, closeBtn);
-      }
-    }
-  }
-
-  _canDragDrop(selector) {
-    return true;
-  }
-
-  _onDropStackConsumables() {
-    return null;
-  }
-
-  _prepareSubmitData(event, form, formData) {
-    const data = super._prepareSubmitData(event, form, formData);
-    dbg("sheet:_prepareSubmitData", {
-      incomingKeys: Object.keys(data),
-      imgInData: "img" in data,
-      dataImg: data.img,
-      actorImg: this.actor.img,
-      isIdentified: this.actor.system.isIdentified,
-      unidentifiedImage: this.actor.system.unidentifiedImage,
-      unidentifiedImageInData: "system.unidentifiedImage" in data
-    });
-    if (data.img && data.img !== this.actor.img) {
-      if (this.actor.system.isIdentified || !this.actor.system.unidentifiedImage) {
-        data["prototypeToken.texture.src"] = data.img;
-        dbg("sheet:_prepareSubmitData", "syncing prototypeToken.texture.src to new img", { src: data.img });
-      }
-    }
-    if ("system.unidentifiedImage" in data && !this.actor.system.isIdentified) {
-      const newUnidentifiedImage = data["system.unidentifiedImage"];
-      if (newUnidentifiedImage) {
-        data["prototypeToken.texture.src"] = newUnidentifiedImage;
-        dbg("sheet:_prepareSubmitData", "syncing prototypeToken.texture.src to unidentifiedImage", { src: newUnidentifiedImage });
-      } else {
-        data["prototypeToken.texture.src"] = data.img || this.actor.img;
-        dbg("sheet:_prepareSubmitData", "unidentifiedImage cleared, using actor img", { src: data["prototypeToken.texture.src"] });
-      }
-    }
-    dbg("sheet:_prepareSubmitData", "final submit keys", Object.keys(data));
-    return data;
-  }
-
-  static #onEditActorImage(event, target) {
-    dbg("sheet:#onEditActorImage", { actorName: this.actor?.name, currentImg: this.actor?.img });
-    event.preventDefault();
-    const fp = new foundry.applications.apps.FilePicker.implementation({
-      type: "image",
-      current: this.actor.img,
-      callback: (path) => {
-        dbg("sheet:#onEditActorImage:callback", { chosenPath: path, actorName: this.actor?.name });
-        this.actor.system.updateImage(path);
-      }
-    });
-    fp.render(true);
-  }
-
-  static async #onOpenItemSheet(event, target) {
-    const item = this.actor.items.contents[0];
-    if (!item) return;
-    await this.#syncItemImage(item);
-    await this.close();
-    await getAdapter().renderItemView(this.actor);
-  }
-
-  static async #onOpenContainerSheet(event, target) {
-    if (!this.containerItem) return;
-    await this.close();
-    await getAdapter().renderContainerView(this.actor);
-  }
-
-  async #syncItemImage(item) {
-    dbg("sheet:#syncItemImage", {
-      actorName: this.actor?.name,
-      itemName: item?.name,
-      itemImg: item?.img,
-      isGM: game.user.isGM
-    });
-    if (!game.user.isGM) {
-      dbg("sheet:#syncItemImage", "not GM, bail");
-      return;
-    }
-    const system = this.actor.system;
-    const expectedImg = system.resolveImage();
-    dbg("sheet:#syncItemImage", {
-      expectedImg,
-      isIdentified: system.isIdentified,
-      unidentifiedImage: system.unidentifiedImage,
-      actorImg: this.actor.img,
-      needsUpdate: item.img !== expectedImg
-    });
-    if (item.img !== expectedImg) {
-      dbg("sheet:#syncItemImage", "updating item.img", { from: item.img, to: expectedImg });
-      await item.update({ img: expectedImg });
-    } else {
-      dbg("sheet:#syncItemImage", "item.img already matches, no update needed");
-    }
-  }
-
-  static async #onToggleOpen(event, target) {
-    dbg("sheet:#onToggleOpen", { actorName: this.actor?.name, currentIsOpen: this.actor?.system?.isOpen, newIsOpen: !this.actor?.system?.isOpen });
-    await setContainerOpen(this.actor, !this.actor.system.isOpen);
-  }
-
-  static async #onToggleIdentified(event, target) {
-    const item = this.actor.system.embeddedItem;
-    const adapter = getAdapter();
-    const currentIdentified = item ? adapter.isItemIdentified(item) : undefined;
-    dbg("sheet:#onToggleIdentified", { actorName: this.actor?.name, embeddedItemId: item?.id, currentIdentified });
-    if (!item || currentIdentified === undefined) return;
-    // Route through the adapter — pf2e opens an IdentifyPopup for unidentified
-    // items rather than flipping the flag directly.
-    await adapter.performIdentifyToggle(item);
-  }
-
-  static async #onToggleLock(event, target) {
-    dbg("sheet:#onToggleLock", { actorName: this.actor?.name, currentIsLocked: this.actor?.system?.isLocked });
-    await toggleContainerLocked(this.actor);
-  }
-
-  static #onEditDescription(event, target) {
-    event.stopPropagation();
-    this.#editingDescriptionTarget = target.dataset.target;
-    this.render();
-  }
-
-  static #onToggleCollapsed(event, target) {
-    if (event.target.closest(".collapsible-content")) return;
-    const expandId = target.dataset.expandId;
-    if (expandId) this.#expandedSections[expandId] = !this.#expandedSections[expandId];
-    target.classList.toggle("collapsed");
-  }
-
-  #injectHeaderToggles(header, closeBtn) {
-    header.querySelectorAll(".ii-config-toggle").forEach(el => el.remove());
-
-    const system = this.actor.system;
-    const buttons = [];
-
-    if (system.isContainer) {
-      buttons.push(createStateToggleButton({
-        extraClass: "ii-config-toggle",
-        active: system.isOpen,
-        iconOn: "fa-box-open",
-        iconOff: "fa-box",
-        labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
-        labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
-        action: "toggleOpen"
-      }));
-    }
-
-    buttons.push(createStateToggleButton({
-      extraClass: "ii-config-toggle",
-      active: system.isLocked,
-      iconOn: "fa-lock",
-      iconOff: "fa-lock-open",
-      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
-      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
-      action: "toggleLock"
-    }));
-
-    const identCfg = getAdapter().getIdentifyButtonConfig(system.isIdentified);
-    buttons.push(createStateToggleButton({
-      extraClass: "ii-config-toggle",
-      active: system.isIdentified,
-      iconOn: identCfg.iconOn,
-      iconFamilyOn: identCfg.iconFamilyOn,
-      iconOff: identCfg.iconOff,
-      iconFamilyOff: identCfg.iconFamilyOff,
-      labelOnKey: identCfg.labelOnKey,
-      labelOffKey: identCfg.labelOffKey,
-      action: "toggleIdentified"
-    }));
-
-    if (closeBtn) closeBtn.before(...buttons);
-    else header.append(...buttons);
-  }
-
-  async _onDrop(event) {
-    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
-    dbg("sheet:_onDrop", { dataType: data.type, uuid: data.uuid });
-    if (data.type !== "Item") {
-      dbg("sheet:_onDrop", "not an Item drop, bail");
-      return;
-    }
-
-    const item = await fromUuid(data.uuid);
-    if (!item) {
-      dbg("sheet:_onDrop", "could not resolve item from uuid, bail", { uuid: data.uuid });
-      return;
-    }
-
-    dbg("sheet:_onDrop", "resolved dropped item", { itemName: item.name, itemImg: item.img, itemUuid: item.uuid, itemType: item.type });
-
-    if (!("quantity" in (item.system ?? {}))) {
-      dbg("sheet:_onDrop", "item is not a physical item (no quantity), bail");
-      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotPhysical"));
-      return;
-    }
-
-    if (!game.user.isGM) {
-      dbg("sheet:_onDrop", "not GM, bail");
-      return;
-    }
-
-    const adapter = getAdapter();
-    const itemData = item.toObject();
-    delete itemData._id;
-
-    // Stamp the item as identified before creation so the updateItem hook does
-    // not fire for this change while actor.img is still the old value.
-    // Route through the adapter so the correct system field is set.
-    adapter.stampNewItemIdentified(itemData, true);
-
-    // Interactive actors hold exactly one embedded item.
-    if (this.actor.items.size > 0) {
-      const ids = this.actor.items.map(i => i.id);
-      dbg("sheet:_onDrop", "clearing existing embedded items", { ids });
-      await this.actor.deleteEmbeddedDocuments("Item", ids);
-    }
-
-    // Update actor first so actor.img is correct before item hooks fire.
-    const updates = {
-      name: item.name,
-      img: item.img,
-      "prototypeToken.name": item.name,
-      "prototypeToken.texture.src": item.img
-    };
-    if (item.system.description?.value) {
-      updates["system.description"] = item.system.description.value;
-    }
-    // Read unidentified name/description through the adapter so the field path
-    // is not hard-coded to dnd5e's `system.unidentified.*` shape.
-    const droppedUnidentifiedName = adapter.getItemUnidentifiedName(item);
-    const droppedUnidentifiedDescription = adapter.getItemUnidentifiedDescription(item);
-    if (droppedUnidentifiedName) {
-      updates["system.unidentifiedName"] = droppedUnidentifiedName;
-    }
-    if (droppedUnidentifiedDescription) {
-      updates["system.unidentifiedDescription"] = droppedUnidentifiedDescription;
-    }
-    dbg("sheet:_onDrop", "firing actor.update with metadata", { updates });
-    await this.actor.update(updates);
-    dbg("sheet:_onDrop", "actor.update complete", { actorImg: this.actor.img });
-
-    dbg("sheet:_onDrop", "firing createEmbeddedDocuments", { itemDataImg: itemData.img });
-    const [createdItem] = await this.actor.createEmbeddedDocuments("Item", [itemData]);
-    dbg("sheet:_onDrop", "createEmbeddedDocuments complete", { createdItemId: createdItem?.id, createdItemImg: createdItem?.img });
-
-    if (createdItem) {
-      // Build the system-specific update payload for all identification fields via
-      // the adapter, using a synthetic "all fields present" changeset so every
-      // actor identification field is mirrored onto the newly embedded item.
-      const allIdentificationChanges = {
-        isIdentified: true,
-        unidentifiedName: this.actor.system.unidentifiedName,
-        description: this.actor.system.description,
-        unidentifiedDescription: this.actor.system.unidentifiedDescription
-      };
-      const itemUpdates = adapter.buildItemIdentificationUpdate(this.actor, allIdentificationChanges);
-      if (Object.keys(itemUpdates).length > 0) {
-        dbg("sheet:_onDrop", "syncing identification fields on createdItem", { itemUpdates });
-        await createdItem.update(itemUpdates);
-      }
-    }
-
-    dbg("sheet:_onDrop", "drop complete", { finalActorImg: this.actor.img, finalCreatedItemImg: createdItem?.img });
-    ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Notify.Deposited", { name: item.name }));
+    return this.render({ force: true });
   }
 }

--- a/scripts/sheets/InteractiveItemSheet.mjs
+++ b/scripts/sheets/InteractiveItemSheet.mjs
@@ -86,15 +86,14 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
 
       dialog.close();
 
-      // Render the embedded item's sheet directly — our actor sheet gates would
-      // re-block it. The renderContainerSheet hook hides contents when inaccessible.
-      const embedded = actor.system.embeddedItem;
-      if (!embedded) continue;
-      const realSheet = embedded.sheet;
-      await realSheet.render({ force: true });
+      // Open the embedded item's sheet via the adapter — bypasses our actor sheet
+      // gates which would re-block the render. The renderContainerSheet hook
+      // hides contents when the container is inaccessible.
+      if (!actor.system.embeddedItem) continue;
+      const renderedSheet = await getAdapter().renderEmbeddedSheet(actor, { force: true });
 
       if (!hasPosition) continue;
-      const el = realSheet.element;
+      const el = renderedSheet?.element;
       if (!el) continue;
 
       const appRect = el.getBoundingClientRect();
@@ -103,7 +102,7 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       const left = Math.max(0, Math.min(rect.left, maxLeft));
       const top = Math.max(0, Math.min(rect.top, maxTop));
 
-      realSheet.setPosition({ left, top });
+      renderedSheet.setPosition({ left, top });
     }
   }
 
@@ -189,8 +188,8 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       }
       const item = this.containerItem;
       if (item) {
-        dbg("sheet:render", "container: delegating to ContainerSheet", { itemId: item.id, itemName: item.name });
-        await item.sheet.render({ force: true });
+        dbg("sheet:render", "container: delegating to adapter.renderContainerView", { itemId: item.id, itemName: item.name });
+        await getAdapter().renderContainerView(this.actor, options);
         return this;
       }
     } else {
@@ -201,9 +200,9 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       }
       const item = this.actor.items.contents[0];
       if (item) {
-        dbg("sheet:render", "item: delegating to ItemSheet5e", { itemId: item.id, itemName: item.name, itemImg: item.img });
+        dbg("sheet:render", "item: delegating to adapter.renderItemView", { itemId: item.id, itemName: item.name, itemImg: item.img });
         await this.#syncItemImage(item);
-        await item.sheet.render({ force: true });
+        await getAdapter().renderItemView(this.actor, options);
         return this;
       }
     }
@@ -353,14 +352,13 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
     if (!item) return;
     await this.#syncItemImage(item);
     await this.close();
-    item.sheet.render({ force: true });
+    await getAdapter().renderItemView(this.actor);
   }
 
   static async #onOpenContainerSheet(event, target) {
-    const item = this.containerItem;
-    if (!item) return;
+    if (!this.containerItem) return;
     await this.close();
-    item.sheet.render({ force: true });
+    await getAdapter().renderContainerView(this.actor);
   }
 
   async #syncItemImage(item) {

--- a/scripts/sheets/InteractiveItemSheet.mjs
+++ b/scripts/sheets/InteractiveItemSheet.mjs
@@ -1,4 +1,5 @@
 import { checkProximity, setContainerOpen, toggleContainerLocked } from "../transfer/ItemTransfer.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 import { createStateToggleButton } from "../utils/domButtons.mjs";
 import { dbg } from "../utils/debugLog.mjs";
 import { isModuleGM, isPlayerView } from "../utils/playerView.mjs";
@@ -397,9 +398,12 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
 
   static async #onToggleIdentified(event, target) {
     const item = this.actor.system.embeddedItem;
-    dbg("sheet:#onToggleIdentified", { actorName: this.actor?.name, embeddedItemId: item?.id, currentIdentified: item?.system?.identified, newIdentified: !item?.system?.identified });
-    if (!item || item.system?.identified === undefined) return;
-    await item.update({ "system.identified": !item.system.identified });
+    const adapter = getAdapter();
+    const currentIdentified = item ? adapter.isItemIdentified(item) : undefined;
+    dbg("sheet:#onToggleIdentified", { actorName: this.actor?.name, embeddedItemId: item?.id, currentIdentified, newIdentified: !currentIdentified });
+    if (!item || currentIdentified === undefined) return;
+    // Route through the adapter so the update targets the correct system field.
+    await adapter.setItemIdentified(item, !currentIdentified);
   }
 
   static async #onToggleLock(event, target) {
@@ -489,14 +493,14 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
       return;
     }
 
+    const adapter = getAdapter();
     const itemData = item.toObject();
     delete itemData._id;
 
-    // Set before creation so the updateItem hook doesn't fire for this change
-    // while actor.img is still the old value.
-    if (itemData.system && "identified" in itemData.system) {
-      itemData.system.identified = true;
-    }
+    // Stamp the item as identified before creation so the updateItem hook does
+    // not fire for this change while actor.img is still the old value.
+    // Route through the adapter so the correct system field is set.
+    adapter.stampNewItemIdentified(itemData, true);
 
     // Interactive actors hold exactly one embedded item.
     if (this.actor.items.size > 0) {
@@ -515,11 +519,15 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
     if (item.system.description?.value) {
       updates["system.description"] = item.system.description.value;
     }
-    if (item.system.unidentified?.name) {
-      updates["system.unidentifiedName"] = item.system.unidentified.name;
+    // Read unidentified name/description through the adapter so the field path
+    // is not hard-coded to dnd5e's `system.unidentified.*` shape.
+    const droppedUnidentifiedName = adapter.getItemUnidentifiedName(item);
+    const droppedUnidentifiedDescription = adapter.getItemUnidentifiedDescription(item);
+    if (droppedUnidentifiedName) {
+      updates["system.unidentifiedName"] = droppedUnidentifiedName;
     }
-    if (item.system.unidentified?.description) {
-      updates["system.unidentifiedDescription"] = item.system.unidentified.description;
+    if (droppedUnidentifiedDescription) {
+      updates["system.unidentifiedDescription"] = droppedUnidentifiedDescription;
     }
     dbg("sheet:_onDrop", "firing actor.update with metadata", { updates });
     await this.actor.update(updates);
@@ -529,19 +537,19 @@ export default class InteractiveItemSheet extends HandlebarsApplicationMixin(Act
     const [createdItem] = await this.actor.createEmbeddedDocuments("Item", [itemData]);
     dbg("sheet:_onDrop", "createEmbeddedDocuments complete", { createdItemId: createdItem?.id, createdItemImg: createdItem?.img });
 
-    if (createdItem && "identified" in (createdItem.system ?? {})) {
-      const itemUpdates = {};
-      if (this.actor.system.unidentifiedName) {
-        itemUpdates["system.unidentified.name"] = this.actor.system.unidentifiedName;
-      }
-      if (this.actor.system.unidentifiedDescription) {
-        itemUpdates["system.unidentified.description"] = this.actor.system.unidentifiedDescription;
-      }
-      if (this.actor.system.description) {
-        itemUpdates["system.description.value"] = this.actor.system.description;
-      }
+    if (createdItem) {
+      // Build the system-specific update payload for all identification fields via
+      // the adapter, using a synthetic "all fields present" changeset so every
+      // actor identification field is mirrored onto the newly embedded item.
+      const allIdentificationChanges = {
+        isIdentified: true,
+        unidentifiedName: this.actor.system.unidentifiedName,
+        description: this.actor.system.description,
+        unidentifiedDescription: this.actor.system.unidentifiedDescription
+      };
+      const itemUpdates = adapter.buildItemIdentificationUpdate(this.actor, allIdentificationChanges);
       if (Object.keys(itemUpdates).length > 0) {
-        dbg("sheet:_onDrop", "syncing unidentified fields on createdItem", { itemUpdates });
+        dbg("sheet:_onDrop", "syncing identification fields on createdItem", { itemUpdates });
         await createdItem.update(itemUpdates);
       }
     }

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -123,7 +123,7 @@ export async function pickupItem(sceneId, tokenId, itemId, targetActorId) {
   const isEphemeralToken = !!tokenDoc.flags?.["pick-up-stix"]?.ephemeral;
   dbg("xfer:pickupItem", "preparing item transfer", { baseActorId, isEphemeralToken, isContainer: sourceActor.system.isContainer });
 
-  const toCreate = await CONFIG.Item.documentClass.createWithContents([item], {
+  const toCreate = await getAdapter().flattenItemsForCreate([item], {
     transformAll: (itemData) => {
       if (itemData instanceof foundry.abstract.Document) itemData = itemData.toObject();
       stripEquipmentState(itemData);
@@ -196,7 +196,7 @@ export async function depositItem(sourceActorId, itemId, sceneId, tokenId) {
     return false;
   }
 
-  const toCreate = await CONFIG.Item.documentClass.createWithContents([item]);
+  const toCreate = await getAdapter().flattenItemsForCreate([item]);
 
   assignContainerParent(targetActor, toCreate);
 

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -1,4 +1,5 @@
 import { getTokenActor, isInteractiveActor } from "../utils/actorHelpers.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 import { dispatchGM } from "../utils/gmDispatch.mjs";
 import { notifyItemAction, notifyTransferError } from "../utils/notify.mjs";
 import { validateContainerAccess, validateItemAccess } from "../utils/containerAccess.mjs";
@@ -24,14 +25,22 @@ function stampInteractiveIdentity(itemData, actor, { embeddedItemData } = {}) {
     description: actor.system.description || descriptionValue
   };
 
+  // Wrap the raw system-data slice as a duck-typed item so the adapter's
+  // getItemUnidentified* methods can read the correct system-specific fields.
+  const adapter = getAdapter();
+  const embeddedItemLike = embeddedItemData ? { system: embeddedItemData } : null;
   const unidentifiedData = {
-    name: embeddedItemData?.unidentified?.name || actor.system.unidentifiedName || actor.name,
+    name: (embeddedItemLike && adapter.getItemUnidentifiedName(embeddedItemLike))
+      || actor.system.unidentifiedName || actor.name,
     img: actor.system.unidentifiedImage || actor.img,
-    description: embeddedItemData?.unidentified?.description || actor.system.unidentifiedDescription || identifiedData.description
+    description: (embeddedItemLike && adapter.getItemUnidentifiedDescription(embeddedItemLike))
+      || actor.system.unidentifiedDescription || identifiedData.description
   };
 
-  const isIdentified = embeddedItemData
-    ? (embeddedItemData.identified !== false)
+  // Read identification state through the adapter so the field path is not
+  // hard-coded to dnd5e's `system.identified` boolean.
+  const isIdentified = embeddedItemLike
+    ? adapter.isItemIdentified(embeddedItemLike)
     : actor.system.isIdentified;
 
   const display = isIdentified ? identifiedData : unidentifiedData;
@@ -402,13 +411,17 @@ export async function toggleItemIdentification(item) {
     return null;
   }
 
-  dbg("xfer:toggleItemIdentification", "applying identification toggle", { name: data.name, img: data.img });
+  dbg("xfer:toggleItemIdentification", "applying identification toggle", { name: data.name, img: data.img, newState });
   await item.update({
     name: data.name,
     img: data.img,
     "system.description.value": data.description,
     "flags.pick-up-stix.tokenState.system.isIdentified": newState
   });
+  // Sync the system's native identification field so the game system's own
+  // identified/unidentified UI reflects the new state (e.g. dnd5e hides item
+  // details from players when system.identified is false).
+  await getAdapter().setItemIdentified(item, newState);
   dbg("xfer:toggleItemIdentification", "toggle complete", { newState });
   return newState;
 }

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -448,6 +448,10 @@ export function buildInteractiveItemData(droppedActor) {
 
   const itemData = sourceItem.toObject();
   delete itemData._id;
+  // Clear any stale container-parent pointer carried from a prior life.
+  // depositCanvasTokenToTarget / depositActorToTarget will set the new
+  // parent (if the destination is a container) immediately after this call.
+  getAdapter().setItemContainerId(itemData, null);
   stripEquipmentState(itemData);
   stampInteractiveIdentity(itemData, droppedActor);
 

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -426,14 +426,19 @@ export async function toggleItemIdentification(item) {
   return newState;
 }
 
+/**
+ * Assigns the container parent reference on each item data object so that the
+ * deposited items appear as children of the destination container in the system's
+ * native sheet. Delegates the field write to the adapter so the field path is not
+ * hard-coded to dnd5e's `system.container`.
+ */
 export function assignContainerParent(containerActor, itemDataArray) {
   if (!containerActor.system?.isContainer) return;
   const containerItem = containerActor.system.containerItem;
   if (!containerItem) return;
   const items = Array.isArray(itemDataArray) ? itemDataArray : [itemDataArray];
   for (const itemData of items) {
-    itemData.system = itemData.system ?? {};
-    itemData.system.container = containerItem.id;
+    getAdapter().setItemContainerId(itemData, containerItem.id);
   }
 }
 

--- a/scripts/utils/domButtons.mjs
+++ b/scripts/utils/domButtons.mjs
@@ -1,10 +1,13 @@
 export function createStateToggleButton({
   extraClass, active, iconOn, iconOff,
+  iconFamilyOn = "fa-solid", iconFamilyOff = "fa-solid",
   labelOnKey, labelOffKey, action, onClick
 }) {
+  const icon = active ? iconOn : iconOff;
+  const family = active ? iconFamilyOn : iconFamilyOff;
   const btn = document.createElement("button");
   btn.type = "button";
-  btn.className = `header-control pseudo-header-control state-toggle fa-solid icon ${extraClass} ${active ? iconOn : iconOff}`;
+  btn.className = `header-control pseudo-header-control state-toggle ${family} icon ${extraClass} ${icon}`;
   btn.classList.toggle("active", active);
   const key = active ? labelOnKey : labelOffKey;
   btn.setAttribute("aria-label", game.i18n.localize(key));

--- a/scripts/utils/domButtons.mjs
+++ b/scripts/utils/domButtons.mjs
@@ -68,7 +68,18 @@ export function createAdapterHeaderButton({
       btn.setAttribute("aria-label", label);
     }
     btn.innerHTML = `<i class="${family} ${icon}"></i>`;
-    if (onClick) btn.addEventListener("click", onClick);
+    if (onClick) {
+      // Foundry's V1 sheet binds a delegated `.header-button` click handler at
+      // render time. When we inject our own `<a class="header-button">` after
+      // render, that handler still fires on it but tries to look the descriptor
+      // up in `windowData.headerButtons` (where ours don't exist) — crashing
+      // with "Cannot read properties of undefined (reading 'onclick')". Use
+      // `stopImmediatePropagation` to short-circuit the delegated handler.
+      btn.addEventListener("click", (ev) => {
+        ev.stopImmediatePropagation();
+        return onClick(ev);
+      });
+    }
     return btn;
   }
 

--- a/scripts/utils/domButtons.mjs
+++ b/scripts/utils/domButtons.mjs
@@ -22,9 +22,10 @@ export function insertHeaderButton(header, btn, closeBtn) {
   else header.appendChild(btn);
 }
 
-export function createRowControl({ iconClass, titleKey, onClick, extraClass = "" }) {
+export function createRowControl({ iconClass, titleKey, onClick, extraClass = "", active = false }) {
   const btn = document.createElement("a");
   btn.className = `ii-row-control ${extraClass}`.trim();
+  btn.classList.toggle("active", active);
   btn.title = game.i18n.localize(titleKey);
   btn.innerHTML = `<i class="${iconClass}"></i>`;
   btn.addEventListener("click", async (ev) => {

--- a/scripts/utils/domButtons.mjs
+++ b/scripts/utils/domButtons.mjs
@@ -21,7 +21,12 @@ export function createStateToggleButton({
 export function insertHeaderButton(header, btn, closeBtn) {
   const identifiedToggle = header.querySelector(".toggle-identified");
   if (identifiedToggle) identifiedToggle.before(btn);
-  else if (closeBtn) closeBtn.before(btn);
+  // Fall back to scanning the header in case the caller failed to resolve the
+  // close button under the system's specific markup. pf2e V1 sheets render
+  // close as `<a class="header-button close">` while dnd5e V2 uses
+  // `<button data-action="close">`.
+  const close = closeBtn ?? header.querySelector("button.close, a.close, [data-action='close']");
+  if (close) close.before(btn);
   else header.appendChild(btn);
 }
 

--- a/scripts/utils/domButtons.mjs
+++ b/scripts/utils/domButtons.mjs
@@ -18,6 +18,74 @@ export function createStateToggleButton({
   return btn;
 }
 
+/**
+ * Create a header button whose DOM shape matches the active system's sheet
+ * conventions. dnd5e produces a V2 `<button class="header-control ...">`;
+ * pf2e produces a V1 `<a class="header-button">`. The adapter's `cssClasses`
+ * supplies both the wrapper class (`stateToggle` / `configButton`) and the
+ * `headerElementType` discriminator.
+ *
+ * Supports both toggle (pass `iconOff`) and single-state (omit `iconOff`)
+ * buttons — the latter is used for the gear / configure control.
+ *
+ * @param {object} opts
+ * @param {object} opts.adapter - Result of `getAdapter()`.
+ * @param {"state"|"config"} [opts.kind="state"] - Picks `cssClasses.stateToggle` vs `configButton`.
+ * @param {string} [opts.extraClass=""] - Caller's identifying class (e.g. "ii-lock-toggle-btn").
+ * @param {boolean} [opts.active] - Toggle on/off state. Omit for non-toggle buttons.
+ * @param {string} opts.iconOn
+ * @param {string} [opts.iconOff] - Omit for single-state buttons (uses iconOn always).
+ * @param {string} [opts.iconFamilyOn="fa-solid"]
+ * @param {string} [opts.iconFamilyOff="fa-solid"]
+ * @param {string} [opts.labelOnKey]
+ * @param {string} [opts.labelOffKey]
+ * @param {Function} [opts.onClick]
+ * @returns {HTMLElement}
+ */
+export function createAdapterHeaderButton({
+  adapter, kind = "state", extraClass = "",
+  active, iconOn, iconOff,
+  iconFamilyOn = "fa-solid", iconFamilyOff = "fa-solid",
+  labelOnKey, labelOffKey,
+  onClick
+}) {
+  const isToggle = iconOff !== undefined;
+  const icon = isToggle && active === false ? iconOff : iconOn;
+  const family = isToggle && active === false ? iconFamilyOff : iconFamilyOn;
+  const labelKey = (isToggle && active === false ? labelOffKey : labelOnKey) ?? null;
+  const cls = adapter.cssClasses;
+  const baseClass = kind === "config" ? cls.configButton : cls.stateToggle;
+  const useAnchor = cls.headerElementType === "a";
+
+  if (useAnchor) {
+    // V1 — `<a class="header-button {extraClass}"><i class="..."></i></a>`
+    const btn = document.createElement("a");
+    btn.className = `${baseClass} ${extraClass}`.trim();
+    if (isToggle) btn.classList.toggle("active", !!active);
+    if (labelKey) {
+      const label = game.i18n.localize(labelKey);
+      btn.dataset.tooltip = label;
+      btn.setAttribute("aria-label", label);
+    }
+    btn.innerHTML = `<i class="${family} ${icon}"></i>`;
+    if (onClick) btn.addEventListener("click", onClick);
+    return btn;
+  }
+
+  // V2 — `<button class="header-control pseudo-header-control state-toggle ...">`
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = `${baseClass} ${family} icon ${extraClass} ${icon}`.trim();
+  if (isToggle) btn.classList.toggle("active", !!active);
+  if (labelKey) {
+    btn.setAttribute("aria-label", game.i18n.localize(labelKey));
+    btn.dataset.tooltip = labelKey;
+    btn.dataset.tooltipDirection = "DOWN";
+  }
+  if (onClick) btn.addEventListener("click", onClick);
+  return btn;
+}
+
 export function insertHeaderButton(header, btn, closeBtn) {
   const identifiedToggle = header.querySelector(".toggle-identified");
   if (identifiedToggle) identifiedToggle.before(btn);

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -278,10 +278,15 @@
 }
 
 .ii-contents-controls-spacer {
-  /* Width approximates the controls block: 3 icons (16px each) + 2 gaps (6px each). */
+  /* Default: 3 icons (lock + identify + delete) — actor-sheet renders. */
   display: inline-block;
   width: calc(3 * 16px + 2 * 6px);
   flex-shrink: 0;
+}
+
+.ii-contents-controls-spacer.is-token {
+  /* Token-sheet renders gain a fourth icon (hand) before the lock. */
+  width: calc(4 * 16px + 3 * 6px);
 }
 
 /* ===== Settings Dialog ===== */

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -257,6 +257,33 @@
   opacity: 0.6;
 }
 
+/* Header row above the contents list. Reuses .ii-contents-row's flex layout
+ * so column widths match the data rows below. The image and controls columns
+ * use empty spacers (display:inline-block) since <span> isn't a replaced
+ * element and the actual data columns get their width from <img>/<span>
+ * children with explicit widths. */
+.ii-contents-row.ii-contents-header {
+  font-size: 0.78em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, rgba(0, 0, 0, 0.6));
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.ii-contents-img-spacer {
+  display: inline-block;
+  width: 28px;
+  flex-shrink: 0;
+}
+
+.ii-contents-controls-spacer {
+  /* Width approximates the controls block: 4 icons (16px each) + 3 gaps (6px each). */
+  display: inline-block;
+  width: calc(4 * 16px + 3 * 6px);
+  flex-shrink: 0;
+}
+
 /* ===== Settings Dialog ===== */
 
 .ii-settings-folder-picker {

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -289,6 +289,51 @@
   width: calc(4 * 16px + 3 * 6px);
 }
 
+/* ===== pf2e Config Sheet — match item-sheet input styling =====
+ * pf2e scopes its sheet-content input styling to `.pf2e.item.sheet`. Our
+ * config dialog is `.pf2e.actor.sheet` so those rules don't reach it.
+ * Worse, pf2e's unlayered rule `.pf2e.actor form input[type=text] { padding: 0 }`
+ * strips the padding the V1 compatibility layer would normally provide.
+ * The selectors below add the `.actor.interactive-item-config form` chain to
+ * outrank pf2e's actor rule (3 classes + 2 elements vs 2 classes + 2 elements)
+ * so our padding/background/border survive the cascade. Padding values come
+ * from foundry's V1 baseline (`body.game .app input[type=text]`). */
+
+.pf2e.actor.interactive-item-config form input[type="text"],
+.pf2e.actor.interactive-item-config form input[type="number"],
+.pf2e.actor.interactive-item-config form select {
+  color: var(--color-text-dark-input);
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid var(--color-border-light-2);
+  padding: 1px 3px;
+}
+
+.pf2e.actor.interactive-item-config form input[type="text"]:hover:not(:disabled),
+.pf2e.actor.interactive-item-config form input[type="text"]:focus,
+.pf2e.actor.interactive-item-config form input[type="number"]:hover:not(:disabled),
+.pf2e.actor.interactive-item-config form input[type="number"]:focus,
+.pf2e.actor.interactive-item-config form select:hover:not(:disabled),
+.pf2e.actor.interactive-item-config form select:focus {
+  border-color: var(--color-border-dark-1);
+  box-shadow: 0 0 4px var(--color-pf-secondary);
+}
+
+.pf2e.actor.interactive-item-config form input:read-only,
+.pf2e.actor.interactive-item-config form input:disabled,
+.pf2e.actor.interactive-item-config form select:disabled {
+  color: var(--color-disabled);
+  opacity: 0.8;
+}
+
+/* Form-group labels — match pf2e item-sheet appearance: darker text,
+ * semi-bold, fixed flex-basis so labels align across rows. */
+.pf2e.actor.interactive-item-config form .form-group > label {
+  color: var(--color-text-dark-2);
+  font-weight: 500;
+  padding-right: 0.5em;
+  flex: 0 1 11em;
+}
+
 /* ===== Settings Dialog ===== */
 
 .ii-settings-folder-picker {

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -185,6 +185,78 @@
   --control-hover-border-color: var(--control-active-border-color);
 }
 
+/* ===== pf2e ContainerSheetPF2e Contents Tab ===== */
+
+.ii-contents-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ii-contents-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--color-border-light-2, rgba(0, 0, 0, 0.1));
+}
+
+.ii-contents-row:last-child {
+  border-bottom: none;
+}
+
+.ii-contents-img {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  object-fit: cover;
+  border: 1px solid var(--color-border-dark-2, rgba(0, 0, 0, 0.3));
+  border-radius: 2px;
+}
+
+.ii-contents-name {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+}
+
+.ii-contents-quantity,
+.ii-contents-bulk {
+  flex-shrink: 0;
+  min-width: 32px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+
+.ii-contents-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ii-contents-control {
+  cursor: pointer;
+  opacity: 0.7;
+  width: 16px;
+  text-align: center;
+}
+
+.ii-contents-control:hover {
+  opacity: 1;
+}
+
+.ii-contents-empty {
+  padding: 1rem;
+  text-align: center;
+  font-style: italic;
+  opacity: 0.6;
+}
+
 /* ===== Settings Dialog ===== */
 
 .ii-settings-folder-picker {

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -69,6 +69,11 @@
   opacity: 1;
 }
 
+.ii-row-control.active {
+  color: var(--color-text-hyperlink);
+  opacity: 1;
+}
+
 /* ===== GM Identification Toggle (injected into dnd5e character sheets) ===== */
 
 .pick-up-stix-identify-toggle {

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -278,9 +278,9 @@
 }
 
 .ii-contents-controls-spacer {
-  /* Width approximates the controls block: 4 icons (16px each) + 3 gaps (6px each). */
+  /* Width approximates the controls block: 3 icons (16px each) + 2 gaps (6px each). */
   display: inline-block;
-  width: calc(4 * 16px + 3 * 6px);
+  width: calc(3 * 16px + 2 * 6px);
   flex-shrink: 0;
 }
 

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -84,6 +84,11 @@
   opacity: 0.75;
 }
 
+.pick-up-stix-identify-toggle.active {
+  color: var(--color-text-hyperlink);
+  opacity: 1;
+}
+
 .pick-up-stix-identify-toggle:hover {
   opacity: 1;
   color: var(--color-text-hyperlink);

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -334,6 +334,51 @@
   flex: 0 1 11em;
 }
 
+/* Header layout — pf2e's `.pf2e.actor form .sheet-header` sets a 3rem
+ * height, a bottom divider line, and `flex: 1` on every child (which
+ * stretches the image to match the name's width). Override those so the
+ * header reads like a pf2e item-sheet header: small fixed image on the
+ * left at natural aspect, flexible name on the right, no divider. */
+.pf2e.actor.interactive-item-config form .sheet-header {
+  border-bottom: none;
+  height: auto;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 8px;
+}
+
+.pf2e.actor.interactive-item-config form .sheet-header > * {
+  flex: 0 1 auto;
+}
+
+.pf2e.actor.interactive-item-config form .sheet-header img.profile {
+  flex: 0 0 64px;
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  border: none;
+}
+
+.pf2e.actor.interactive-item-config form .sheet-header .document-name {
+  flex: 1 1 auto;
+  font-size: var(--font-size-24);
+  font-family: var(--serif-condensed);
+  font-weight: 700;
+  line-height: 1.1;
+  white-space: normal;
+}
+
+/* Quick-open button (Open Container / Open Item Sheet) sits below the
+ * header on its own row. Existing rule
+ * `.pick-up-stix.sheet .sheet-header + button` already provides margin;
+ * make sure it spans full width and isn't pulled into the header flex. */
+.pf2e.actor.interactive-item-config form .sheet-header + button {
+  display: block;
+  width: 100%;
+  margin: 8px 0;
+}
+
 /* ===== Settings Dialog ===== */
 
 .ii-settings-folder-picker {

--- a/templates/item-config-v1.hbs
+++ b/templates/item-config-v1.hbs
@@ -1,0 +1,83 @@
+{{!-- pf2e (V1) GM config dialog template for pick-up-stix interactive object actors. --}}
+
+<form class="pf2e item-config" autocomplete="off">
+
+  {{#if needsItem}}
+  <div class="needs-item-prompt">
+    <i class="fa-solid fa-arrow-down"></i>
+    <p>{{localize "INTERACTIVE_ITEMS.Sheet.NeedsItem"}}</p>
+    <img class="needs-item-icon" src="modules/pick-up-stix/icons/interactive-item-icon.svg" alt="" />
+  </div>
+  {{else}}
+
+  {{!-- Preview + quick-open button --}}
+  {{#if isContainer}}
+    {{#if hasContainerItem}}
+    <header class="sheet-header">
+      <img class="profile ii-clickable-image" src="{{containerImg}}" alt="{{containerName}}"
+           data-action="editActorImage" />
+      <span class="document-name">{{containerName}}</span>
+    </header>
+    <button type="button" data-action="openContainerSheet">
+      <i class="fa-solid fa-up-right-from-square"></i>
+      {{localize "INTERACTIVE_ITEMS.Sheet.ViewContainerSheet"}}
+    </button>
+    {{/if}}
+  {{else}}
+    {{#if hasItem}}
+    <header class="sheet-header">
+      <img class="profile ii-clickable-image" src="{{itemImg}}" alt="{{itemName}}"
+           data-action="editActorImage" />
+      <span class="document-name">{{itemName}}</span>
+    </header>
+    <button type="button" data-action="openItemSheet">
+      <i class="fa-solid fa-up-right-from-square"></i>
+      {{localize "INTERACTIVE_ITEMS.Sheet.ViewItemSheet"}}
+    </button>
+    {{/if}}
+  {{/if}}
+
+  {{#if isEditable}}
+  <fieldset>
+    <legend>{{localize "INTERACTIVE_ITEMS.Sheet.ConfigLegend"}}</legend>
+
+    {{> "pick-up-stix.config-fields-v1"}}
+
+    {{#if isContainer}}
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Sheet.OpenImage"}}</label>
+      <div class="form-fields">
+        <button type="button" class="file-picker" data-type="image" data-target="system.openImage"
+                title="{{localize 'FILES.BrowseTooltip'}}" tabindex="-1">
+          <i class="fas fa-file-import fa-fw"></i>
+        </button>
+        <input class="image" type="text" name="system.openImage"
+               placeholder="path/to/file.png" value="{{system.openImage}}" />
+      </div>
+    </div>
+    {{else}}
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Sheet.UnidentifiedImage"}}</label>
+      <div class="form-fields">
+        <button type="button" class="file-picker" data-type="image" data-target="system.unidentifiedImage"
+                title="{{localize 'FILES.BrowseTooltip'}}" tabindex="-1">
+          <i class="fas fa-file-import fa-fw"></i>
+        </button>
+        <input class="image" type="text" name="system.unidentifiedImage"
+               placeholder="path/to/file.png" value="{{system.unidentifiedImage}}" />
+      </div>
+    </div>
+    {{/if}}
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Sheet.LockedMessage"}}</label>
+      <div class="form-fields">
+        <input type="text" name="system.lockedMessage" value="{{system.lockedMessage}}"
+          placeholder="{{localize 'INTERACTIVE_ITEMS.Sheet.LockedMessagePlaceholder'}}" />
+      </div>
+    </div>
+  </fieldset>
+  {{/if}}
+
+  {{/if}}
+</form>

--- a/templates/partials/config-fields-v1.hbs
+++ b/templates/partials/config-fields-v1.hbs
@@ -1,0 +1,62 @@
+{{!-- Shared form fields for the pf2e (V1) config dialog. Uses V1 conventions:
+      file-picker buttons (handled by FormApplication._activateFilePicker) and
+      the {{editor}} Handlebars helper for rich text. --}}
+
+<div class="form-group">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.Name"}}</label>
+  <div class="form-fields">
+    <input type="text" name="name" value="{{actor.name}}"
+      placeholder="{{localize 'INTERACTIVE_ITEMS.Sheet.NamePlaceholder'}}" />
+  </div>
+</div>
+
+<div class="form-group">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.UnidentifiedName"}}</label>
+  <div class="form-fields">
+    <input type="text" name="system.unidentifiedName" value="{{system.unidentifiedName}}"
+      placeholder="{{localize 'INTERACTIVE_ITEMS.Sheet.UnidentifiedNamePlaceholder'}}" />
+  </div>
+</div>
+
+<div class="form-group">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.LimitedName"}}</label>
+  <div class="form-fields">
+    <input type="text" name="system.limitedName" value="{{system.limitedName}}"
+      placeholder="{{localize 'INTERACTIVE_ITEMS.Sheet.LimitedNamePlaceholder'}}" />
+  </div>
+</div>
+
+<div class="form-group stacked">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.Description"}}</label>
+  <div class="form-fields">
+    {{editor descriptionHTML target="system.description" button=true editable=isEditable engine="prosemirror"}}
+  </div>
+</div>
+
+<div class="form-group stacked">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.UnidentifiedDescription"}}</label>
+  <div class="form-fields">
+    {{editor unidentifiedDescriptionHTML target="system.unidentifiedDescription" button=true editable=isEditable engine="prosemirror"}}
+  </div>
+</div>
+
+<div class="form-group stacked">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.LimitedDescription"}}</label>
+  <div class="form-fields">
+    {{editor limitedDescriptionHTML target="system.limitedDescription" button=true editable=isEditable engine="prosemirror"}}
+  </div>
+</div>
+
+<div class="form-group">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.InteractionRange"}}</label>
+  <div class="form-fields">
+    <input type="number" name="system.interactionRange" value="{{system.interactionRange}}" min="0" step="0.5" />
+  </div>
+</div>
+
+<div class="form-group">
+  <label>{{localize "INTERACTIVE_ITEMS.Sheet.InspectionRange"}}</label>
+  <div class="form-fields">
+    <input type="number" name="system.inspectionRange" value="{{system.inspectionRange}}" min="0" step="0.5" />
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Introduces a system adapter architecture (`scripts/adapter/`) so core code is system-agnostic and dispatches to per-system implementations rather than branching on `game.system.id`.
- Adds full pf2e support alongside existing dnd5e: identification/mystification (with `Pf2eIdentifyPopup` and per-state cache writes), native `ContainerSheetPF2e` integration with an injected **Contents** tab, container drop gating via libWrapper, and pf2e-specific actor model stubs.
- Splits the GM config sheet into per-adapter implementations — dnd5e ships an ApplicationV2 sheet, pf2e ships an ApplicationV1 sheet to match each system's conventions.
- Refactors sheet rendering into a dispatcher (`InteractiveItemSheet`) that routes to `adapter.renderConfigSheet` / `renderContainerView` / `renderItemView` / `renderEmbeddedSheet`, with V1/V2 header-button parity.
- Hidden-contents gate, proximity-driven sheet close/promote, and container row controls (lock / identify / delete / pickup) work across both systems.
- Updates `module.json` to declare pf2e in `relationships.systems` and rewrites the README to be system-agnostic.