### PR TITLE
feat: generic-system adapter (fully custom, flag-backed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,29 @@ Interactive objects display through the active system's own item and container s
 - **Socket-based security** -- All player mutations (pickup, deposit, open/close, placement) route through sockets to the active GM client for processing.
 - **Round-trip placement** -- Items picked up from the canvas remember their source actor and token state. Dropping them back restores the original token appearance and reuses the original base actor.
 
+## Generic-system mode
+
+Pick-Up-Stix ships dedicated adapters for **dnd5e** (≥ 4.0.0) and **pf2e**
+(≥ 8.0.0). On any other system it falls back to a **generic adapter**
+that uses entirely module-owned data and UI. In generic mode:
+
+- All canvas placement, pickup, drop, and proximity flows work normally.
+- Interactive-object data is stored in module flags rather than the
+  system's actor / item types, so the module is independent of how the
+  active system structures its data.
+- Custom item-view, container-view, and config sheets are rendered
+  directly by the module — the system's own item sheets are not used.
+- **Item identification is disabled** — items are treated as permanently
+  identified and the identify UI is hidden.
+- On first launch the module auto-detects a "pickup item type" from
+  the system's declared item types, or prompts the GM to pick one via
+  dialog if no obvious match is found. You can change it later in
+  module settings.
+
 ## Requirements
 
 - Foundry VTT v13+
-- A supported game system (currently dnd5e 4.0.0+ or pf2e 8.0.0+)
+- A supported game system (dnd5e 4.0.0+ or pf2e 8.0.0+ with full support; any other system with generic-mode fallback)
 - [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper) module
 
 ## Installation

--- a/lang/en.json
+++ b/lang/en.json
@@ -35,6 +35,10 @@
       "GMOverrideEnabled": {
         "Name": "GM Override Enabled",
         "Hint": "When enabled, GMs see and interact with everything regardless of player gating (proximity, identification, lock state, etc.). Disable to preview the module as a player would experience it. Per-client; does not affect other GMs."
+      },
+      "GenericPickupItemType": {
+        "Name": "Generic Mode — Pickup Item Type",
+        "Hint": "(Generic mode only) The item type used when a player picks up an interactive object. Set automatically on first launch when a likely candidate is detected; otherwise prompted via dialog. Change here if detection picked the wrong type."
       }
     },
     "FolderToggle": {
@@ -51,6 +55,7 @@
         "Contents": "Contents"
       },
       "NeedsItem": "Drop an item from the Items sidebar onto this sheet to initialize this interactive object.",
+      "NeedsModeGeneric": "This interactive object has no mode set. Close this dialog and re-create the actor to pick item or container mode.",
       "Contents": "Contents",
       "Empty": "Empty",
       "Closed": "This container is closed.",
@@ -120,7 +125,8 @@
       "NoToken": "No token found on the canvas for this character.",
       "NoContainerInContainer": "Containers cannot be placed inside other containers.",
       "CannotGiveContainer": "Container-type interactive objects cannot be placed in a player's inventory.",
-      "NoSceneActors": "No eligible actors found on this scene."
+      "NoSceneActors": "No eligible actors found on this scene.",
+      "GenericMode": "Pick-Up-Stix is running in generic mode for system '{system}'. Some system-specific features (e.g. native identification) are disabled. The pickup item type used for inventory transfers is configurable in module settings."
     },
     "Context": {
       "DropItem": "Drop Item",
@@ -179,7 +185,13 @@
       "QuantityMin": "Min",
       "QuantityMax": "Max",
       "QuantityConfirm": "Confirm",
-      "QuantityCancel": "Cancel"
+      "QuantityCancel": "Cancel",
+      "Confirm": "Confirm",
+      "PickPickupType": {
+        "Title": "Pick-Up-Stix — Pick Pickup Item Type",
+        "Body": "No item type matching 'item', 'loot', 'gear', 'equipment', 'treasure', or 'consumable' was found in system '{system}'. Pick which item type the module should use when players pick up interactive objects. You can change this later in module settings.",
+        "Label": "Pickup item type:"
+      }
     },
     "Limited": {
       "DefaultContainerName": "A container of some sort",

--- a/module.json
+++ b/module.json
@@ -18,23 +18,6 @@
           "verified": "1.13.4"
         }
       }
-    ],
-    "systems": [
-      {
-        "id": "dnd5e",
-        "type": "system",
-        "compatibility": {
-          "minimum": "4.0.0"
-        }
-      },
-      {
-        "id": "pf2e",
-        "type": "system",
-        "compatibility": {
-          "minimum": "8.0.0",
-          "verified": "8.1.0"
-        }
-      }
     ]
   },
   "documentTypes": {

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -36,7 +36,15 @@ export default class SystemAdapter {
     /** System exposes Item5e.createWithContents-style deep-create static. */
     hasNativeDeepCreate: false,
     /** System already renders identify/mystify controls on inventory rows (pf2e). */
-    hasNativeInventoryIdentify: false
+    hasNativeInventoryIdentify: false,
+    /**
+     * System has a native identification concept (identified/mystified items
+     * with separate display data). When false, core code suppresses all
+     * identify UI surfaces (HUD button, header toggle, row controls, context
+     * menu entries, config sheet identify-related fields) and treats every
+     * item as permanently identified.
+     */
+    supportsIdentification: false
   };
 
   // === Item type vocabulary ==================================================
@@ -286,6 +294,162 @@ export default class SystemAdapter {
    * @returns {Promise<object[]>}
    */
   async flattenItemsForCreate(items, options = {}) { _abstract("flattenItemsForCreate"); }
+
+  // === Dispatcher data accessors ============================================
+  // Default implementations read from `actor.system` (the model-backed path
+  // used by dnd5e and pf2e). The generic adapter overrides all five to read
+  // from `flags["pick-up-stix"].interactive` instead.
+
+  /**
+   * True if the actor is in container mode.
+   *
+   * Model-backed adapters (dnd5e, pf2e) rely on the `InteractiveItemModel`
+   * getter `actor.system.isContainer`; flag-backed adapters (generic) read
+   * the equivalent flag. The default therefore covers both existing adapters
+   * with no override required.
+   *
+   * @param {Actor} actor
+   * @returns {boolean}
+   */
+  isInteractiveContainer(actor) {
+    return !!actor?.system?.isContainer;
+  }
+
+  /**
+   * True if the actor has an embedded item available to render.
+   *
+   * Model-backed adapters check `actor.items.size > 0` (the embedded-items
+   * collection); flag-backed adapters check whether
+   * `flags["pick-up-stix"].interactive` contains populated item data (or, for
+   * containers, whether the flag array is present at all since containers
+   * always render the container view).
+   *
+   * @param {Actor} actor
+   * @returns {boolean}
+   */
+  hasInteractiveEmbeddedItem(actor) {
+    return actor?.items?.size > 0;
+  }
+
+  /**
+   * Human-readable display name for an interactive actor, identification-aware.
+   *
+   * Model-backed adapters delegate to `system.resolveTokenName()` which handles
+   * the identified/unidentified name swap. Flag-backed adapters read the name
+   * directly from `flags["pick-up-stix"].interactive`.
+   *
+   * @param {Actor} actor
+   * @returns {string}
+   */
+  getInteractiveDisplayName(actor) {
+    return actor?.system?.resolveTokenName?.() ?? actor?.name ?? "";
+  }
+
+  /**
+   * Title used for the out-of-range limited-view dialog.
+   *
+   * Model-backed adapters read `actor.system.limitedDisplayName` (a model
+   * field that falls back to `actor.name`). Flag-backed adapters read the
+   * equivalent flag. dnd5e and pf2e require no override.
+   *
+   * @param {Actor} actor
+   * @returns {string}
+   */
+  getInteractiveLimitedName(actor) {
+    return actor?.system?.limitedDisplayName ?? actor?.name ?? "";
+  }
+
+  /**
+   * Body HTML used for the out-of-range limited-view dialog.
+   *
+   * Model-backed adapters read `actor.system.limitedDisplayDescription` (a
+   * model HTML field). Flag-backed adapters read the equivalent flag. dnd5e
+   * and pf2e require no override.
+   *
+   * @param {Actor} actor
+   * @returns {string}
+   */
+  getInteractiveLimitedDescription(actor) {
+    return actor?.system?.limitedDisplayDescription ?? "";
+  }
+
+  /**
+   * Current open/closed state of an interactive container actor. Model-backed
+   * adapters read `actor.system.isOpen`; flag-backed adapters read the
+   * equivalent flag. Defaults to `false` for non-container actors.
+   *
+   * @param {Actor} actor
+   * @returns {boolean}
+   */
+  isInteractiveOpen(actor) {
+    return !!actor?.system?.isOpen;
+  }
+
+  /**
+   * Current locked state of an interactive actor. Model-backed adapters read
+   * `actor.system.isLocked`; flag-backed adapters read the equivalent flag.
+   *
+   * @param {Actor} actor
+   * @returns {boolean}
+   */
+  isInteractiveLocked(actor) {
+    return !!actor?.system?.isLocked;
+  }
+
+  /**
+   * Persist a new open/closed state on a container actor. Model-backed
+   * adapters write to `actor.system.isOpen` directly; flag-backed adapters
+   * update the equivalent flag via setInteractiveData (or equivalent).
+   *
+   * @param {Actor} actor
+   * @param {boolean} isOpen
+   * @returns {Promise<void>}
+   */
+  async setInteractiveOpenState(actor, isOpen) {
+    await actor.update({ "system.isOpen": !!isOpen });
+  }
+
+  /**
+   * Persist a new locked state on an actor. Model-backed adapters write to
+   * `actor.system.isLocked` directly; flag-backed adapters update the
+   * equivalent flag. When unlocking an already-open container, callers are
+   * responsible for any related open-state side effects — this method only
+   * touches the locked field.
+   *
+   * @param {Actor} actor
+   * @param {boolean} isLocked
+   * @returns {Promise<void>}
+   */
+  async setInteractiveLockedState(actor, isLocked) {
+    await actor.update({ "system.isLocked": !!isLocked });
+  }
+
+  /**
+   * Resolve the user-facing "locked" message for an actor. Model-backed
+   * adapters delegate to `actor.system.lockedDisplayMessage` (a model getter
+   * that falls back to a localized default). Flag-backed adapters read the
+   * configured message from flags, falling back to the same localized default.
+   *
+   * @param {Actor} actor
+   * @returns {string}
+   */
+  getInteractiveLockedMessage(actor) {
+    return actor?.system?.lockedDisplayMessage
+      ?? game.i18n.localize("INTERACTIVE_ITEMS.Notify.Locked");
+  }
+
+  /**
+   * Optional alternate image used when a container actor is in the open
+   * state. Model-backed adapters read `actor.system.openImage`; flag-backed
+   * adapters read the equivalent flag. Returns null when no open image is
+   * configured (in which case callers fall back to the actor's default img).
+   *
+   * @param {Actor} actor
+   * @returns {string|null}
+   */
+  getInteractiveOpenImage(actor) {
+    return actor?.system?.openImage ?? null;
+  }
 
   // === Sheet delegation ======================================================
 

--- a/scripts/adapter/dnd5e/index.mjs
+++ b/scripts/adapter/dnd5e/index.mjs
@@ -33,7 +33,9 @@ export default class Dnd5eAdapter extends SystemAdapter {
     /** dnd5e ships a full window-style ContainerSheet application. */
     hasNativeContainerWindow: true,
     /** dnd5e exposes `Item5e.createWithContents` for deep-creating containers. */
-    hasNativeDeepCreate: true
+    hasNativeDeepCreate: true,
+    /** dnd5e supports identified/unidentified item states. */
+    supportsIdentification: true
   };
 
   /**

--- a/scripts/adapter/generic/configSheet.mjs
+++ b/scripts/adapter/generic/configSheet.mjs
@@ -1,0 +1,400 @@
+/**
+ * GenericInteractiveItemConfigSheet — ApplicationV2 GM config dialog for
+ * pick-up-stix interactive object actors on generic (unsupported) systems.
+ *
+ * All interactive-object state is read from and written to
+ * `flags["pick-up-stix"].interactive` via `adapter.getInteractiveData` /
+ * `adapter.setInteractiveData`. The actor's `system.*` data and
+ * `actor.items` are never accessed.
+ *
+ * Per-actor singleton cached in `#instances`; abandoned-actor cleanup
+ * in `close()` mirrors the dnd5e/pf2e config sheets.
+ */
+
+import { getAdapter } from "../index.mjs";
+import { createStateToggleButton } from "../../utils/domButtons.mjs";
+import { dbg } from "../../utils/debugLog.mjs";
+
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;
+const MODULE_ID = "pick-up-stix";
+
+/**
+ * Generic GM-only config sheet for `pick-up-stix.interactiveItem` actors on
+ * systems that have no dedicated adapter. All data lives in actor flags.
+ */
+export default class GenericInteractiveItemConfigSheet
+  extends HandlebarsApplicationMixin(ActorSheetV2) {
+
+  /** Per-actor singleton cache so repeat opens reuse the existing window. */
+  static #instances = new Map();
+
+  /**
+   * Form-field name (e.g. `data.description`) currently being edited via a
+   * prose-mirror editor. Null when no editor is active — in that case the
+   * sheet shows the collapsible display cards instead.
+   * @type {string|null}
+   */
+  #editingDescriptionTarget = null;
+
+  /** Map of `data.*` field name → whether its display card is expanded. */
+  #expandedSections = {};
+
+  /**
+   * Resolve the config sheet for a given actor, creating one on first call
+   * and returning the cached instance on subsequent calls.
+   *
+   * @param {Actor} actor
+   * @returns {GenericInteractiveItemConfigSheet}
+   */
+  static forActor(actor) {
+    const key = actor.uuid;
+    let sheet = GenericInteractiveItemConfigSheet.#instances.get(key);
+    if (!sheet) {
+      sheet = new GenericInteractiveItemConfigSheet({ document: actor });
+      GenericInteractiveItemConfigSheet.#instances.set(key, sheet);
+    }
+    return sheet;
+  }
+
+  static DEFAULT_OPTIONS = {
+    classes: ["pick-up-stix", "interactive-item-sheet", "sheet", "standard-form"],
+    position: { width: 740, height: "auto" },
+    window: { resizable: true },
+    form: {
+      submitOnChange: true,
+      handler: GenericInteractiveItemConfigSheet.#onSubmit
+    },
+    actions: {
+      editActorImage: GenericInteractiveItemConfigSheet.#onEditActorImage,
+      toggleOpen: GenericInteractiveItemConfigSheet.#onToggleOpen,
+      toggleLock: GenericInteractiveItemConfigSheet.#onToggleLock,
+      editDescription: GenericInteractiveItemConfigSheet.#onEditDescription,
+      toggleCollapsed: GenericInteractiveItemConfigSheet.#onToggleCollapsed,
+      openItemSheet: GenericInteractiveItemConfigSheet.#onOpenItemSheet,
+      openContainerSheet: GenericInteractiveItemConfigSheet.#onOpenContainerSheet
+    }
+  };
+
+  static PARTS = {
+    config: { template: "modules/pick-up-stix/templates/item-config-generic.hbs" }
+  };
+
+  get title() {
+    const adapter = getAdapter();
+    return `${game.i18n.localize("INTERACTIVE_ITEMS.Sheet.Configure")}: ${adapter.getInteractiveDisplayName(this.actor)}`;
+  }
+
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    Object.assign(context, data, {
+      actor: this.actor,
+      isEditable: this.isEditable,
+      needsMode: data.mode == null,
+      // Item-mode actors with no itemData yet show the drop prompt (mirrors
+      // the dnd5e/pf2e config sheets' `needsItem` UX — drop an item onto
+      // the sheet to populate name/img/description/quantity).
+      needsItem: data.mode === "item" && !data.itemData,
+      isContainer: data.mode === "container",
+      isItem: data.mode === "item"
+    });
+
+    // Description editor state — collapsible cards by default; the clicked
+    // card swaps to a `<prose-mirror compact>` editor IN PLACE so the layout
+    // doesn't reflow. Per-card editing flags rather than a single switch at
+    // the top of the form, otherwise editing the bottom card would move its
+    // editor up to the first card's slot.
+    context.expanded = this.#expandedSections;
+    context.descriptionEnriched = !!data.description;
+    context.limitedDescriptionEnriched = !!data.limitedDescription;
+    context.editingDescription = this.#editingDescriptionTarget === "data.description";
+    context.editingLimitedDescription = this.#editingDescriptionTarget === "data.limitedDescription";
+    return context;
+  }
+
+  /**
+   * Wire prose-mirror save events to clear the editing target and re-render
+   * the card view. Runs on every paint because V2 re-binds listeners on
+   * re-render.
+   */
+  _onRender(context, options) {
+    super._onRender(context, options);
+    this.element.querySelectorAll("prose-mirror").forEach(editor => {
+      editor.addEventListener("save", () => {
+        this.#editingDescriptionTarget = null;
+        this.render();
+      });
+    });
+
+    // Inject the GM-only window-header toggles (lock, open/close-for-containers)
+    // so they're available alongside the close button on every render.
+    if (this.isEditable) {
+      const header = this.element.querySelector(".window-header");
+      if (header) this.#injectHeaderToggles(header);
+    }
+  }
+
+  /**
+   * Inject Lock and (containers only) Open/Close toggles into the config
+   * window's own header. Mirrors the dnd5e config sheet's
+   * `#injectHeaderToggles` but reads state via the adapter so the buttons
+   * reflect the flag-backed values rather than `actor.system.*`. Identify
+   * is intentionally omitted — generic mode has supportsIdentification:false.
+   */
+  #injectHeaderToggles(header) {
+    header.querySelectorAll(".ii-config-toggle").forEach(el => el.remove());
+
+    const adapter = getAdapter();
+    const isContainer = adapter.isInteractiveContainer(this.actor);
+    const isOpen = adapter.isInteractiveOpen(this.actor);
+    const isLocked = adapter.isInteractiveLocked(this.actor);
+    const buttons = [];
+
+    if (isContainer) {
+      buttons.push(createStateToggleButton({
+        extraClass: "ii-config-toggle",
+        active: isOpen,
+        iconOn: "fa-box-open",
+        iconOff: "fa-box",
+        labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
+        labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
+        action: "toggleOpen"
+      }));
+    }
+
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-config-toggle",
+      active: isLocked,
+      iconOn: "fa-lock",
+      iconOff: "fa-lock-open",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
+      action: "toggleLock"
+    }));
+
+    const title = header.querySelector(".window-title");
+    if (title) title.after(...buttons);
+    else header.prepend(...buttons);
+  }
+
+  /**
+   * Open the player-facing item view sheet for an item-mode interactive.
+   * Closes the config sheet first so only one view is open at a time.
+   */
+  static async #onOpenItemSheet(_event, _target) {
+    dbg("generic-config:openItemSheet", { actorId: this.actor?.id });
+    await this.close();
+    await getAdapter().renderItemView(this.actor);
+  }
+
+  /**
+   * Open the player-facing container view sheet for a container-mode interactive.
+   * Closes the config sheet first so only one view is open at a time.
+   */
+  static async #onOpenContainerSheet(_event, _target) {
+    dbg("generic-config:openContainerSheet", { actorId: this.actor?.id });
+    await this.close();
+    await getAdapter().renderContainerView(this.actor);
+  }
+
+  /**
+   * Allow drag-and-drop onto the sheet — used by the empty item-mode state
+   * so the GM can drag a sidebar item to populate the wrapped item data.
+   */
+  _canDragDrop(_selector) {
+    return true;
+  }
+
+  /**
+   * Drop handler. Accepts an Item drag from sidebar / compendium / character
+   * sheet and writes a snapshot of its name/img/description/quantity into the
+   * actor's `flags["pick-up-stix"].interactive.itemData` blob. Also syncs the
+   * actor's `name` / `img` / prototype-token texture so the placed token
+   * matches the dropped item.
+   *
+   * Mirrors the dnd5e/pf2e config sheet `_onDrop` shape but reads/writes via
+   * the adapter's flag-based API rather than embedded `actor.items`.
+   */
+  async _onDrop(event) {
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    dbg("generic-config:_onDrop", { dataType: data?.type, uuid: data?.uuid });
+    if (data?.type !== "Item") return;
+
+    const item = await fromUuid(data.uuid);
+    if (!item) return;
+
+    const adapter = getAdapter();
+    if (!adapter.isPhysicalItem(item)) {
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotPhysical"));
+      return;
+    }
+    if (!game.user.isGM) return;
+
+    // Extract data via the most common system paths. Both
+    // `system.description.value` (dnd5e/pf2e shape) and `system.description`
+    // (some generic systems) are checked. Missing description = empty string.
+    const description = item.system?.description?.value
+      ?? item.system?.description
+      ?? "";
+    const quantity = Number.isFinite(item.system?.quantity) ? item.system.quantity : 1;
+
+    // Sync actor + prototype token so the placed token visually matches.
+    await this.actor.update({
+      name: item.name,
+      img: item.img,
+      "prototypeToken.name": item.name,
+      "prototypeToken.texture.src": item.img
+    });
+
+    // Persist the flag-blob snapshot. Top-level name/img/description mirror
+    // the actor so the rest of the module's display logic (limited dialog,
+    // item view) reads the right values too.
+    await adapter.setInteractiveData(this.actor, {
+      name: item.name,
+      img: item.img,
+      description,
+      itemData: { name: item.name, img: item.img, description, quantity }
+    });
+
+    ui.notifications.info(
+      game.i18n.format("INTERACTIVE_ITEMS.Notify.Deposited", { name: item.name })
+    );
+  }
+
+  /**
+   * Form submit handler. Expands `data.*` key paths from the form fields
+   * and persists them to the flag blob.
+   *
+   * @param {Event} event
+   * @param {HTMLFormElement} form
+   * @param {FormDataExtended} formData
+   */
+  static async #onSubmit(event, form, formData) {
+    const expanded = foundry.utils.expandObject(formData.object);
+    const partial = expanded.data ?? {};
+    dbg("generic-config:submit", { actorId: this.actor?.id, keys: Object.keys(partial) });
+
+    // Order matters: write the flag data FIRST so the updateActor hook
+    // (which fires from the subsequent actor.update below) reads the fresh
+    // `data.name` when computing the prototype-token nameplate via
+    // getInteractiveDisplayName. With the old order, the hook ran against
+    // a stale `data.name` and the prototype token always lagged one save
+    // behind, so newly-placed tokens picked up the prior name.
+    await getAdapter().setInteractiveData(this.actor, partial);
+
+    // Mirror `data.name` to `actor.name` so the existing updateActor hook
+    // syncs the prototype-token name and any placed tokens' nameplates.
+    if (partial.name && partial.name !== this.actor.name) {
+      await this.actor.update({ name: partial.name });
+    }
+
+    // When editing a token-bound (synthetic) actor's config sheet, the
+    // synthetic's name update writes to the token's delta but doesn't touch
+    // the TokenDocument's own `name` field — that's what the nameplate
+    // reads. Mirror the rename onto the token doc too so the hover label
+    // updates without needing a re-place. The base-actor edit path doesn't
+    // need this (it goes through the updateActor name-sync hook for all
+    // placed tokens).
+    const tokenDoc = this.actor.token;
+    if (tokenDoc && partial.name && tokenDoc.name !== partial.name) {
+      await tokenDoc.update({ name: partial.name });
+    }
+  }
+
+  /**
+   * Open a FilePicker to choose a new actor image and synchronise it to both
+   * the flag blob and the actor's prototype token texture.
+   *
+   * @param {Event} event
+   * @param {HTMLElement} _target
+   */
+  static async #onEditActorImage(event, _target) {
+    event.preventDefault();
+    dbg("generic-config:editActorImage", { actorId: this.actor?.id });
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    const fp = new foundry.applications.apps.FilePicker.implementation({
+      type: "image",
+      current: data.img || this.actor.img,
+      callback: async (path) => {
+        await adapter.setInteractiveData(this.actor, { img: path });
+        await this.actor.update({ img: path, "prototypeToken.texture.src": path });
+        this.render();
+      }
+    });
+    fp.render(true);
+  }
+
+  /**
+   * Toggle the container's open/closed state in the flag blob.
+   *
+   * @param {Event} _event
+   * @param {HTMLElement} _target
+   */
+  static async #onToggleOpen(_event, _target) {
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    dbg("generic-config:toggleOpen", { actorId: this.actor?.id, wasOpen: data.isOpen });
+    await adapter.setInteractiveData(this.actor, { isOpen: !data.isOpen });
+  }
+
+  /**
+   * Toggle the container's locked state in the flag blob.
+   *
+   * @param {Event} _event
+   * @param {HTMLElement} _target
+   */
+  static async #onToggleLock(_event, _target) {
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    dbg("generic-config:toggleLock", { actorId: this.actor?.id, wasLocked: data.isLocked });
+    await adapter.setInteractiveData(this.actor, { isLocked: !data.isLocked });
+  }
+
+  /**
+   * Enter description-editor mode for the targeted field (the card's
+   * `data-target` attribute, e.g. `data.description`). Re-renders so the
+   * template swaps the card for the prose-mirror editor.
+   */
+  static #onEditDescription(event, target) {
+    event.stopPropagation();
+    this.#editingDescriptionTarget = target.dataset.target;
+    this.render();
+  }
+
+  /**
+   * Toggle a description card's expanded/collapsed state. Persisted in
+   * `#expandedSections` so the choice survives re-renders. Clicks inside the
+   * already-expanded content area are ignored so editing controls don't
+   * collapse the card under the cursor.
+   */
+  static #onToggleCollapsed(event, target) {
+    if (event.target.closest(".collapsible-content")) return;
+    const expandId = target.dataset.expandId;
+    if (expandId) this.#expandedSections[expandId] = !this.#expandedSections[expandId];
+    target.classList.toggle("collapsed");
+  }
+
+  async close(options = {}) {
+    dbg("generic-config:close", { actorName: this.actor?.name, actorId: this.actor?.id });
+    // Remove from cache before awaiting super.close so a re-open during close
+    // always creates a fresh instance.
+    GenericInteractiveItemConfigSheet.#instances.delete(this.actor?.uuid);
+    const result = await super.close(options);
+
+    // Abandoned-actor cleanup: if the actor was created via the kind-picker
+    // (createKindConfirmed flag set) but the GM closed the sheet before a mode
+    // was assigned, delete the blank actor. Mirrors the dnd5e/pf2e config sheets.
+    const actor = this.actor;
+    if (actor && game.actors.has(actor.id) && !actor.token && game.user.isGM) {
+      const data = getAdapter().getInteractiveData(actor);
+      if (actor.getFlag(MODULE_ID, "createKindConfirmed") && data.mode == null) {
+        dbg("generic-config:close", "deleting abandoned actor with no mode", { actorId: actor.id });
+        await actor.delete();
+      }
+    }
+    return result;
+  }
+}

--- a/scripts/adapter/generic/container.mjs
+++ b/scripts/adapter/generic/container.mjs
@@ -1,0 +1,68 @@
+const MODULE_ID = "pick-up-stix";
+
+/**
+ * Container mixin for the generic adapter.
+ *
+ * Container-parent linking is flag-based (used when generic mode creates a
+ * pickup stub in Phase 7). The generic adapter never creates system-level
+ * container items, so `getItemContainerId` / `setItemContainerId` operate
+ * on the same flag namespace as the dnd5e/pf2e adapters for compatibility
+ * with the shared transfer utilities.
+ */
+export const GenericContainer = {
+  /**
+   * @param {Item} item
+   * @returns {string|null}
+   */
+  getItemContainerId(item) {
+    return item?.getFlag?.(MODULE_ID, "containerId") ?? null;
+  },
+
+  /**
+   * @param {object} itemData - Raw item data object (pre-create).
+   * @param {string|null} containerId
+   */
+  setItemContainerId(itemData, containerId) {
+    foundry.utils.setProperty(
+      itemData,
+      `flags.${MODULE_ID}.containerId`,
+      containerId ?? null
+    );
+  },
+
+  /**
+   * Flatten a list of items into plain data objects ready for createDocuments,
+   * assigning new random IDs and optionally transforming each entry.
+   *
+   * @param {Array<foundry.abstract.Document|object>} items
+   * @param {{ transformAll?: (data: object) => object|null }} [options]
+   * @returns {Promise<object[]>}
+   */
+  async flattenItemsForCreate(items, options = {}) {
+    const { transformAll } = options;
+    const out = [];
+    for (const src of items) {
+      const data = src instanceof foundry.abstract.Document
+        ? src.toObject()
+        : foundry.utils.deepClone(src);
+      data._id = foundry.utils.randomID();
+      const result = transformAll ? transformAll(data) : data;
+      if (result != null) out.push(result);
+    }
+    return out;
+  },
+
+  /**
+   * Flatten items and create them via the document class.
+   *
+   * @param {Array<foundry.abstract.Document|object>} items
+   * @param {{ parent?: foundry.abstract.Document }} [options]
+   * @returns {Promise<foundry.abstract.Document[]>}
+   */
+  async createItemsWithContents(items, options = {}) {
+    const flat = await this.flattenItemsForCreate(items);
+    const createOptions = { keepId: true };
+    if (options.parent) createOptions.parent = options.parent;
+    return CONFIG.Item.documentClass.createDocuments(flat, createOptions);
+  }
+};

--- a/scripts/adapter/generic/containerView.mjs
+++ b/scripts/adapter/generic/containerView.mjs
@@ -1,0 +1,510 @@
+/**
+ * GenericInteractiveContainerView — ApplicationV2 sheet shown when a player
+ * (or GM) opens a container-mode generic interactive actor token.
+ *
+ * Renders the contents list from `flags["pick-up-stix"].interactive.contents[]`
+ * with per-row controls. Handles Item and interactive-Actor drops onto the
+ * contents list, appending an `{id, name, img, description, quantity}` record.
+ * Row dragstart emits a synthetic `"InteractiveContent"` payload for Phase 7
+ * to wire to canvas placement.
+ *
+ * Non-GM viewers see a placeholder ("contents hidden") when the container is
+ * closed/locked or they're out of interaction range — same UX as dnd5e/pf2e
+ * container views but evaluated inline rather than via a hook decorator.
+ *
+ * Per-actor singleton cached in `#instances`; cleaned up in `close()`.
+ */
+
+import { getAdapter } from "../index.mjs";
+import { checkProximity, pickupItem, depositItem, setContainerOpen, toggleContainerLocked } from "../../transfer/ItemTransfer.mjs";
+import { isModuleGM, isPlayerView } from "../../utils/playerView.mjs";
+import { validateContainerAccess } from "../../utils/containerAccess.mjs";
+import { resolvePickupTarget } from "../../utils/pickupFlow.mjs";
+import { dispatchGM } from "../../utils/gmDispatch.mjs";
+import { promptItemQuantity } from "../../utils/quantityPrompt.mjs";
+import { createStateToggleButton } from "../../utils/domButtons.mjs";
+import { dbg } from "../../utils/debugLog.mjs";
+
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;
+
+/**
+ * Container view sheet for generic-mode interactive actors in container mode.
+ * Shown to players and GMs when the token is clicked.
+ */
+export default class GenericInteractiveContainerView
+  extends HandlebarsApplicationMixin(ActorSheetV2) {
+
+  /** Per-actor singleton cache so repeat opens reuse the existing window. */
+  static #instances = new Map();
+
+  /**
+   * Resolve the container view sheet for a given actor, creating one on first
+   * call and returning the cached instance on subsequent calls.
+   *
+   * @param {Actor} actor
+   * @returns {GenericInteractiveContainerView}
+   */
+  static forActor(actor) {
+    const key = actor.uuid;
+    let sheet = GenericInteractiveContainerView.#instances.get(key);
+    if (!sheet) {
+      dbg("generic-container-view:forActor", "creating new instance", { actorName: actor.name });
+      sheet = new GenericInteractiveContainerView({ document: actor });
+      GenericInteractiveContainerView.#instances.set(key, sheet);
+    }
+    return sheet;
+  }
+
+  static DEFAULT_OPTIONS = {
+    classes: ["pick-up-stix", "generic-container-view", "sheet"],
+    position: { width: 420, height: "auto" },
+    window: { resizable: true },
+    // Drag-and-drop is wired entirely via explicit addEventListener in
+    // _onRender (both dragstart on rows and drop on the whole window).
+    // The V2 DragDrop framework's bind/re-bind timing turned out flaky
+    // here: the first drop after a render sometimes silently no-oped
+    // because the listener wasn't re-attached on the post-render DOM in
+    // the same tick the drop fired. Explicit listeners in _onRender run
+    // synchronously after every render and don't miss.
+    actions: {
+      deleteContent: GenericInteractiveContainerView.#onDeleteContent
+    }
+  };
+
+  static PARTS = {
+    body: { template: "modules/pick-up-stix/templates/container-view-generic.hbs" }
+  };
+
+  get title() {
+    return getAdapter().getInteractiveDisplayName(this.actor);
+  }
+
+  /**
+   * Build template context from the actor's interactive flag blob.
+   * Evaluates the contents-visibility gate inline: non-GM viewers see a
+   * placeholder when the container is closed/locked or they're out of
+   * interaction range.
+   *
+   * @param {object} options
+   * @returns {Promise<object>}
+   */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+
+    dbg("generic-container-view:_prepareContext", {
+      actorName: this.actor?.name,
+      isOpen: data.isOpen,
+      isLocked: data.isLocked,
+      contentsCount: (data.contents ?? []).length
+    });
+
+    context.name = data.name || this.actor.name;
+
+    // Swap to the open image when the container is open and one is configured.
+    context.img = (data.isOpen && data.openImage)
+      ? data.openImage
+      : (data.img || this.actor.img);
+
+    context.descriptionHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      data.description ?? "", { async: true }
+    );
+
+    context.isGM = game.user.isGM;
+    // The pickup hand button is only meaningful when the source container
+    // is a placed token (synthetic actor) — picking up from the sidebar
+    // template doesn't correspond to anything in the world.
+    context.isTokenActor = !!this.actor.token;
+
+    context.contents = (data.contents ?? []).map(c => ({
+      ...c,
+      showQuantity: (c.quantity ?? 1) > 1
+    }));
+
+    // Contents-visibility gate — same logic as the dnd5e/pf2e contents-hide
+    // decorators, but evaluated inline since this sheet owns its own rendering.
+    const closedOrLocked = !data.isOpen || data.isLocked;
+    const inRange = checkProximity(this.actor, { silent: true, range: "interaction" });
+
+    if (!isModuleGM() && (closedOrLocked || !inRange)) {
+      dbg("generic-container-view:_prepareContext", "hiding contents", { closedOrLocked, inRange });
+      context.showContents = false;
+      context.hiddenMessage = closedOrLocked
+        ? game.i18n.localize("INTERACTIVE_ITEMS.Notify.ContainerClosed")
+        : game.i18n.localize("INTERACTIVE_ITEMS.Container.ContentsHidden");
+    } else {
+      context.showContents = true;
+    }
+
+    return context;
+  }
+
+  /**
+   * Attach per-row listeners on every render. V2 re-runs _onRender on each
+   * repaint so listeners are always fresh. We wire dragstart and the pickup
+   * click handler here rather than via the V2 DragDrop framework so the
+   * payload reliably reaches the canvas drop handler and the pickup target
+   * resolution happens with up-to-date state.
+   *
+   * @param {object} context
+   * @param {object} options
+   */
+  _onRender(context, options) {
+    super._onRender(context, options);
+
+    // Attach drop/dragover on the template-root section rather than
+    // this.element. V2 re-uses this.element across renders so addEventListener
+    // would stack — the drop would fire N times after N renders, re-opening
+    // the quantity prompt for every accumulated listener. The section is
+    // part of the rendered template content, which V2 replaces each render,
+    // so old listeners are garbage-collected with the old DOM. Covers the
+    // whole sheet body: header, description, contents list.
+    const dropTarget = this.element?.querySelector(".generic-container-view");
+    if (dropTarget) {
+      dropTarget.addEventListener("dragover", (event) => event.preventDefault());
+      dropTarget.addEventListener("drop", (event) => this.#onDropOntoContents(event));
+    }
+
+    // GM-only window-header toggles (Open/Close, Lock, Configure). The
+    // window-header IS preserved across renders, so guard against duplicate
+    // injection by removing any prior toggles first inside #injectHeaderToggles.
+    if (game.user.isGM) {
+      const header = this.element?.querySelector(".window-header");
+      if (header) this.#injectHeaderToggles(header);
+    }
+
+    if (!context.showContents) return;
+
+    this.element.querySelectorAll(".ii-contents-row").forEach(row => {
+      row.addEventListener("dragstart", (event) => this.#onRowDragStart(event, row));
+    });
+
+    this.element.querySelectorAll(".ii-pickup-btn").forEach(btn => {
+      btn.addEventListener("click", (event) => this.#onPickupClick(event, btn));
+    });
+  }
+
+  /**
+   * Inject Open/Close + Lock + Configure window-header toggles. Matches the
+   * dnd5e/pf2e shared decorator's order. Identify is intentionally omitted
+   * (generic mode has supportsIdentification:false).
+   */
+  #injectHeaderToggles(header) {
+    header.querySelectorAll(".ii-containerview-toggle").forEach(el => el.remove());
+
+    const adapter = getAdapter();
+    const isOpen = adapter.isInteractiveOpen(this.actor);
+    const isLocked = adapter.isInteractiveLocked(this.actor);
+    const actor = this.actor;
+    const buttons = [];
+
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-containerview-toggle",
+      active: isOpen,
+      iconOn: "fa-box-open",
+      iconOff: "fa-box",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateOpened",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateClosed",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        await setContainerOpen(actor, !adapter.isInteractiveOpen(actor));
+      }
+    }));
+
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-containerview-toggle",
+      active: isLocked,
+      iconOn: "fa-lock",
+      iconOff: "fa-lock-open",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
+      onClick: (ev) => {
+        ev.preventDefault();
+        toggleContainerLocked(actor);
+      }
+    }));
+
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-containerview-toggle",
+      active: true,
+      iconOn: "fa-gear",
+      iconOff: "fa-gear",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        await this.close();
+        actor.sheet.renderConfig();
+      }
+    }));
+
+    const title = header.querySelector(".window-title");
+    if (title) title.after(...buttons);
+    else header.prepend(...buttons);
+  }
+
+  /**
+   * Handle a drag-and-drop onto the sheet. Accepts:
+   * - `type: "Item"` — a sidebar / compendium / actor item.
+   * - `type: "Actor"` — an item-mode interactive actor (generic).
+   *
+   * Extracts `{name, img, description, quantity}` from the dragged object and
+   * appends a new content record (with a fresh random id) to `contents[]`.
+   * Drop is gated on container state (proximity for players, closed/locked
+   * for everyone) via validateContainerAccess.
+   *
+   * Wired explicitly in _onRender via addEventListener on `this.element`.
+   *
+   * @param {DragEvent} event
+   */
+  async #onDropOntoContents(event) {
+    event.preventDefault();
+    const adapter = getAdapter();
+    const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
+    dbg("generic-container-view:onDrop", { type: data?.type, uuid: data?.uuid });
+
+    // Player-view drops are gated on proximity + open + unlocked, matching
+    // the dnd5e/pf2e _gateContainerDrop flow. GM (with override) bypasses.
+    if (isPlayerView()) {
+      if (!validateContainerAccess(this.actor, { checkProximity: true })) {
+        dbg("generic-container-view:onDrop", "player gate failed, bail");
+        return;
+      }
+    } else {
+      // GM with override on: still surface a closed-container warning so
+      // they aren't confused by silent acceptance into a closed container.
+      // Lock state is always enforced (notification, not block).
+      if (!validateContainerAccess(this.actor, { checkProximity: false })) {
+        dbg("generic-container-view:onDrop", "GM gate failed, bail");
+        return;
+      }
+    }
+
+    let payload = null;
+
+    if (data?.type === "Item") {
+      const item = await fromUuid(data.uuid);
+      if (!item) {
+        dbg("generic-container-view:onDrop", "item not found", { uuid: data.uuid });
+        return;
+      }
+
+      // Partial-stack prompt for inventory-source items with qty > 1.
+      // World items skip — they're created at the dragged quantity and have
+      // no source to decrement.
+      const sourceQty = adapter.getItemQuantity(item);
+      let chosenQty = null;
+      if (item.actor && sourceQty > 1) {
+        chosenQty = await promptItemQuantity({
+          itemName: item.name,
+          max: sourceQty,
+          actionKey: "INTERACTIVE_ITEMS.Dialog.QuantityActionDeposit",
+          actionFormatArgs: { target: this.actor.name }
+        });
+        if (chosenQty == null) {
+          dbg("generic-container-view:onDrop", "deposit quantity dialog cancelled, bail");
+          return;
+        }
+      }
+
+      // Inventory-source items: route through the depositItem socket so the
+      // GM-side handler writes the contents row AND decrements the source.
+      // Otherwise the source item leaks (it stays in the player's inventory
+      // even though a copy now exists in the container).
+      if (item.actor) {
+        const tokenDoc = this.actor.token;
+        if (!tokenDoc) {
+          // Container is being viewed via sidebar template — can't route
+          // through the socket (needs sceneId/tokenId). Direct write below
+          // can't decrement the source either, so bail with a notice.
+          dbg("generic-container-view:onDrop", "no token on container actor, can't route inventory deposit");
+          ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
+          return;
+        }
+        const sceneId = tokenDoc.parent.id;
+        const tokenId = tokenDoc.id;
+        const moveQty = chosenQty ?? sourceQty;
+        dbg("generic-container-view:onDrop", "inventory-source: dispatching depositItem", { sourceActorId: item.actor.id, moveQty });
+        await dispatchGM(
+          "depositItem",
+          { sourceActorId: item.actor.id, itemId: item.id, sceneId, tokenId, quantity: moveQty },
+          async () => depositItem(item.actor.id, item.id, sceneId, tokenId, moveQty)
+        );
+        return;
+      }
+
+      // World item (no source actor): direct flag write at the dragged quantity.
+      payload = {
+        id: foundry.utils.randomID(),
+        name: item.name,
+        img: item.img,
+        // Both `system.description.value` (dnd5e/pf2e) and `system.description`
+        // (many generic systems) are checked; missing = empty string.
+        description: item.system?.description?.value ?? item.system?.description ?? "",
+        quantity: sourceQty
+      };
+    } else if (data?.type === "Actor") {
+      // Only accept item-mode generic interactive actors so GMs can
+      // deposit placed items directly into a container by dragging.
+      const droppedActor = await fromUuid(data.uuid);
+      if (!droppedActor) {
+        dbg("generic-container-view:onDrop", "actor not found", { uuid: data.uuid });
+        return;
+      }
+      const droppedData = adapter.getInteractiveData(droppedActor);
+      if (droppedData.mode !== "item" || !droppedData.itemData) {
+        dbg("generic-container-view:onDrop", "actor is not an item-mode interactive with itemData — skipping", {
+          mode: droppedData.mode, hasItemData: !!droppedData.itemData
+        });
+        return;
+      }
+      // Prefer top-level interactive fields — those reflect the GM's
+      // current edits via the config sheet. itemData is the snapshot at
+      // drop time and goes stale after any rename / image change.
+      payload = {
+        id: foundry.utils.randomID(),
+        name: droppedData.name || droppedData.itemData?.name || droppedActor.name,
+        img: droppedData.img || droppedData.itemData?.img || droppedActor.img,
+        description: droppedData.description || droppedData.itemData?.description || "",
+        quantity: droppedData.itemData?.quantity ?? 1
+      };
+    }
+
+    if (!payload) {
+      dbg("generic-container-view:onDrop", "unhandled drag type, skipping", { type: data?.type });
+      return;
+    }
+
+    dbg("generic-container-view:onDrop", "appending content row", { name: payload.name, qty: payload.quantity });
+    const current = adapter.getInteractiveData(this.actor);
+    const next = [...(current.contents ?? []), payload];
+    await adapter.setInteractiveData(this.actor, { contents: next });
+    this.render();
+  }
+
+  /**
+   * Emit a synthetic `"InteractiveContent"` drag payload when the user
+   * starts dragging a content row. Wired explicitly in `_onRender` rather
+   * than through V2's DragDrop framework so the payload reliably lands on
+   * `dataTransfer` before the canvas drop handler reads it.
+   *
+   * The inner `<img>` has `draggable="false"` (template) so clicks on the
+   * image bubble up to the `<li>` instead of triggering the browser's
+   * built-in image-drag (which would put the image URL in dataTransfer
+   * instead of our JSON payload).
+   *
+   * @param {DragEvent} event
+   * @param {HTMLElement} row - The `<li>` content row (currentTarget).
+   */
+  #onRowDragStart(event, row) {
+    const contentId = row?.dataset?.contentId;
+    if (!contentId) return;
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    const rowData = data.contents?.find(c => c.id === contentId);
+    if (!rowData) {
+      dbg("generic-container-view:onRowDragStart", "content row not found in flag data", { contentId });
+      return;
+    }
+    const payload = {
+      type: "InteractiveContent",
+      sourceActorUuid: this.actor.uuid,
+      contentId,
+      itemData: rowData
+    };
+    dbg("generic-container-view:onRowDragStart", "setting drag payload", { contentId, name: rowData.name });
+    event.dataTransfer.setData("text/plain", JSON.stringify(payload));
+    event.dataTransfer.effectAllowed = "all";
+  }
+
+  /**
+   * Pickup-hand click on a content row. Resolves the player target, checks
+   * proximity + lock, then dispatches `pickupItem` with `contentId` so the
+   * GM-side helper pulls the row out of `contents[]` and creates a stub
+   * item on the target.
+   *
+   * @param {MouseEvent} event
+   * @param {HTMLElement} btn - The clicked button (has `data-content-id`).
+   */
+  async #onPickupClick(event, btn) {
+    event.preventDefault();
+    event.stopPropagation();
+    const contentId = btn?.dataset?.contentId;
+    if (!contentId) return;
+    dbg("generic-container-view:onPickupClick", { contentId, actorName: this.actor?.name });
+
+    // Same gates as the HUD pickup button on item-mode tokens.
+    if (!checkProximity(this.actor)) return;
+    if (!validateContainerAccess(this.actor, { checkOpen: false })) return;
+
+    const targetActor = await resolvePickupTarget(this.actor);
+    if (!targetActor) return;
+
+    const tokenDoc = this.actor.token;
+    if (!tokenDoc) {
+      dbg("generic-container-view:onPickupClick", "no token on actor (sidebar template?), bail");
+      return;
+    }
+    const sceneId = tokenDoc.parent.id;
+    const tokenId = tokenDoc.id;
+
+    // Partial-stack prompt — same UX as the token-level pickup HUD button.
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    const row = data.contents?.find(c => c.id === contentId);
+    const rowQty = row?.quantity ?? 1;
+    let chosenQty = null;
+    if (rowQty > 1) {
+      chosenQty = await promptItemQuantity({
+        itemName: row?.name ?? "",
+        max: rowQty,
+        actionKey: "INTERACTIVE_ITEMS.Dialog.QuantityActionPickup",
+        actionFormatArgs: { target: targetActor.name }
+      });
+      if (chosenQty == null) {
+        dbg("generic-container-view:onPickupClick", "quantity dialog cancelled, bail");
+        return;
+      }
+    }
+
+    await dispatchGM(
+      "pickupItem",
+      { sceneId, tokenId, itemId: null, targetActorId: targetActor.id, quantity: chosenQty, contentId },
+      async () => pickupItem(sceneId, tokenId, null, targetActor.id, chosenQty, contentId)
+    );
+  }
+
+  /**
+   * GM-only: remove a content row by its id from the `contents[]` array.
+   *
+   * @param {Event} event
+   * @param {HTMLElement} target  The button element carrying `data-content-id`.
+   */
+  static async #onDeleteContent(event, target) {
+    event.preventDefault();
+    if (!game.user.isGM) return;
+    const contentId = target.dataset.contentId;
+    dbg("generic-container-view:onDeleteContent", { contentId, actorId: this.actor?.id });
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    const next = (data.contents ?? []).filter(c => c.id !== contentId);
+    await adapter.setInteractiveData(this.actor, { contents: next });
+    this.render();
+  }
+
+  /**
+   * Remove this sheet from the per-actor cache when it closes so a subsequent
+   * open creates a fresh instance rather than attempting to re-render a closed
+   * window.
+   *
+   * @param {object} [options]
+   * @returns {Promise<void>}
+   */
+  async close(options = {}) {
+    dbg("generic-container-view:close", { actorName: this.actor?.name });
+    GenericInteractiveContainerView.#instances.delete(this.actor?.uuid);
+    return super.close(options);
+  }
+}

--- a/scripts/adapter/generic/data.mjs
+++ b/scripts/adapter/generic/data.mjs
@@ -1,0 +1,152 @@
+const MODULE_ID = "pick-up-stix";
+const NS = "interactive";
+
+/**
+ * Default interactive data shape for a freshly-created generic actor.
+ * `mode` is null until the GM picks via the kind-picker dialog (existing
+ * pick-up-stix.mjs flow); once chosen, it's "item" or "container".
+ *
+ * @returns {object}
+ */
+export function makeDefaultInteractiveData() {
+  return {
+    mode: null,
+    name: "",
+    img: "",
+    description: "",
+    isLocked: false,
+    isOpen: false,
+    lockedMessage: "",
+    openImage: null,
+    limitedName: "",
+    limitedDescription: "",
+    interactionRange: 1,
+    inspectionRange: 4,
+    itemData: null,   // mode="item":      {name, img, description, quantity}
+    contents: []      // mode="container": Array<{id, name, img, description, quantity}>
+  };
+}
+
+export const GenericData = {
+
+  /**
+   * Read the full interactive blob from the actor's flags. Returns the
+   * default shape merged with whatever the actor has stored so callers
+   * can rely on every key existing.
+   *
+   * @param {Actor} actor
+   * @returns {object}
+   */
+  getInteractiveData(actor) {
+    const stored = actor?.getFlag?.(MODULE_ID, NS) ?? {};
+    return foundry.utils.mergeObject(
+      makeDefaultInteractiveData(),
+      stored,
+      { inplace: false, insertKeys: true }
+    );
+  },
+
+  /**
+   * Persist a partial update to the interactive blob via setFlag.
+   *
+   * @param {Actor} actor
+   * @param {object} partial
+   * @returns {Promise<Actor>}
+   */
+  async setInteractiveData(actor, partial) {
+    const current = this.getInteractiveData(actor);
+    const next = foundry.utils.mergeObject(current, partial, { inplace: false });
+    return actor.setFlag(MODULE_ID, NS, next);
+  },
+
+  // === Dispatcher abstractions (override base SystemAdapter implementations) ===
+
+  isInteractiveContainer(actor) {
+    return this.getInteractiveData(actor).mode === "container";
+  },
+
+  /**
+   * Container actors always have an "embedded" view (the contents UI,
+   * even if empty). Item actors only have one once itemData is set.
+   *
+   * @param {Actor} actor
+   * @returns {boolean}
+   */
+  hasInteractiveEmbeddedItem(actor) {
+    const data = this.getInteractiveData(actor);
+    if (data.mode === "container") return true;
+    return !!data.itemData;
+  },
+
+  /**
+   * @param {Actor} actor
+   * @returns {string}
+   */
+  getInteractiveDisplayName(actor) {
+    const data = this.getInteractiveData(actor);
+    return data.name || actor?.name || "";
+  },
+
+  /**
+   * @param {Actor} actor
+   * @returns {string}
+   */
+  getInteractiveLimitedName(actor) {
+    const data = this.getInteractiveData(actor);
+    if (data.limitedName) return data.limitedName;
+    if (data.mode === "container") {
+      return game.i18n.localize("INTERACTIVE_ITEMS.Limited.DefaultContainerName");
+    }
+    return game.i18n.format("INTERACTIVE_ITEMS.Limited.DefaultItemName", {
+      type: game.i18n.localize("INTERACTIVE_ITEMS.Limited.DefaultItemTypeGeneric")
+    });
+  },
+
+  /**
+   * @param {Actor} actor
+   * @returns {string}
+   */
+  getInteractiveLimitedDescription(actor) {
+    const data = this.getInteractiveData(actor);
+    let body = data.limitedDescription
+      || game.i18n.localize("INTERACTIVE_ITEMS.Limited.DefaultDescription");
+    if (data.mode === "container") {
+      const stateKey = data.isOpen
+        ? "INTERACTIVE_ITEMS.Limited.AppearsOpen"
+        : "INTERACTIVE_ITEMS.Limited.AppearsClosed";
+      body = `${body}\n<p>${game.i18n.localize(stateKey)}</p>`;
+    }
+    return body;
+  },
+
+  /** Read isOpen from the flag blob — actor.system has no such field on generic. */
+  isInteractiveOpen(actor) {
+    return !!this.getInteractiveData(actor).isOpen;
+  },
+
+  /** Read isLocked from the flag blob — actor.system has no such field on generic. */
+  isInteractiveLocked(actor) {
+    return !!this.getInteractiveData(actor).isLocked;
+  },
+
+  /** Write isOpen into the flag blob; the updateActor hook re-renders open sheets. */
+  async setInteractiveOpenState(actor, isOpen) {
+    await this.setInteractiveData(actor, { isOpen: !!isOpen });
+  },
+
+  /** Write isLocked into the flag blob. */
+  async setInteractiveLockedState(actor, isLocked) {
+    await this.setInteractiveData(actor, { isLocked: !!isLocked });
+  },
+
+  /** Read the per-actor locked message from flags, falling back to the default. */
+  getInteractiveLockedMessage(actor) {
+    const data = this.getInteractiveData(actor);
+    return data.lockedMessage || game.i18n.localize("INTERACTIVE_ITEMS.Notify.Locked");
+  },
+
+  /** Read openImage from the flag blob — actor.system has no such field on generic. */
+  getInteractiveOpenImage(actor) {
+    return this.getInteractiveData(actor).openImage ?? null;
+  }
+};

--- a/scripts/adapter/generic/hooks.mjs
+++ b/scripts/adapter/generic/hooks.mjs
@@ -1,0 +1,28 @@
+import { dbg } from "../../utils/debugLog.mjs";
+
+/**
+ * Hook registration mixin for the generic adapter.
+ *
+ * All `register*` methods are permanent no-ops — the generic adapter does not
+ * decorate system sheets because it never uses them. Drop handling for the
+ * module's custom sheets happens inside those sheets directly (Phase 6). The
+ * no-ops satisfy the SystemAdapter contract so core code can call them
+ * unconditionally without branching on adapter type.
+ */
+export const GenericHooks = {
+  registerItemSheetHooks(_handlers) {
+    dbg("generic-hooks:registerItemSheetHooks", "no-op — generic mode doesn't decorate system item sheets");
+  },
+  registerContainerViewHooks(_handlers) {
+    dbg("generic-hooks:registerContainerViewHooks", "no-op — generic mode uses its own container view sheet");
+  },
+  registerActorInventoryHooks(_callback) {
+    dbg("generic-hooks:registerActorInventoryHooks", "no-op — identify UI is hidden in generic mode");
+  },
+  registerContainerDropGate(_callback) {
+    dbg("generic-hooks:registerContainerDropGate", "no-op — generic container sheet handles its own drops");
+  },
+  registerItemContextMenu(_extender) {
+    dbg("generic-hooks:registerItemContextMenu", "no-op — no portable context menu hook");
+  }
+};

--- a/scripts/adapter/generic/identification.mjs
+++ b/scripts/adapter/generic/identification.mjs
@@ -1,0 +1,23 @@
+/**
+ * Identification mixin for the generic adapter.
+ *
+ * Every method is a safe no-op — identification UI is hidden via the
+ * `supportsIdentification: false` capability gate, so most stubs are never
+ * reached in practice. They exist to satisfy the SystemAdapter contract so
+ * the generic adapter can be used as a drop-in replacement without runtime
+ * errors if a call site somehow bypasses the gate.
+ */
+export const GenericIdentification = {
+  isItemIdentified(_item) { return true; },
+  async setItemIdentified(item, _isIdentified) { return item; },
+  getItemUnidentifiedName(_item) { return null; },
+  getItemUnidentifiedDescription(_item) { return null; },
+  getItemUnidentifiedImage(_item) { return null; },
+  buildItemIdentificationUpdate(_actor, _changes) { return {}; },
+  buildEmbeddedItemSourceUpdate(_actor, _isIdentified) { return {}; },
+  parseEmbeddedItemChanges(_item, _changes, _actor) { return {}; },
+  isIdentificationChange(_item, _changes) { return false; },
+  stampNewItemIdentified(itemData, _isIdentified) { return itemData; },
+  async performIdentifyToggle(_item) { /* no-op */ },
+  isPhysicalItem(item) { return item != null && item.system != null; }
+};

--- a/scripts/adapter/generic/index.mjs
+++ b/scripts/adapter/generic/index.mjs
@@ -1,0 +1,77 @@
+import SystemAdapter from "../SystemAdapter.mjs";
+import { GenericData } from "./data.mjs";
+import { GenericIdentification } from "./identification.mjs";
+import { GenericContainer } from "./container.mjs";
+import { GenericSheets } from "./sheets.mjs";
+import { GenericHooks } from "./hooks.mjs";
+
+const MODULE_ID = "pick-up-stix";
+
+/**
+ * Fallback SystemAdapter for systems without a dedicated pick-up-stix adapter.
+ *
+ * Diverges from the dnd5e/pf2e adapters at the data layer: every
+ * interactive-object property lives in `flags["pick-up-stix"].interactive.*`,
+ * the actor's `system` data is never read, and `actor.items` is never used.
+ * The custom sheets in `./configSheet.mjs`, `./itemView.mjs`, and
+ * `./containerView.mjs` render entirely from flag data.
+ *
+ * `containerItemType` and `defaultLootItemType` are defined directly on the
+ * class (not mixed in via Object.assign) because Object.assign invokes getter
+ * accessors at copy time, which would capture the wrong `this` context.
+ */
+export default class GenericAdapter extends SystemAdapter {
+  static SYSTEM_ID = "generic";
+
+  capabilities = {
+    hasUnidentifiedItemImage: false,
+    hasItemDropSheetHook: false,
+    hasItemContextMenuHook: false,
+    hasNativeContainerWindow: false,
+    hasNativeDeepCreate: false,
+    hasNativeInventoryIdentify: false,
+    supportsIdentification: false
+  };
+
+  get cssClasses() {
+    return {
+      stateToggle: "header-control",
+      configButton: "header-control",
+      rowControl: "",
+      headerElementType: "button"
+    };
+  }
+
+  get nativeIdentifyHeaderSelector() {
+    return null;
+  }
+
+  /**
+   * Unused on the generic path — we never create system items for containers.
+   *
+   * @returns {string}
+   */
+  get containerItemType() {
+    return "";
+  }
+
+  /**
+   * The item type used when creating a pickup stub in a player's inventory
+   * (Phase 7). Read from a world setting populated by a heuristic + dialog.
+   *
+   * @returns {string}
+   */
+  get defaultLootItemType() {
+    try {
+      return game.settings.get(MODULE_ID, "genericPickupItemType") || "";
+    } catch {
+      return "";
+    }
+  }
+}
+
+Object.assign(GenericAdapter.prototype, GenericData);
+Object.assign(GenericAdapter.prototype, GenericIdentification);
+Object.assign(GenericAdapter.prototype, GenericContainer);
+Object.assign(GenericAdapter.prototype, GenericSheets);
+Object.assign(GenericAdapter.prototype, GenericHooks);

--- a/scripts/adapter/generic/itemView.mjs
+++ b/scripts/adapter/generic/itemView.mjs
@@ -1,0 +1,175 @@
+/**
+ * GenericInteractiveItemView — read-only ApplicationV2 sheet shown when a
+ * player (or GM) opens an item-mode generic interactive actor token.
+ *
+ * Displays name, image, optional quantity badge (when quantity > 1), and
+ * enriched HTML description. All data is sourced from the actor's
+ * `flags["pick-up-stix"].interactive` blob via `adapter.getInteractiveData`.
+ * The actor's `system.*` and `actor.items` are never accessed.
+ *
+ * Per-actor singleton cached in `#instances`; cleaned up in `close()`.
+ */
+
+import { getAdapter } from "../index.mjs";
+import { createStateToggleButton } from "../../utils/domButtons.mjs";
+import { toggleContainerLocked } from "../../transfer/ItemTransfer.mjs";
+import { dbg } from "../../utils/debugLog.mjs";
+
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+const ActorSheetV2 = foundry.applications.sheets.ActorSheetV2;
+
+/**
+ * Read-only item view sheet for generic-mode interactive actors in
+ * item mode. Shown to players and GMs when the token is clicked.
+ */
+export default class GenericInteractiveItemView
+  extends HandlebarsApplicationMixin(ActorSheetV2) {
+
+  /** Per-actor singleton cache so repeat opens reuse the existing window. */
+  static #instances = new Map();
+
+  /**
+   * Resolve the item view sheet for a given actor, creating one on first call
+   * and returning the cached instance on subsequent calls.
+   *
+   * @param {Actor} actor
+   * @returns {GenericInteractiveItemView}
+   */
+  static forActor(actor) {
+    const key = actor.uuid;
+    let sheet = GenericInteractiveItemView.#instances.get(key);
+    if (!sheet) {
+      dbg("generic-item-view:forActor", "creating new instance", { actorName: actor.name });
+      sheet = new GenericInteractiveItemView({ document: actor });
+      GenericInteractiveItemView.#instances.set(key, sheet);
+    }
+    return sheet;
+  }
+
+  static DEFAULT_OPTIONS = {
+    classes: ["pick-up-stix", "generic-item-view", "sheet"],
+    position: { width: 360, height: "auto" },
+    window: { resizable: true },
+    // Read-only — no form submission.
+    form: { submitOnChange: false }
+  };
+
+  static PARTS = {
+    body: { template: "modules/pick-up-stix/templates/item-view-generic.hbs" }
+  };
+
+  get title() {
+    return getAdapter().getInteractiveDisplayName(this.actor);
+  }
+
+  /**
+   * Build template context from the actor's interactive flag blob. Prefers
+   * `data.itemData` for all display values but falls back to the top-level
+   * flag fields (`data.name`, `data.img`, `data.description`) so the sheet
+   * renders even for actors that were configured before `itemData` was
+   * populated.
+   *
+   * @param {object} options
+   * @returns {Promise<object>}
+   */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+
+    dbg("generic-item-view:_prepareContext", { actorName: this.actor?.name, hasItemData: !!data.itemData });
+
+    // Prefer top-level interactive fields — those reflect the GM's current
+    // edits via the config sheet. `data.itemData` is the snapshot taken when
+    // a source item was dropped onto the config sheet and only changes on
+    // a re-drop; using it directly would show stale name/img/description
+    // after any edit. Quantity is sourced only from itemData.
+    const snapshot = data.itemData ?? {};
+    const itemData = {
+      name: data.name || snapshot.name || "",
+      img: data.img || snapshot.img || "",
+      description: data.description || snapshot.description || "",
+      quantity: snapshot.quantity ?? 1
+    };
+
+    context.itemData = itemData;
+    context.showQuantity = (itemData.quantity ?? 1) > 1;
+    context.descriptionHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+      itemData.description,
+      { async: true }
+    );
+
+    return context;
+  }
+
+  /**
+   * Inject the GM-only window-header toggles (Lock, Configure) on every
+   * render. Identify is intentionally omitted — generic mode has
+   * supportsIdentification:false. Open/Close is also omitted — items don't
+   * have an open state.
+   *
+   * @param {object} context
+   * @param {object} options
+   */
+  _onRender(context, options) {
+    super._onRender(context, options);
+    if (!game.user.isGM) return;
+    const header = this.element?.querySelector(".window-header");
+    if (header) this.#injectHeaderToggles(header);
+  }
+
+  #injectHeaderToggles(header) {
+    header.querySelectorAll(".ii-itemview-toggle").forEach(el => el.remove());
+
+    const adapter = getAdapter();
+    const isLocked = adapter.isInteractiveLocked(this.actor);
+    const actor = this.actor;
+    const buttons = [];
+
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-itemview-toggle",
+      active: isLocked,
+      iconOn: "fa-lock",
+      iconOff: "fa-lock-open",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
+      onClick: (ev) => {
+        ev.preventDefault();
+        toggleContainerLocked(actor);
+      }
+    }));
+
+    // Configure: closes this view and opens the GM config sheet.
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-itemview-toggle",
+      active: true,
+      iconOn: "fa-gear",
+      iconOff: "fa-gear",
+      labelOnKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
+      labelOffKey: "INTERACTIVE_ITEMS.Sheet.ConfigureHUD",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        await this.close();
+        actor.sheet.renderConfig();
+      }
+    }));
+
+    const title = header.querySelector(".window-title");
+    if (title) title.after(...buttons);
+    else header.prepend(...buttons);
+  }
+
+  /**
+   * Remove this sheet from the per-actor cache when it closes so a subsequent
+   * open creates a fresh instance rather than attempting to re-render a
+   * closed window.
+   *
+   * @param {object} [options]
+   * @returns {Promise<void>}
+   */
+  async close(options = {}) {
+    dbg("generic-item-view:close", { actorName: this.actor?.name });
+    GenericInteractiveItemView.#instances.delete(this.actor?.uuid);
+    return super.close(options);
+  }
+}

--- a/scripts/adapter/generic/sheets.mjs
+++ b/scripts/adapter/generic/sheets.mjs
@@ -1,0 +1,74 @@
+import { dbg } from "../../utils/debugLog.mjs";
+
+/**
+ * Sheet delegation mixin for the generic adapter.
+ *
+ * Each method lazy-imports the corresponding custom sheet class. The imports
+ * execute only when a sheet is actually opened, so the adapter package loads
+ * cleanly even before the target files exist (Phases 4-6). If a file is
+ * absent, the dynamic import rejects and the error surfaces at open-time
+ * rather than at module init.
+ */
+export const GenericSheets = {
+  /**
+   * Open (or focus) the generic container view for the given actor.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application>}
+   */
+  async renderContainerView(actor, options = {}) {
+    if (typeof options !== "object" || options === null) options = {};
+    dbg("generic-sheets:renderContainerView", { actorName: actor?.name });
+    const { default: GenericInteractiveContainerView } = await import("./containerView.mjs");
+    const sheet = GenericInteractiveContainerView.forActor(actor);
+    await sheet.render({ force: true, ...options });
+    return sheet;
+  },
+
+  /**
+   * Open (or focus) the generic item view for the given actor.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application>}
+   */
+  async renderItemView(actor, options = {}) {
+    if (typeof options !== "object" || options === null) options = {};
+    dbg("generic-sheets:renderItemView", { actorName: actor?.name });
+    const { default: GenericInteractiveItemView } = await import("./itemView.mjs");
+    const sheet = GenericInteractiveItemView.forActor(actor);
+    await sheet.render({ force: true, ...options });
+    return sheet;
+  },
+
+  /**
+   * Open the appropriate embedded view (container or item) based on the
+   * actor's current mode.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application>}
+   */
+  async renderEmbeddedSheet(actor, options = {}) {
+    return this.isInteractiveContainer(actor)
+      ? this.renderContainerView(actor, options)
+      : this.renderItemView(actor, options);
+  },
+
+  /**
+   * Open (or focus) the generic GM config sheet for the given actor.
+   *
+   * @param {Actor} actor
+   * @param {object} [options]
+   * @returns {Promise<Application>}
+   */
+  async renderConfigSheet(actor, options = {}) {
+    if (typeof options !== "object" || options === null) options = {};
+    dbg("generic-sheets:renderConfigSheet", { actorName: actor?.name });
+    const { default: GenericInteractiveItemConfigSheet } = await import("./configSheet.mjs");
+    const sheet = GenericInteractiveItemConfigSheet.forActor(actor);
+    await sheet.render({ force: true, ...options });
+    return sheet;
+  }
+};

--- a/scripts/adapter/index.mjs
+++ b/scripts/adapter/index.mjs
@@ -11,9 +11,13 @@ let _adapter = null;
  * `./adapter/<systemId>/index.mjs`, so only the active system's code is
  * fetched over the network.
  *
+ * If no system-specific adapter exists, the generic adapter
+ * (`./generic/index.mjs`) is loaded as a fallback and a console warning is
+ * emitted. The generic adapter stores all state in actor flags rather than
+ * relying on system-specific data models.
+ *
  * @returns {Promise<import("./SystemAdapter.mjs").default>}
- * @throws {Error} If `game.system` is not available at module-entry time, or
- *   if no adapter exists for the active system.
+ * @throws {Error} If `game.system` is not available at module-entry time.
  */
 export async function loadAdapter() {
   if (_adapter) return _adapter;
@@ -26,9 +30,9 @@ export async function loadAdapter() {
   let mod;
   try {
     mod = await import(`./${systemId}/index.mjs`);
-  } catch (err) {
-    console.error(`pick-up-stix: no adapter for system "${systemId}"`, err);
-    throw err;
+  } catch {
+    console.warn(`pick-up-stix: no dedicated adapter for system "${systemId}", loading generic adapter`);
+    mod = await import("./generic/index.mjs");
   }
 
   _adapter = new mod.default();

--- a/scripts/adapter/pf2e/index.mjs
+++ b/scripts/adapter/pf2e/index.mjs
@@ -68,7 +68,9 @@ export default class Pf2eAdapter extends SystemAdapter {
     /** pf2e has no createWithContents equivalent; the adapter walks manually. */
     hasNativeDeepCreate: false,
     /** pf2e renders toggle-identified controls natively on every inventory row. */
-    hasNativeInventoryIdentify: true
+    hasNativeInventoryIdentify: true,
+    /** pf2e supports identified/unidentified item states. */
+    supportsIdentification: true
   };
 
   /**

--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -2,7 +2,7 @@ import { isInteractiveActor, getTokenActor } from "../utils/actorHelpers.mjs";
 import { getItemSourceActorId } from "../utils/itemFlags.mjs";
 import { dispatchGM } from "../utils/gmDispatch.mjs";
 import { notifyItemAction, notifyTransferError } from "../utils/notify.mjs";
-import { getPlayerCandidateTokens, depositItem, buildInteractiveItemData, assignContainerParent } from "../transfer/ItemTransfer.mjs";
+import { getPlayerCandidateTokens, depositItem, buildInteractiveItemData, assignContainerParent, buildGenericStubItem } from "../transfer/ItemTransfer.mjs";
 import { dbg } from "../utils/debugLog.mjs";
 import { dragModifiersHeld } from "../utils/dragModifier.mjs";
 import { findCanvasDropTargets, promptDropChoice, PLACE_ON_CANVAS } from "../utils/canvasDropTargets.mjs";
@@ -23,6 +23,19 @@ function onDropCanvasData(canvas, data, event) {
     ctrlHeld: event.ctrlKey || event.metaKey,
     uuid: data.uuid
   });
+
+  // Synthetic payload emitted by GenericInteractiveContainerView when the GM
+  // drags a content row out of a container sheet onto the canvas. Removes the
+  // row from the container's contents flag array and places a new item-mode
+  // interactive token at the drop point.
+  if (data.type === "InteractiveContent") {
+    dbg("place:onDropCanvasData", "InteractiveContent drop detected", {
+      sourceActorUuid: data.sourceActorUuid, contentId: data.contentId
+    });
+    _handleInteractiveContentDrop(canvas, data)
+      .catch(err => console.error(`${MODULE_ID} | InteractiveContent drop failed:`, err));
+    return false;
+  }
 
   if (data.type === "Item") {
     if (!dragModifiersHeld(event)) {
@@ -61,6 +74,181 @@ function onDropCanvasData(canvas, data, event) {
   }
 
   dbg("place:onDropCanvasData", "non-Item/Actor type, let core handle", { type: data.type });
+}
+
+/**
+ * Handle a synthetic `"InteractiveContent"` drag payload emitted when the GM
+ * drags a row out of a `GenericInteractiveContainerView` onto the canvas.
+ *
+ * Removes the dragged content row from the source container's `contents[]`
+ * flag array, then creates a new item-mode interactive actor at the snapped
+ * drop point and places a token for it.
+ *
+ * @param {Canvas} canvas
+ * @param {object} data - Drag payload with `sourceActorUuid`, `contentId`, `itemData`, `x`, `y`.
+ * @returns {Promise<false>}
+ */
+async function _handleInteractiveContentDrop(canvas, data) {
+  const adapter = getAdapter();
+  const sourceActor = await fromUuid(data.sourceActorUuid);
+  if (!sourceActor) {
+    dbg("place:_handleInteractiveContentDrop", "source actor not found", { uuid: data.sourceActorUuid });
+    return false;
+  }
+
+  // Remove the dragged row from the container's contents array.
+  const sourceData = adapter.getInteractiveData(sourceActor);
+  const filtered = (sourceData.contents || []).filter(c => c.id !== data.contentId);
+  dbg("place:_handleInteractiveContentDrop", "removing content row from source", {
+    sourceActorName: sourceActor.name, contentId: data.contentId,
+    beforeCount: sourceData.contents?.length ?? 0, afterCount: filtered.length
+  });
+  await adapter.setInteractiveData(sourceActor, { contents: filtered });
+
+  // Create a new item-mode interactive actor at the drop point.
+  dbg("place:_handleInteractiveContentDrop", "placing new interactive token from content row", {
+    itemData: data.itemData, x: data.x, y: data.y
+  });
+  await createInteractiveTokenFromContentRow(canvas, data.itemData, data.x, data.y);
+  return false;
+}
+
+/**
+ * Create a new generic item-mode interactive actor and place a token on the
+ * canvas, populated entirely from a content-row payload (no source Item
+ * document — everything comes from the flag blob).
+ *
+ * The actor is always ephemeral: content rows have no persistent template and
+ * no inventory source to round-trip through. The flag blob holds the full
+ * display data (name, img, description, quantity).
+ *
+ * @param {Canvas} canvas
+ * @param {object} itemData - `{name, img, description, quantity}` from the row.
+ * @param {number} x - Canvas x coordinate of the drop.
+ * @param {number} y - Canvas y coordinate of the drop.
+ */
+async function createInteractiveTokenFromContentRow(canvas, itemData, x, y) {
+  const adapter = getAdapter();
+  const snapped = canvas.grid.getTopLeftPoint({ x, y });
+  const name = itemData.name || "Interactive Item";
+  const img = itemData.img || "icons/svg/item-bag.svg";
+
+  dbg("place:createInteractiveTokenFromContentRow", { name, img, x: snapped.x, y: snapped.y });
+
+  // Create an ephemeral actor of our sub-type. The generic adapter never touches
+  // actor.system, so the system field is an empty object — safe to omit.
+  const actor = await CONFIG.Actor.documentClass.create({
+    name,
+    type: "pick-up-stix.interactiveItem",
+    img,
+    prototypeToken: { name, texture: { src: img } },
+    flags: { "pick-up-stix": { ephemeral: true } }
+  });
+
+  if (!actor) {
+    dbg("place:createInteractiveTokenFromContentRow", "actor create returned null, bail");
+    return;
+  }
+
+  // Populate the flag blob so the generic sheets and pickup flow can read the data.
+  await adapter.setInteractiveData(actor, {
+    mode: "item",
+    name,
+    img,
+    itemData: {
+      name,
+      img,
+      description: itemData.description ?? "",
+      quantity: itemData.quantity ?? 1
+    }
+  });
+
+  const tokenData = foundry.utils.mergeObject(
+    actor.prototypeToken.toObject(),
+    {
+      x: snapped.x, y: snapped.y,
+      actorId: actor.id,
+      flags: { "pick-up-stix": { ephemeral: true } }
+    }
+  );
+
+  if (hasLevels()) {
+    tokenData.level = getViewedLevelId();
+    dbg("place:createInteractiveTokenFromContentRow", "v14 level assigned", { level: tokenData.level });
+  }
+
+  await canvas.scene.createEmbeddedDocuments("Token", [tokenData]);
+  dbg("place:createInteractiveTokenFromContentRow", "token placed", { actorId: actor.id, name });
+}
+
+/**
+ * Generic-mode actor factory used by `createInteractiveToken`. Creates an
+ * actor of sub-type `pick-up-stix.interactiveItem` with the dropped item's
+ * data snapshotted into `flags["pick-up-stix"].interactive` (no embedded
+ * `actor.items`, no `system.*` writes — neither path works on systems that
+ * replace `CONFIG.Actor.dataModels` or restrict item types).
+ *
+ * Containers aren't supported via this path because `adapter.isContainerItem`
+ * always returns false on generic (containers require a configured type that
+ * world items wouldn't normally match). World items dropped onto the canvas
+ * always become item-mode interactives.
+ *
+ * @param {Item} item
+ * @param {string} img
+ * @param {number} moveQty
+ * @param {boolean} ephemeral
+ * @returns {Promise<Actor>}
+ */
+async function _createGenericInteractiveActor(item, img, moveQty, ephemeral) {
+  const description = item.system?.description?.value
+    ?? item.system?.description
+    ?? "";
+
+  const interactiveData = {
+    mode: "item",
+    name: item.name,
+    img,
+    description,
+    itemData: {
+      name: item.name,
+      img,
+      description,
+      quantity: moveQty
+    }
+  };
+
+  // Honor the configured template-vs-ephemeral folder split so generic
+  // interactive actors live in the same place as their model-backed
+  // counterparts.
+  const folderId = ephemeral
+    ? (game.settings.get(MODULE_ID, "ephemeralFolder") || null)
+    : (game.settings.get(MODULE_ID, "actorFolder") || null);
+
+  const flags = {
+    [MODULE_ID]: {
+      interactive: interactiveData,
+      // Mark the actor as already kind-confirmed so the createActor hook's
+      // kind-picker path is skipped (we've populated mode + itemData here).
+      createKindConfirmed: true
+    }
+  };
+  if (ephemeral) flags[MODULE_ID].ephemeral = true;
+  // Track the source item's uuid for ephemeral-cleanup / future-reuse heuristics.
+  if (!item.actor) flags[MODULE_ID].sourceItemUuid = item.uuid;
+
+  const actorData = {
+    name: item.name,
+    type: "pick-up-stix.interactiveItem",
+    img,
+    prototypeToken: { name: item.name, texture: { src: img } },
+    flags
+  };
+  if (folderId) actorData.folder = folderId;
+
+  dbg("place:createInteractiveToken:generic", "creating generic actor", {
+    itemName: item.name, ephemeral, folderId, moveQty
+  });
+  return CONFIG.Actor.documentClass.create(actorData);
 }
 
 async function _handleItemDrop(data) {
@@ -288,9 +476,52 @@ async function depositItemToTarget(item, targetToken, { quantity = null } = {}) 
     itemName: item.name, itemUuid: item.uuid,
     targetName: targetActor.name, targetId: targetActor.id,
     tokenId, sceneId, isGM: game.user.isGM,
-    targetIsInteractiveContainer: targetActor.system?.isContainer === true,
+    targetIsInteractiveContainer: adapter.isInteractiveContainer(targetActor),
     sourceQty, moveQty
   });
+
+  // Generic interactive container target: writes go through flag.contents
+  // rather than createDocuments. Two sub-paths:
+  //   - GM + world item (no source actor to decrement): write the row directly.
+  //   - Everyone else (inventory source): route through depositItem so the
+  //     GM-side handler mutates the container actor's flags.
+  //     The GM-side depositItem has a matching generic-container branch.
+  if (adapter.constructor.SYSTEM_ID === "generic" && adapter.isInteractiveContainer(targetActor)) {
+    if (game.user.isGM && !item.actor) {
+      // GM world-item path: write directly (no source to decrement).
+      const row = {
+        id: foundry.utils.randomID(),
+        name: item.name,
+        img: item.img,
+        description: item.system?.description?.value ?? item.system?.description ?? "",
+        quantity: moveQty
+      };
+      const current = adapter.getInteractiveData(targetActor);
+      dbg("place:depositItemToTarget", "GM + world item: appending content row directly", { rowName: row.name, qty: moveQty });
+      await adapter.setInteractiveData(targetActor, {
+        contents: [...(current.contents ?? []), row]
+      });
+      notifyItemAction("Deposited", item.name);
+      return;
+    }
+    if (!item.actor) {
+      // Player + world item: not supported (no source to decrement on the
+      // player side, and players can't write the target's flags directly).
+      dbg("place:depositItemToTarget", "player + world item, bail");
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
+      return;
+    }
+    // Inventory source (GM or player): route through the socket relay. The
+    // GM-side depositItem will write to flag.contents and decrement source.
+    dbg("place:depositItemToTarget", "generic container + inventory source: dispatching to GM", { isGM: game.user.isGM });
+    await dispatchGM(
+      "depositItem",
+      { sourceActorId: item.actor.id, itemId: item.id, sceneId, tokenId, quantity: moveQty },
+      async () => depositItem(item.actor.id, item.id, sceneId, tokenId, moveQty)
+    );
+    notifyItemAction("Deposited", item.name);
+    return;
+  }
 
   // Players can't remove world items; depositItem requires a source actor.
   if (!game.user.isGM && !item.actor) {
@@ -339,18 +570,66 @@ async function depositItemToTarget(item, targetToken, { quantity = null } = {}) 
 
 async function depositActorToTarget(droppedActor, targetToken) {
   const targetActor = targetToken.actor;
+  const adapter = getAdapter();
+  const targetIsInteractiveContainer = adapter.isInteractiveContainer(targetActor);
   dbg("place:depositActorToTarget", {
     droppedName: droppedActor.name, droppedId: droppedActor.id,
     targetName: targetActor.name, targetId: targetActor.id,
-    targetIsContainer: targetActor.system?.isContainer === true
+    targetIsInteractiveContainer
   });
 
-  if (droppedActor.system.isContainer) {
+  if (adapter.isInteractiveContainer(droppedActor)) {
     dbg("place:depositActorToTarget", "dropped actor is container-mode, bail");
     ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.CannotGiveContainer"));
     return;
   }
 
+  if (!game.user.isGM) {
+    // Players can't see sidebar actors; no socket action exists for this path.
+    dbg("place:depositActorToTarget", "player path blocked (no socket action for actor→target)");
+    ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
+    return;
+  }
+
+  // Generic source: build payload from flag data rather than embedded items.
+  if (adapter.constructor.SYSTEM_ID === "generic") {
+    const droppedData = adapter.getInteractiveData(droppedActor);
+    if (droppedData.mode !== "item") {
+      dbg("place:depositActorToTarget", "generic source not in item mode, bail");
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotInitialized"));
+      return;
+    }
+    // Prefer top-level fields (GM-edited) over itemData snapshot.
+    const name = droppedData.name || droppedData.itemData?.name || droppedActor.name;
+    const img = droppedData.img || droppedData.itemData?.img || droppedActor.img;
+    const description = droppedData.description || droppedData.itemData?.description || "";
+    const quantity = droppedData.itemData?.quantity ?? 1;
+
+    if (targetIsInteractiveContainer) {
+      // Generic container target: append a content row to its flag blob.
+      const row = { id: foundry.utils.randomID(), name, img, description, quantity };
+      const current = adapter.getInteractiveData(targetActor);
+      dbg("place:depositActorToTarget", "generic→generic-container: appending content row", { rowName: name });
+      await adapter.setInteractiveData(targetActor, {
+        contents: [...(current.contents ?? []), row]
+      });
+    } else {
+      // Non-container target (PC/NPC): create a stub item on the target.
+      const lootType = adapter.defaultLootItemType;
+      if (!lootType) {
+        dbg("place:depositActorToTarget", "generic source but no loot type configured, bail");
+        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
+        return;
+      }
+      const stubData = buildGenericStubItem({ name, img, description, quantity, lootType });
+      dbg("place:depositActorToTarget", "generic→PC/NPC: creating stub item on target", { stubName: stubData.name });
+      await CONFIG.Item.documentClass.create(stubData, { parent: targetActor });
+    }
+    notifyItemAction("Deposited", droppedActor.name);
+    return;
+  }
+
+  // Model-backed source (dnd5e / pf2e) — existing path.
   const itemData = buildInteractiveItemData(droppedActor);
   if (!itemData) {
     dbg("place:depositActorToTarget", "buildInteractiveItemData returned null, bail");
@@ -361,27 +640,23 @@ async function depositActorToTarget(droppedActor, targetToken) {
   if (targetActor.system?.isContainer && targetActor.system.containerItem) {
     // Delegate container-parent field write to the adapter so the field path
     // is not hard-coded to dnd5e's `system.container`.
-    getAdapter().setItemContainerId(itemData, targetActor.system.containerItem.id);
+    adapter.setItemContainerId(itemData, targetActor.system.containerItem.id);
   }
 
-  if (game.user.isGM) {
-    dbg("place:depositActorToTarget", "GM path: createDocuments on target");
-    await CONFIG.Item.documentClass.createDocuments([itemData], { parent: targetActor, keepId: false });
-    notifyItemAction("Deposited", droppedActor.name);
-  } else {
-    // Players can't see sidebar actors; no socket action exists for this path.
-    dbg("place:depositActorToTarget", "player path blocked (no socket action for actor→target)");
-    ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
-  }
+  dbg("place:depositActorToTarget", "GM path: createDocuments on target");
+  await CONFIG.Item.documentClass.createDocuments([itemData], { parent: targetActor, keepId: false });
+  notifyItemAction("Deposited", droppedActor.name);
 }
 
 async function depositCanvasTokenToTarget(tokenDoc, targetToken, { quantity = null } = {}) {
   const sourceActor = tokenDoc.actor;
   const targetActor  = targetToken.actor;
+  const adapter = getAdapter();
+  const targetIsInteractiveContainer = adapter.isInteractiveContainer(targetActor);
   dbg("place:depositCanvasTokenToTarget", {
     sourceName: sourceActor?.name, sourceId: sourceActor?.id,
     targetName: targetActor.name, targetId: targetActor.id,
-    targetIsContainer: targetActor.system?.isContainer === true,
+    targetIsInteractiveContainer,
     quantity
   });
 
@@ -390,7 +665,53 @@ async function depositCanvasTokenToTarget(tokenDoc, targetToken, { quantity = nu
     return;
   }
 
-  const adapter = getAdapter();
+  // Generic source: build payload from flag data. No embedded item to read
+  // quantity from, so the snapshot's quantity is the source-of-truth.
+  if (adapter.constructor.SYSTEM_ID === "generic") {
+    const sourceData = adapter.getInteractiveData(sourceActor);
+    if (sourceData.mode !== "item") {
+      dbg("place:depositCanvasTokenToTarget", "generic source not in item mode, bail");
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotInitialized"));
+      return;
+    }
+    const name = sourceData.name || sourceData.itemData?.name || sourceActor.name;
+    const img = sourceData.img || sourceData.itemData?.img || sourceActor.img;
+    const description = sourceData.description || sourceData.itemData?.description || "";
+    const flagQty = sourceData.itemData?.quantity ?? 1;
+    const moveQty = quantity == null ? flagQty : Math.max(1, Math.min(Math.floor(quantity), flagQty));
+    const isPartial = moveQty < flagQty;
+
+    if (targetIsInteractiveContainer) {
+      const row = { id: foundry.utils.randomID(), name, img, description, quantity: moveQty };
+      const current = adapter.getInteractiveData(targetActor);
+      dbg("place:depositCanvasTokenToTarget", "generic→generic-container: appending content row", { rowName: name, qty: moveQty });
+      await adapter.setInteractiveData(targetActor, {
+        contents: [...(current.contents ?? []), row]
+      });
+    } else {
+      const lootType = adapter.defaultLootItemType;
+      if (!lootType) {
+        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
+        return;
+      }
+      const stubData = buildGenericStubItem({ name, img, description, quantity: moveQty, lootType });
+      dbg("place:depositCanvasTokenToTarget", "generic→PC/NPC: creating stub item on target", { stubName: stubData.name });
+      await CONFIG.Item.documentClass.create(stubData, { parent: targetActor });
+    }
+
+    if (isPartial) {
+      // Decrement the source actor's stored quantity.
+      await adapter.setInteractiveData(sourceActor, {
+        itemData: { ...(sourceData.itemData ?? {}), quantity: flagQty - moveQty }
+      });
+    } else {
+      await tokenDoc.delete({ pickUpStix: { suppressPrompt: true } });
+    }
+    notifyItemAction("Deposited", sourceActor.name);
+    return;
+  }
+
+  // Model-backed source (dnd5e / pf2e) — existing path.
   const embeddedItem = sourceActor.system?.topLevelItems?.[0] ?? null;
   const sourceQty = embeddedItem ? adapter.getItemQuantity(embeddedItem) : 1;
   const moveQty = quantity == null
@@ -545,7 +866,13 @@ async function createInteractiveToken(item, x, y, { ephemeral = false, level = n
 
   let actor;
 
-  if (!ephemeral) {
+  // Generic-mode short circuit: actor state lives entirely in
+  // flags["pick-up-stix"].interactive — no embedded items, no system fields.
+  // Falls through to the shared token-placement logic below once the actor is
+  // created.
+  if (adapter.constructor.SYSTEM_ID === "generic") {
+    actor = await _createGenericInteractiveActor(item, img, moveQty, ephemeral);
+  } else if (!ephemeral) {
     const sourceUuid = item.actor ? null : item.uuid;
     const sourceActorId = getItemSourceActorId(item);
     dbg("place:createInteractiveToken", "template mode", { sourceActorId, sourceUuid });

--- a/scripts/canvas/qtyBadge.mjs
+++ b/scripts/canvas/qtyBadge.mjs
@@ -6,19 +6,37 @@ import { dbg } from "../utils/debugLog.mjs";
 const PROP = "pickUpStixQty";
 
 /**
- * Resolve the embedded item the badge should track, or null when the
- * token is not an eligible interactive item. Containers and base actors
- * (no token) are excluded — containers always carry a single backpack
- * item and should never show the badge.
+ * True if the badge should be drawn on this token. Excludes non-interactive
+ * actors, container-mode interactive actors (they carry a single backpack
+ * item and shouldn't show a count), and tokens whose actor failed to resolve.
  *
- * @param {Token} token - The PIXI Token placeable.
- * @returns {Item|null}
+ * @param {Token} token
+ * @returns {boolean}
  */
-function getInteractiveItem(token) {
+function isEligibleToken(token) {
   const actor = token.actor;
-  if (!isInteractiveActor(actor)) return null;
-  if (actor.system?.isContainer) return null;
-  return actor.system?.embeddedItem ?? null;
+  if (!isInteractiveActor(actor)) return false;
+  return !getAdapter().isInteractiveContainer(actor);
+}
+
+/**
+ * Resolve the current stack quantity to display on the token. Works for
+ * both model-backed adapters (read from the embedded item via the adapter)
+ * and the generic adapter (read from `flags["pick-up-stix"].interactive
+ * .itemData.quantity`).
+ *
+ * @param {Token} token
+ * @returns {number}
+ */
+function getDisplayQuantity(token) {
+  const actor = token.actor;
+  if (!actor) return 1;
+  const adapter = getAdapter();
+  if (adapter.constructor.SYSTEM_ID === "generic") {
+    return adapter.getInteractiveData(actor).itemData?.quantity ?? 1;
+  }
+  const item = actor.system?.embeddedItem;
+  return item ? adapter.getItemQuantity(item) : 1;
 }
 
 /**
@@ -61,8 +79,7 @@ function position(token) {
 function updateText(token) {
   const badge = token[PROP];
   if (!badge) return;
-  const item = getInteractiveItem(token);
-  const qty = item ? getAdapter().getItemQuantity(item) : 1;
+  const qty = getDisplayQuantity(token);
   const visible = qty > 1 && !token.document.isSecret;
   badge.text = String(qty);
   badge.visible = visible;
@@ -81,7 +98,7 @@ function updateText(token) {
  */
 export function registerQtyBadge() {
   Hooks.on("drawToken", (token) => {
-    if (!getInteractiveItem(token)) return;
+    if (!isEligibleToken(token)) return;
     dbg("badge:drawToken", { tokenId: token.id });
     const PreciseText = foundry.canvas.containers.PreciseText;
     const badge = new PreciseText("", buildStyle());
@@ -100,21 +117,24 @@ export function registerQtyBadge() {
     if (flags?.refreshState) updateText(token);
   });
 
+  // Model-backed: quantity lives on the embedded item; refresh when it changes.
   Hooks.on("updateItem", (item, changes) => {
     if (!foundry.utils.hasProperty(changes ?? {}, "system.quantity")) return;
     dbg("badge:updateItem", { itemId: item.id, qty: changes.system.quantity });
     for (const token of canvas.tokens?.placeables ?? []) {
-      const embedded = getInteractiveItem(token);
+      const embedded = token.actor?.system?.embeddedItem;
       if (embedded?.id === item.id) updateText(token);
     }
   });
 
-  // Identification flips can change what the badge should show on systems
-  // that mask the count when unidentified. Refresh on the wrapping actor's
-  // identification change as a forward-compatible hook.
+  // Refresh on actor updates that could affect the displayed quantity or
+  // visibility: model-backed identification flips, and generic-mode flag
+  // changes (which is where the qty lives when there's no embedded item).
   Hooks.on("updateActor", (actor, changes) => {
     if (!isInteractiveActor(actor)) return;
-    if (!foundry.utils.hasProperty(changes ?? {}, "system.isIdentified")) return;
+    const idChanged = foundry.utils.hasProperty(changes ?? {}, "system.isIdentified");
+    const flagChanged = foundry.utils.hasProperty(changes ?? {}, "flags.pick-up-stix.interactive");
+    if (!idChanged && !flagChanged) return;
     for (const token of canvas.tokens?.placeables ?? []) {
       if (token.actor?.id === actor.id) updateText(token);
     }

--- a/scripts/hud/InteractiveTokenHUD.mjs
+++ b/scripts/hud/InteractiveTokenHUD.mjs
@@ -18,6 +18,32 @@ export function registerTokenHUD() {
   _patchCanHUD();
   _patchRefreshState();
   _patchClickRight();
+  _patchCanControl();
+}
+
+/**
+ * Prevent selection / keyboard control of interactive tokens when the viewer
+ * is in player-view mode (true players AND GMs with the override disabled).
+ *
+ * Without this wrapper, Foundry's core left-click flow runs `_canControl`,
+ * which returns true for any actor the user owns. For a GM that owns every
+ * actor, an interactive token would be selected even though `_refreshState`
+ * is hiding the selection outline — and the selected token responds to
+ * keyboard movement keys. By denying `_canControl` in player view, the
+ * token stays unselectable for both real players and the GM testing with
+ * override off.
+ *
+ * GM with override on keeps full control (e.g. to relocate a placed
+ * interactive token).
+ */
+function _patchCanControl() {
+  libWrapper.register(MODULE_ID, "foundry.canvas.placeables.Token.prototype._canControl", function(wrapped, user, event) {
+    if (isInteractiveActor(this.actor) && isPlayerView()) {
+      dbg("hud:_canControl", "denying control on interactive token in player view", { actorName: this.actor?.name });
+      return false;
+    }
+    return wrapped(user, event);
+  }, "MIXED");
 }
 
 function _patchCanHUD() {
@@ -113,12 +139,18 @@ function onRenderTokenHUD(app, html, context, options) {
   );
   col.appendChild(inspectBtn);
 
-  if (!system.isContainer) {
+  // Pickup button: available on all non-container item-mode interactives.
+  // Model-backed adapters (dnd5e/pf2e) read from system.topLevelItems;
+  // the generic adapter reads from the flag blob and creates a stub item.
+  const pickupAdapter = getAdapter();
+  const isGenericPickup = pickupAdapter.constructor.SYSTEM_ID === "generic";
+  const pickupSupported = !pickupAdapter.isInteractiveContainer(actor);
+  if (pickupSupported) {
   const pickupBtn = createHUDButton(
     "fa-hand",
     game.i18n.localize("INTERACTIVE_ITEMS.HUD.PickUp"),
     async () => {
-      dbg("hud:pickup", { actorName: actor.name, isGM });
+      dbg("hud:pickup", { actorName: actor.name, isGM, isGenericPickup });
       // Check proximity before lock state — distance is more actionable than
       // "locked" (players can't tell something is locked from too far away).
       if (!checkProximity(actor)) {
@@ -132,6 +164,41 @@ function onRenderTokenHUD(app, html, context, options) {
       dbg("hud:pickup", "resolved target actor", { targetActorName: targetActor?.name });
       if (!targetActor) return;
 
+      // Generic path: flag blob holds the item data; no embedded item document.
+      // Pass itemId as null so the socket payload and GM handler both route to
+      // _pickupItemGeneric inside pickupItem.
+      if (isGenericPickup) {
+        // Partial-stack prompt — same UX as the model-backed path below, but
+        // the source qty comes from the flag itemData rather than an embedded
+        // Item document.
+        const interactiveData = pickupAdapter.getInteractiveData(actor);
+        const genericQty = interactiveData.itemData?.quantity ?? 1;
+        let genericChosenQty = null;
+        if (genericQty > 1) {
+          genericChosenQty = await promptItemQuantity({
+            itemName: interactiveData.name || actor.name,
+            max: genericQty,
+            actionKey: "INTERACTIVE_ITEMS.Dialog.QuantityActionPickup",
+            actionFormatArgs: { target: targetActor.name }
+          });
+          if (genericChosenQty == null) {
+            dbg("hud:pickup", "generic quantity dialog cancelled, bail");
+            return;
+          }
+        }
+
+        dbg("hud:pickup", "generic path — dispatching pickupItem", { quantity: genericChosenQty });
+        await dispatchGM(
+          "pickupItem",
+          { sceneId, tokenId, itemId: null, targetActorId: targetActor.id, quantity: genericChosenQty },
+          async () => pickupItem(sceneId, tokenId, null, targetActor.id, genericChosenQty)
+        );
+        if (!game.user.isGM) notifyItemAction("PickedUp", actor.name);
+        canvas.tokens.hud.close();
+        return;
+      }
+
+      // Model-backed path: read the embedded item from the actor's data model.
       const item = system.topLevelItems[0];
       if (!item) {
         dbg("hud:pickup", "no top-level items found");
@@ -175,8 +242,14 @@ function onRenderTokenHUD(app, html, context, options) {
   }
 
   // GM-only "Split stack" button: visible on non-container stacked tokens (qty > 1).
-  if (isGM && !system.isContainer) {
-    const adapter = getAdapter();
+  // Model-backed only — split operates on the embedded Item document via the
+  // system's quantity field. Generic mode stores quantity in a flag and would
+  // need its own split flow; for now the button is hidden there.
+  const splitAdapter = getAdapter();
+  const splitSupported = splitAdapter.constructor.SYSTEM_ID !== "generic"
+    && !splitAdapter.isInteractiveContainer(actor);
+  if (isGM && splitSupported) {
+    const adapter = splitAdapter;
     const embeddedItem = system.topLevelItems[0];
     const sourceQty = embeddedItem ? adapter.getItemQuantity(embeddedItem) : 1;
     if (embeddedItem && sourceQty > 1 && !adapter.isContainerItem(embeddedItem)) {
@@ -207,8 +280,9 @@ function onRenderTokenHUD(app, html, context, options) {
     }
   }
 
-  if (system.isContainer) {
-    const isOpen = system.isOpen;
+  const containerAdapter = getAdapter();
+  if (containerAdapter.isInteractiveContainer(actor)) {
+    const isOpen = containerAdapter.isInteractiveOpen(actor);
     const openBtn = createHUDButton(
       isOpen ? "fa-box-open" : "fa-box",
       game.i18n.localize(isOpen
@@ -229,11 +303,15 @@ function onRenderTokenHUD(app, html, context, options) {
           actor.sheet.render(true);
         } else {
           // Wait for the GM-driven update to propagate before rendering,
-          // so the sheet's isOpen gate sees the new value.
+          // so the sheet's isOpen gate sees the new value. Watch for either
+          // the system.isOpen field (model-backed) or the flag-blob path
+          // (generic) depending on which adapter is active.
           const targetUuid = actor.uuid;
           const hookId = Hooks.on("updateActor", (updatedActor, changes) => {
             if (updatedActor.uuid !== targetUuid) return;
-            if (foundry.utils.getProperty(changes, "system.isOpen") !== true) return;
+            const systemOpenChanged = foundry.utils.getProperty(changes, "system.isOpen") === true;
+            const flagOpenChanged = foundry.utils.getProperty(changes, "flags.pick-up-stix.interactive.isOpen") === true;
+            if (!systemOpenChanged && !flagOpenChanged) return;
             Hooks.off("updateActor", hookId);
             clearTimeout(timeoutId);
             actor.sheet.render(true);
@@ -247,7 +325,7 @@ function onRenderTokenHUD(app, html, context, options) {
   }
 
   if (isGM) {
-    const isLocked = system.isLocked;
+    const isLocked = containerAdapter.isInteractiveLocked(actor);
     const lockBtn = createHUDButton(
       isLocked ? "fa-lock" : "fa-lock-open",
       game.i18n.localize(isLocked
@@ -262,7 +340,7 @@ function onRenderTokenHUD(app, html, context, options) {
     col.appendChild(lockBtn);
   }
 
-  if (isGM) {
+  if (isGM && getAdapter().capabilities.supportsIdentification) {
     const identified = system.isIdentified;
     const adapter = getAdapter();
     const identCfg = adapter.getIdentifyButtonConfig(identified);

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -147,6 +147,17 @@ Hooks.once("init", async () => {
     default: false
   });
 
+  // Item type used when creating a pickup stub in a player's inventory (generic
+  // mode only). Populated automatically by heuristic or via dialog on first launch.
+  game.settings.register(MODULE_ID, "genericPickupItemType", {
+    name: "INTERACTIVE_ITEMS.Settings.GenericPickupItemType.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.GenericPickupItemType.Hint",
+    scope: "world",
+    config: true,
+    type: String,
+    default: ""
+  });
+
   game.settings.register(MODULE_ID, "ephemeralFolder", {
     // Not shown in config UI — managed programmatically.
     scope: "world",
@@ -160,6 +171,15 @@ Hooks.once("init", async () => {
     config: false,
     type: Boolean,
     default: false
+  });
+
+  // Comma-separated list of system IDs that have already seen the generic-mode
+  // warning. Stored per client so each user gets their own first-launch notice.
+  game.settings.register(MODULE_ID, "genericModeNoticeSystems", {
+    scope: "client",
+    config: false,
+    type: String,
+    default: ""
   });
 
   getAdapter().registerItemContextMenu(_injectItemContextMenuEntries);
@@ -181,6 +201,68 @@ Hooks.once("init", async () => {
     installItemDropListener: _installContainerSheetItemDrop,
     injectItemRowControls: _injectContainerSheetRowControls,
     injectContentsTab: _injectContainerContentsTab,
+  });
+
+  // Generic-mode: dragging a container row onto a character sheet emits a
+  // synthetic "InteractiveContent" payload that no system sheet recognises
+  // (Eventide-class systems log it as an "Unhandled drop type"). Intercept
+  // before the system handler runs and route through the existing pickupItem
+  // socket flow — which already handles building the stub item on the target
+  // and removing the row from the source container.
+  Hooks.on("dropActorSheetData", (actor, sheet, data) => {
+    if (data?.type !== "InteractiveContent") return;
+    // Dropping a content row onto another interactive actor (container or
+    // item-mode wrapper) isn't part of the supported flow.
+    if (isInteractiveActor(actor)) return;
+
+    dbg("hook:dropActorSheetData:InteractiveContent", {
+      targetActorName: actor?.name, contentId: data?.contentId,
+      sourceActorUuid: data?.sourceActorUuid
+    });
+
+    // Fire async; the hook itself must return false synchronously.
+    fromUuid(data.sourceActorUuid).then(async (sourceActor) => {
+      if (!sourceActor) {
+        dbg("hook:dropActorSheetData:InteractiveContent", "source actor not found, bail");
+        return;
+      }
+      const tokenDoc = sourceActor.token;
+      if (!tokenDoc) {
+        // Sidebar template — pickup needs a placed token because the
+        // socket relay resolves by sceneId/tokenId.
+        dbg("hook:dropActorSheetData:InteractiveContent", "source actor has no token, bail");
+        return;
+      }
+      const sceneId = tokenDoc.parent.id;
+      const tokenId = tokenDoc.id;
+
+      // Partial-stack prompt mirroring the pickup HUD / row click handlers.
+      const adapter = getAdapter();
+      const sourceData = adapter.getInteractiveData(sourceActor);
+      const row = sourceData.contents?.find(c => c.id === data.contentId);
+      const rowQty = row?.quantity ?? 1;
+      let chosenQty = null;
+      if (rowQty > 1) {
+        chosenQty = await promptItemQuantity({
+          itemName: row?.name ?? "",
+          max: rowQty,
+          actionKey: "INTERACTIVE_ITEMS.Dialog.QuantityActionPickup",
+          actionFormatArgs: { target: actor.name }
+        });
+        if (chosenQty == null) {
+          dbg("hook:dropActorSheetData:InteractiveContent", "quantity dialog cancelled, bail");
+          return;
+        }
+      }
+
+      await dispatchGM(
+        "pickupItem",
+        { sceneId, tokenId, itemId: null, targetActorId: actor.id, quantity: chosenQty, contentId: data.contentId },
+        async () => pickupItem(sceneId, tokenId, null, actor.id, chosenQty, data.contentId)
+      );
+    }).catch(err => console.error(`${MODULE_ID} | InteractiveContent sheet drop failed:`, err));
+
+    return false;
   });
 
   Hooks.on("dropActorSheetData", (actor, sheet, data) => {
@@ -327,7 +409,10 @@ function _injectActorInventoryIdentifyToggles(app, html) {
   if (!root) return;
 
   const adapter = getAdapter();
-  const skipIdentify = adapter.capabilities.hasNativeInventoryIdentify;
+  // Skip our wand toggle when the system handles it natively, or when the
+  // adapter declares no identification support (generic/unknown systems).
+  const skipIdentify = adapter.capabilities.hasNativeInventoryIdentify
+    || !adapter.capabilities.supportsIdentification;
 
   // Add an empty, label-less header cell to each items-section header so the
   // row's controls column has a matching slot in the header. dnd5e's inventory
@@ -510,30 +595,32 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
     }
   }));
 
-  if (nativeIdentifyBtn) {
-    // Relocate the system's button into our canonical position.
-    orderedNodes.push(nativeIdentifyBtn);
-  } else {
-    const identCfg = adapter.getIdentifyButtonConfig(sys.isIdentified);
-    orderedNodes.push(createAdapterHeaderButton({
-      adapter,
-      extraClass: "ii-identify-toggle-btn",
-      active: sys.isIdentified,
-      iconOn: identCfg.iconOn,
-      iconFamilyOn: identCfg.iconFamilyOn,
-      iconOff: identCfg.iconOff,
-      iconFamilyOff: identCfg.iconFamilyOff,
-      labelOnKey: identCfg.labelOnKey,
-      labelOffKey: identCfg.labelOffKey,
-      onClick: async (ev) => {
-        ev.preventDefault();
-        const embeddedItem = configActor.system.embeddedItem;
-        if (!embeddedItem) return;
-        // Route through the adapter — pf2e opens a DC dialog for unidentified
-        // items rather than flipping the flag directly.
-        await adapter.performIdentifyToggle(embeddedItem);
-      }
-    }));
+  if (adapter.capabilities.supportsIdentification) {
+    if (nativeIdentifyBtn) {
+      // Relocate the system's button into our canonical position.
+      orderedNodes.push(nativeIdentifyBtn);
+    } else {
+      const identCfg = adapter.getIdentifyButtonConfig(sys.isIdentified);
+      orderedNodes.push(createAdapterHeaderButton({
+        adapter,
+        extraClass: "ii-identify-toggle-btn",
+        active: sys.isIdentified,
+        iconOn: identCfg.iconOn,
+        iconFamilyOn: identCfg.iconFamilyOn,
+        iconOff: identCfg.iconOff,
+        iconFamilyOff: identCfg.iconFamilyOff,
+        labelOnKey: identCfg.labelOnKey,
+        labelOffKey: identCfg.labelOffKey,
+        onClick: async (ev) => {
+          ev.preventDefault();
+          const embeddedItem = configActor.system.embeddedItem;
+          if (!embeddedItem) return;
+          // Route through the adapter — pf2e opens a DC dialog for unidentified
+          // items rather than flipping the flag directly.
+          await adapter.performIdentifyToggle(embeddedItem);
+        }
+      }));
+    }
   }
 
   orderedNodes.push(createAdapterHeaderButton({
@@ -642,16 +729,18 @@ function _injectContainerSheetRowControls({ actor, app, html }) {
       // Interactive items round-trip via the cached identifiedData/unidentifiedData
       // payloads (toggleItemIdentification swaps name/img/description); plain
       // deposited items just flip the system's native identified flag through
-      // the adapter.
-      target.appendChild(createRowControl({
-        iconClass: "fa-solid fa-wand-sparkles",
-        titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleIdentified",
-        active: getAdapter().isItemIdentified(item),
-        onClick: async () => {
-          if (isInteractive) await toggleItemIdentification(item);
-          else await getAdapter().performIdentifyToggle(item);
-        }
-      }));
+      // the adapter. Only rendered when the adapter supports identification.
+      if (getAdapter().capabilities.supportsIdentification) {
+        target.appendChild(createRowControl({
+          iconClass: "fa-solid fa-wand-sparkles",
+          titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleIdentified",
+          active: getAdapter().isItemIdentified(item),
+          onClick: async () => {
+            if (isInteractive) await toggleItemIdentification(item);
+            else await getAdapter().performIdentifyToggle(item);
+          }
+        }));
+      }
 
       target.appendChild(createRowControl({
         iconClass: "fa-solid fa-trash-can",
@@ -1231,25 +1320,28 @@ function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {})
     }
   ));
 
-  const isIdentified = adapter.isItemIdentified(item);
-  const identCfg = adapter.getIdentifyButtonConfig(isIdentified);
-  const identIcon = isIdentified ? identCfg.iconOn : identCfg.iconOff;
-  const identFamily = isIdentified
-    ? (identCfg.iconFamilyOn ?? "fa-solid")
-    : (identCfg.iconFamilyOff ?? "fa-solid");
-  controls.append(_buildContentRowControl(
-    identIcon,
-    isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey,
-    identFamily,
-    async () => {
-      if (!game.user.isGM) return;
-      dbg("contents:identifyRow", { itemName: item.name, itemId: item.id, currentlyIdentified: isIdentified });
-      // Adapter routing handles pf2e's mystify-popup vs direct setIdentified
-      // distinction; the updateItem hook re-renders the container sheet so
-      // the row's icon and tooltip refresh with the new state.
-      await adapter.performIdentifyToggle(item);
-    }
-  ));
+  // Only render the identify control when the adapter supports identification.
+  if (adapter.capabilities.supportsIdentification) {
+    const isIdentified = adapter.isItemIdentified(item);
+    const identCfg = adapter.getIdentifyButtonConfig(isIdentified);
+    const identIcon = isIdentified ? identCfg.iconOn : identCfg.iconOff;
+    const identFamily = isIdentified
+      ? (identCfg.iconFamilyOn ?? "fa-solid")
+      : (identCfg.iconFamilyOff ?? "fa-solid");
+    controls.append(_buildContentRowControl(
+      identIcon,
+      isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey,
+      identFamily,
+      async () => {
+        if (!game.user.isGM) return;
+        dbg("contents:identifyRow", { itemName: item.name, itemId: item.id, currentlyIdentified: isIdentified });
+        // Adapter routing handles pf2e's mystify-popup vs direct setIdentified
+        // distinction; the updateItem hook re-renders the container sheet so
+        // the row's icon and tooltip refresh with the new state.
+        await adapter.performIdentifyToggle(item);
+      }
+    ));
+  }
 
   // Delete is the only currently-active control on contents rows. GM-only —
   // players see the icon but the click no-ops for them. The deleteItem hook
@@ -1556,8 +1648,13 @@ Hooks.on("preCreateToken", (tokenDoc, data, options, userId) => {
     dbg("hook:preCreateToken", "actorLink=true, bail");
     return;
   }
-  if (!actor.system.isContainer && actor.items.size === 0) {
-    dbg("hook:preCreateToken", "item-type actor with no items, blocking placement", { actorName: actor.name });
+  // Block placement of an item-mode actor that hasn't had a source item
+  // assigned yet. Routed through the adapter so generic mode (where the
+  // "has embedded item" answer comes from flag data rather than actor.items)
+  // works correctly.
+  const adapterForGate = getAdapter();
+  if (!adapterForGate.isInteractiveContainer(actor) && !adapterForGate.hasInteractiveEmbeddedItem(actor)) {
+    dbg("hook:preCreateToken", "item-type actor with no embedded item, blocking placement", { actorName: actor.name });
     ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotInitialized"));
     return false;
   }
@@ -1825,21 +1922,65 @@ Hooks.on("createActor", async (actor, options, userId) => {
     itemsSize: actor.items.size
   });
 
+  const adapter = getAdapter();
+  const isGeneric = adapter.constructor.SYSTEM_ID === "generic";
+
   if (actor.getFlag(MODULE_ID, "containerDefault")) {
-    if (!actor.items.some(i => getAdapter().isContainerItem(i))) {
+    if (isGeneric) {
+      // Generic path: write container flag data if not already present (first
+      // creation from the sidebar folder button), then return — no embedded
+      // item to create. On subsequent createActor fires (token copy, reload)
+      // the flag data is already there and setInteractiveData is a no-op.
+      const existing = adapter.getInteractiveData(actor);
+      if (!existing.mode) {
+        const closedImg = actor.img || game.settings.get(MODULE_ID, "defaultContainerImage") || CHEST_CLOSED;
+        const openImg = game.settings.get(MODULE_ID, "defaultContainerOpenImage") || CHEST_OPEN;
+        dbg("hook:createActor:containerDefault", "generic path — writing initial flag data", { actorId: actor.id });
+        await adapter.setInteractiveData(actor, {
+          mode: "container",
+          name: actor.name,
+          img: closedImg,
+          openImage: openImg,
+          contents: []
+        });
+      }
+      return;
+    }
+    if (!actor.items.some(i => adapter.isContainerItem(i))) {
       // Use the adapter for both item type and identification field so neither
       // is hard-coded to the dnd5e vocabulary or `system.identified` boolean.
-      const containerData = { name: actor.name, type: getAdapter().containerItemType, img: actor.img };
-      getAdapter().stampNewItemIdentified(containerData, true);
+      const containerData = { name: actor.name, type: adapter.containerItemType, img: actor.img };
+      adapter.stampNewItemIdentified(containerData, true);
       await actor.createEmbeddedDocuments("Item", [containerData]);
     }
     return;
   }
 
-  if (actor.items.size > 0) return;
+  if (!isGeneric && actor.items.size > 0) return;
   if (actor.getFlag(MODULE_ID, "ephemeral")) return;
-  if (actor.getFlag(MODULE_ID, "createKindConfirmed")) return;
-  if (actor.system.sourceItemUuid) return;
+
+  // Generic path: when the actor is created with createKindConfirmed pre-set
+  // (sidebar folder button "item" choice), write initial item flag data if not
+  // already present, then return — no picker needed.
+  if (actor.getFlag(MODULE_ID, "createKindConfirmed")) {
+    if (isGeneric) {
+      const existing = adapter.getInteractiveData(actor);
+      if (!existing.mode) {
+        // Initialise mode but leave itemData null — the config sheet shows
+        // a "drop an item to populate" prompt and the sheet's _onDrop
+        // populates the snapshot. Mirrors the dnd5e/pf2e empty-item UX.
+        dbg("hook:createActor:createKindConfirmed", "generic path — init mode=item, itemData stays null until drop", { actorId: actor.id });
+        await adapter.setInteractiveData(actor, {
+          mode: "item",
+          name: actor.name,
+          img: actor.img
+        });
+      }
+    }
+    return;
+  }
+
+  if (!isGeneric && actor.system.sourceItemUuid) return;
 
   // Foundry's Create Actor dialog auto-renders the sheet after create — suppress
   // while the picker is open to avoid the empty-sheet flash.
@@ -1859,17 +2000,42 @@ Hooks.on("createActor", async (actor, options, userId) => {
     await actor.update({
       img: closedImg,
       "prototypeToken.texture.src": closedImg,
-      "system.openImage": openImg,
       [`flags.${MODULE_ID}.containerDefault`]: true
     });
-    // Use the adapter for both item type and identification field so neither
-    // is hard-coded to the dnd5e vocabulary or `system.identified` boolean.
-    const containerData = { name: actor.name, type: getAdapter().containerItemType, img: closedImg };
-    getAdapter().stampNewItemIdentified(containerData, true);
-    await actor.createEmbeddedDocuments("Item", [containerData]);
+
+    if (isGeneric) {
+      // Generic path: write all container state into the flag blob.
+      dbg("hook:createActor:container", "generic path — writing flag data", { actorId: actor.id });
+      await adapter.setInteractiveData(actor, {
+        mode: "container",
+        name: actor.name,
+        img: closedImg,
+        openImage: openImg,
+        contents: []
+      });
+    } else {
+      // Model-backed path: set openImage on system and create the embedded item.
+      await actor.update({ "system.openImage": openImg });
+      // Use the adapter for both item type and identification field so neither
+      // is hard-coded to the dnd5e vocabulary or `system.identified` boolean.
+      const containerData = { name: actor.name, type: adapter.containerItemType, img: closedImg };
+      adapter.stampNewItemIdentified(containerData, true);
+      await actor.createEmbeddedDocuments("Item", [containerData]);
+    }
     actor.sheet?.render({ force: true });
   } else if (result === "item") {
     await actor.setFlag(MODULE_ID, "createKindConfirmed", true);
+    if (isGeneric) {
+      // Generic path: init mode=item but leave itemData null — the config
+      // sheet opens with a "drop an item" prompt and the sheet's _onDrop
+      // populates the snapshot. Mirrors the dnd5e/pf2e empty-item UX.
+      dbg("hook:createActor:item", "generic path — init mode=item, itemData stays null until drop", { actorId: actor.id });
+      await adapter.setInteractiveData(actor, {
+        mode: "item",
+        name: actor.name,
+        img: actor.img
+      });
+    }
     actor.sheet?.render({ force: true });
   } else {
     // Dialog closed without selection — remove the blank actor
@@ -2023,16 +2189,19 @@ Hooks.on("updateActor", async (actor, changes, options, userId) => {
       && !descriptionChanged && !unidentifiedDescriptionChanged) return;
 
   const system = actor.system;
+  const adapter = getAdapter();
 
   // Token nameplate sync is needed only when the *display name* changes.
+  // Routed through the adapter (model-backed default for dnd5e/pf2e,
+  // flag-backed override for generic) so generic-mode actors — whose
+  // `actor.system` is a plain object with no model methods — don't throw.
   if (nameChanged || unidentifiedNameChanged) {
-    const protoName = system.resolveTokenName();
+    const protoName = adapter.getInteractiveDisplayName(actor);
     await actor.update({ "prototypeToken.name": protoName }, { noHook: true });
     const tokens = canvas.scene?.tokens.filter(t => t.actorId === actor.id) ?? [];
     for (const token of tokens) {
-      const tokenSystem = token.actor?.system;
-      if (!tokenSystem) continue;
-      const tokenName = tokenSystem.resolveTokenName();
+      if (!token.actor) continue;
+      const tokenName = adapter.getInteractiveDisplayName(token.actor);
       await token.update({ name: tokenName });
     }
   }
@@ -2131,6 +2300,41 @@ Hooks.on("createItem", (item) => {
 Hooks.on("deleteItem", (item) => {
   const actor = item.parent;
   if (actor) _rerenderContainerViews(actor);
+});
+
+// Re-render open generic container/item view sheets when the actor's
+// `flags["pick-up-stix"].interactive` blob changes. This covers both the
+// container view (contents list, open/closed image, description) and the
+// item view (name, image, description, quantity) for generic-mode actors.
+// Scoped to generic-mode actors only: model-backed (dnd5e/pf2e) actors are
+// handled by their own system-sheet render hooks and the existing
+// isLocked/isOpen/isIdentified rerender above.
+Hooks.on("updateActor", (actor, changes) => {
+  if (!isInteractiveActor(actor)) return;
+  if (!foundry.utils.hasProperty(changes, "flags.pick-up-stix.interactive")) return;
+
+  dbg("hook:updateActor:genericRerender", { actorName: actor.name, actorId: actor.id });
+
+  // Walk both AppV1 (ui.windows) and AppV2 (foundry.applications.instances)
+  // registries to find the open generic view, if any.
+  for (const app of Object.values(ui.windows)) {
+    if (!app.rendered) continue;
+    if (app.document?.id !== actor.id) continue;
+    // Only re-render generic view sheets; let dnd5e/pf2e sheets handle
+    // themselves through their own hooks.
+    const className = app.constructor?.name ?? "";
+    if (className !== "GenericInteractiveContainerView" && className !== "GenericInteractiveItemView") continue;
+    dbg("hook:updateActor:genericRerender", "re-rendering AppV1 generic sheet", { className, actorName: actor.name });
+    app.render(true);
+  }
+  for (const app of foundry.applications.instances.values()) {
+    if (!app.rendered) continue;
+    if (app.document?.id !== actor.id) continue;
+    const className = app.constructor?.name ?? "";
+    if (className !== "GenericInteractiveContainerView" && className !== "GenericInteractiveItemView") continue;
+    dbg("hook:updateActor:genericRerender", "re-rendering AppV2 generic sheet", { className, actorName: actor.name });
+    app.render();
+  }
 });
 
 // Re-render container views when a deposited item's lock flag or stack
@@ -2670,6 +2874,32 @@ Hooks.once("ready", async () => {
     const parent = await _ensureActorFolder();
     _previousActorFolderId = parent?.id ?? null;
     await _ensureEphemeralFolder(parent);
+
+    // Notify GMs on the first launch for each unsupported system so they know
+    // generic mode is active and some system-specific features are unavailable.
+    const adapter = getAdapter();
+    if (adapter.constructor.SYSTEM_ID === "generic") {
+      const sysId = game.system.id;
+      const seen = (game.settings.get(MODULE_ID, "genericModeNoticeSystems") || "")
+        .split(",").map(s => s.trim()).filter(Boolean);
+      dbg("ready:genericModeNotice", { sysId, alreadySeen: seen.includes(sysId) });
+      if (!seen.includes(sysId)) {
+        ui.notifications.warn(
+          game.i18n.format("INTERACTIVE_ITEMS.Notify.GenericMode", { system: sysId }),
+          { permanent: false }
+        );
+        seen.push(sysId);
+        game.settings.set(MODULE_ID, "genericModeNoticeSystems", seen.join(","));
+      }
+
+      // Seed the pickup item type on first launch (or when the setting was cleared).
+      // The heuristic runs silently; when no keyword match is found a dialog asks
+      // the GM to pick a type. Either way the setting is persisted for subsequent loads.
+      if (!game.settings.get(MODULE_ID, "genericPickupItemType")) {
+        dbg("ready:genericMode", "genericPickupItemType not set, running seed heuristic");
+        await _seedGenericPickupItemType();
+      }
+    }
   }
 });
 
@@ -2750,13 +2980,89 @@ async function _ensureEphemeralFolder(parent) {
   return folder;
 }
 
+/**
+ * Keywords used to heuristically detect a suitable pickup item type from the
+ * system's declared item types. Types whose lowercased name includes any of
+ * these keywords are candidates; the first match wins.
+ */
+const _PICKUP_KEYWORDS = ["item", "loot", "gear", "equipment", "treasure", "consumable"];
+
+/**
+ * Detect or prompt for a suitable pickup item type for generic-mode worlds.
+ *
+ * First tries a keyword heuristic against the system's declared item types.
+ * If a match is found it is silently persisted. If no match is found a
+ * `DialogV2.prompt` asks the GM to pick one from a `<select>`.
+ *
+ * Skipped silently when the system declares no item types at all (a console
+ * warning is emitted instead so the problem is visible in the dev tools).
+ */
+async function _seedGenericPickupItemType() {
+  const itemTypes = game.system?.documentTypes?.Item
+    ? Object.keys(game.system.documentTypes.Item).filter(t => t !== "base")
+    : [];
+
+  if (itemTypes.length === 0) {
+    console.warn(`${MODULE_ID}: generic mode — system declares no item types; pickups will fail.`);
+    return;
+  }
+
+  const heuristic = itemTypes.find(t => {
+    const lower = t.toLowerCase();
+    return _PICKUP_KEYWORDS.some(k => lower.includes(k));
+  });
+
+  if (heuristic) {
+    dbg("ready:_seedGenericPickupItemType", "heuristic match found, setting silently", { heuristic });
+    await game.settings.set(MODULE_ID, "genericPickupItemType", heuristic);
+    return;
+  }
+
+  dbg("ready:_seedGenericPickupItemType", "no heuristic match, opening dialog", { itemTypes });
+  const options = itemTypes.map(t => `<option value="${t}">${t}</option>`).join("");
+  const choice = await foundry.applications.api.DialogV2.prompt({
+    window: { title: game.i18n.localize("INTERACTIVE_ITEMS.Dialog.PickPickupType.Title") },
+    content: `
+      <p>${game.i18n.format("INTERACTIVE_ITEMS.Dialog.PickPickupType.Body", { system: game.system.id })}</p>
+      <label>${game.i18n.localize("INTERACTIVE_ITEMS.Dialog.PickPickupType.Label")}
+        <select name="pickupType">${options}</select>
+      </label>`,
+    ok: {
+      label: game.i18n.localize("INTERACTIVE_ITEMS.Dialog.Confirm"),
+      callback: (event, button) => button.form.elements.pickupType.value
+    },
+    rejectClose: false
+  });
+
+  if (choice) {
+    dbg("ready:_seedGenericPickupItemType", "GM chose item type", { choice });
+    await game.settings.set(MODULE_ID, "genericPickupItemType", choice);
+  } else {
+    dbg("ready:_seedGenericPickupItemType", "dialog closed without selection, skipping");
+  }
+}
+
 function _onGMOverrideChanged() {
-  dbg("settings:gmOverrideChanged", { value: game.settings.get(MODULE_ID, "gmOverrideEnabled") });
+  const enabled = game.settings.get(MODULE_ID, "gmOverrideEnabled");
+  dbg("settings:gmOverrideChanged", { value: enabled });
   // reset:true forces #prepareControls() to re-run; plain render() skips it and leaves active stale.
   ui.controls?.render({ reset: true });
   foundry.applications.instances.get("settings-config")?.render();
   ui.actors?.render();
   if (canvas?.ready) {
+    // When the GM switches OFF the override, any interactive token they
+    // already had controlled needs to be released — _canControl now denies
+    // new control attempts in player view, but it doesn't retroactively
+    // un-control already-selected tokens, and a selected token still
+    // responds to keyboard movement.
+    if (!enabled) {
+      for (const token of canvas.tokens.controlled) {
+        if (isInteractiveActor(token.actor)) {
+          dbg("settings:gmOverrideChanged", "releasing controlled interactive token", { tokenId: token.id, actorName: token.actor?.name });
+          token.release();
+        }
+      }
+    }
     for (const token of canvas.tokens.placeables) token.renderFlags.set({ refreshState: true });
   }
   canvas?.hud?.token?.render();

--- a/scripts/sheets/InteractiveItemSheet.mjs
+++ b/scripts/sheets/InteractiveItemSheet.mjs
@@ -38,15 +38,15 @@ export default class InteractiveItemSheet extends ActorSheetV2 {
    * before opening the new one.
    */
   static async showLimitedDialog(actor) {
-    dbg("sheet:showLimitedDialog", { actorName: actor.name, actorUuid: actor.uuid, isContainer: actor.system.isContainer });
+    dbg("sheet:showLimitedDialog", { actorName: actor.name, actorUuid: actor.uuid, isContainer: getAdapter().isInteractiveContainer(actor) });
     const key = actor.uuid;
     const existing = InteractiveItemSheet.limitedDialogs.get(key);
     if (existing) await existing.close();
 
-    const system = actor.system;
-    const title = system.limitedDisplayName;
+    const adapter = getAdapter();
+    const title = adapter.getInteractiveLimitedName(actor);
     const body = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-      system.limitedDisplayDescription,
+      adapter.getInteractiveLimitedDescription(actor),
       { async: true }
     );
 
@@ -80,13 +80,14 @@ export default class InteractiveItemSheet extends ActorSheetV2 {
     const dialog = InteractiveItemSheet.limitedDialogs.get(actor.uuid);
     if (!dialog?.element) return;
 
+    const adapter = getAdapter();
     const titleEl = dialog.element.querySelector(".window-title");
-    if (titleEl) titleEl.textContent = actor.system.limitedDisplayName;
+    if (titleEl) titleEl.textContent = adapter.getInteractiveLimitedName(actor);
 
     const contentEl = dialog.element.querySelector(".limited-view");
     if (contentEl) {
       contentEl.innerHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-        actor.system.limitedDisplayDescription,
+        adapter.getInteractiveLimitedDescription(actor),
         { async: true }
       );
     }
@@ -165,7 +166,7 @@ export default class InteractiveItemSheet extends ActorSheetV2 {
       configMode: this.#configMode,
       tokenDocId: this._tokenDoc?.id,
       isGM: isModuleGM(),
-      isContainer: this.actor?.system?.isContainer,
+      isContainer: getAdapter().isInteractiveContainer(this.actor),
       pendingPicker: InteractiveItemSheet.pendingPicker.has(this.actor?.id)
     });
     if (InteractiveItemSheet.pendingPicker.has(this.actor.id)) {
@@ -193,17 +194,14 @@ export default class InteractiveItemSheet extends ActorSheetV2 {
       return this;
     }
 
-    const system = this.actor.system;
-
-    if (system.isContainer) {
+    if (adapter.isInteractiveContainer(this.actor)) {
       if (isPlayerView() && !checkProximity(this.actor, { silent: true, range: "inspection" })) {
         dbg("sheet:render", "container: player out of inspection range → showLimitedDialog");
         InteractiveItemSheet.showLimitedDialog(this.actor);
         return this;
       }
-      const item = system.containerItem;
-      if (item) {
-        dbg("sheet:render", "container: delegating to adapter.renderContainerView", { itemId: item.id, itemName: item.name });
+      if (adapter.hasInteractiveEmbeddedItem(this.actor)) {
+        dbg("sheet:render", "container: delegating to adapter.renderContainerView");
         await adapter.renderContainerView(this.actor, options);
         return this;
       }
@@ -213,9 +211,8 @@ export default class InteractiveItemSheet extends ActorSheetV2 {
         InteractiveItemSheet.showLimitedDialog(this.actor);
         return this;
       }
-      const item = this.actor.items.contents[0];
-      if (item) {
-        dbg("sheet:render", "item: delegating to adapter.renderItemView", { itemId: item.id, itemName: item.name });
+      if (adapter.hasInteractiveEmbeddedItem(this.actor)) {
+        dbg("sheet:render", "item: delegating to adapter.renderItemView");
         await adapter.renderItemView(this.actor, options);
         return this;
       }

--- a/scripts/socket/SocketHandler.mjs
+++ b/scripts/socket/SocketHandler.mjs
@@ -22,7 +22,8 @@ export function registerSocket() {
           payload.data.tokenId,
           payload.data.itemId,
           payload.data.targetActorId,
-          payload.data.quantity ?? null  // optional partial-stack quantity
+          payload.data.quantity ?? null,  // optional partial-stack quantity
+          payload.data.contentId ?? null  // optional (generic) container-row id
         );
         break;
       case "depositItem":

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -88,9 +88,13 @@ function getPlayerPositionOverride(tokenId) {
  * @param {number|null} [quantity=null] - Optional partial-stack quantity. When
  *   null/undefined the full stack is moved (existing behavior). Clamped to
  *   `[1, source quantity]` server-side.
+ * @param {string|null} [contentId=null] - (Generic mode only) When set, pick
+ *   up the specific row from the source container's `contents[]` flag array
+ *   rather than the whole token. Ignored by model-backed adapters which use
+ *   embedded Item documents instead.
  */
-export async function pickupItem(sceneId, tokenId, itemId, targetActorId, quantity = null) {
-  dbg("xfer:pickupItem", { sceneId, tokenId, itemId, targetActorId, quantity });
+export async function pickupItem(sceneId, tokenId, itemId, targetActorId, quantity = null, contentId = null) {
+  dbg("xfer:pickupItem", { sceneId, tokenId, itemId, targetActorId, quantity, contentId });
   const result = getTokenActor(sceneId, tokenId);
   const targetActor = game.actors.get(targetActorId);
 
@@ -101,6 +105,15 @@ export async function pickupItem(sceneId, tokenId, itemId, targetActorId, quanti
   }
 
   const { actor: sourceActor, tokenDoc } = result;
+  const adapter = getAdapter();
+
+  // Generic path: actor state lives entirely in flags rather than actor.system
+  // and actor.items. Build a stub item from the flag blob and create it on the
+  // target — no embedded-item documents to read or delete.
+  if (adapter.constructor.SYSTEM_ID === "generic") {
+    return _pickupItemGeneric(sourceActor, tokenDoc, targetActor, quantity, { sceneId, tokenId, contentId });
+  }
+
   dbg("xfer:pickupItem", "resolved actors", {
     sourceActorName: sourceActor.name, sourceActorId: sourceActor.id, sourceActorImg: sourceActor.img,
     isContainer: sourceActor.system.isContainer, targetActorName: targetActor.name, targetActorId: targetActor.id
@@ -132,7 +145,6 @@ export async function pickupItem(sceneId, tokenId, itemId, targetActorId, quanti
   const baseActorId = tokenDoc.actorId;
   const isEphemeralToken = !!tokenDoc.flags?.["pick-up-stix"]?.ephemeral;
 
-  const adapter = getAdapter();
   const sourceQty = adapter.getItemQuantity(item);
   // Clamp the requested quantity into [1, sourceQty]. null/undefined means
   // "move the full stack" (legacy behavior).
@@ -201,6 +213,213 @@ export async function pickupItem(sceneId, tokenId, itemId, targetActorId, quanti
 }
 
 /**
+ * Build the stub-item data object for a generic pickup. Detects the active
+ * system's expected shape for `system.description` by inspecting the data
+ * model schema for the configured pickup item type:
+ *   - Object-shape (SchemaField): write `{ value: description }`.
+ *     This is the dnd5e/pf2e shape (`{value, chat, unidentified, ...}`).
+ *   - String/HTML-shape: write the description directly.
+ *     This is the Eventide / many other systems' shape.
+ *   - No description field declared: skip it entirely.
+ *
+ * Without this detection, writing the wrong shape into `system.description`
+ * causes the system's item sheet to render "[object Object]" (object shape
+ * written to a string field) or to drop the description silently (string
+ * written to an object field).
+ *
+ * @param {object} args
+ * @param {string} args.name
+ * @param {string} args.img
+ * @param {string} args.description
+ * @param {number} args.quantity
+ * @param {string} args.lootType
+ * @returns {object}
+ */
+export function buildGenericStubItem({ name, img, description, quantity, lootType }) {
+  const Model = CONFIG.Item.dataModels?.[lootType];
+  const descField = Model?.schema?.fields?.description;
+
+  const stubData = {
+    name,
+    img,
+    type: lootType,
+    system: { quantity }
+  };
+
+  if (descField instanceof foundry.data.fields.SchemaField) {
+    // Object shape: { value, chat, ... }. Write to .value.
+    stubData.system.description = { value: description ?? "" };
+  } else if (descField) {
+    // String / HTML field: write the description directly.
+    stubData.system.description = description ?? "";
+  }
+  // else: no description field declared on this item type — skip it.
+
+  return stubData;
+}
+
+/**
+ * Generic-mode pickup: reads the interactive flag blob from the source actor,
+ * builds a stub item of the configured `genericPickupItemType`, creates it on
+ * the target actor's inventory, then removes the source token from the scene.
+ *
+ * Generic actors have no embedded `actor.items` — all state lives in
+ * `flags["pick-up-stix"].interactive`. The `description.value` shape is used
+ * for the stub because most systems with HTML description fields follow it;
+ * on systems that use a different path the description simply lands unset,
+ * which is graceful degradation.
+ *
+ * @param {Actor} sourceActor
+ * @param {TokenDocument} tokenDoc
+ * @param {Actor} targetActor
+ * @param {number|null} quantity
+ * @param {object} ids
+ * @param {string} ids.sceneId
+ * @param {string} ids.tokenId
+ * @returns {Promise<boolean>}
+ */
+async function _pickupItemGeneric(sourceActor, tokenDoc, targetActor, quantity, { sceneId, tokenId, contentId = null }) {
+  const adapter = getAdapter();
+  const interactiveData = adapter.getInteractiveData(sourceActor);
+
+  dbg("xfer:_pickupItemGeneric", {
+    sourceActorName: sourceActor.name, mode: interactiveData.mode,
+    hasItemData: !!interactiveData.itemData,
+    targetActorName: targetActor.name, contentId
+  });
+
+  // Two pickup variants:
+  //  - contentId set → pulling a single row out of a container's contents[].
+  //    The source remains in place (container token persists, row removed).
+  //  - contentId null → whole-token item-mode pickup. Source token is removed.
+  if (contentId) {
+    return _pickupContentRow(sourceActor, targetActor, contentId, quantity);
+  }
+
+  if (interactiveData.mode !== "item" || !interactiveData.itemData) {
+    dbg("xfer:_pickupItemGeneric", "source actor is not an item-mode generic interactive, bail");
+    ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoItems"));
+    return false;
+  }
+
+  // Prefer top-level interactive fields — those reflect the GM's current
+  // edits via the config sheet. interactiveData.itemData is the snapshot at
+  // drop time and goes stale after any rename / image change. Quantity is
+  // only stored in itemData.
+  const snapshot = interactiveData.itemData ?? {};
+  const name = interactiveData.name || snapshot.name || sourceActor.name;
+  const img = interactiveData.img || snapshot.img || sourceActor.img;
+  const description = interactiveData.description || snapshot.description || "";
+  const flagQty = snapshot.quantity ?? 1;
+  const lootType = adapter.defaultLootItemType;
+
+  if (!lootType) {
+    dbg("xfer:_pickupItemGeneric", "no loot item type configured, bail");
+    ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
+    return false;
+  }
+
+  // Clamp the requested quantity into [1, flagQty].
+  const moveQty = quantity == null
+    ? flagQty
+    : Math.max(1, Math.min(Math.floor(quantity), flagQty));
+
+  const stubData = buildGenericStubItem({ name, img, description, quantity: moveQty, lootType });
+
+  dbg("xfer:_pickupItemGeneric", "creating stub item on target", {
+    stubName: stubData.name, lootType, moveQty, targetActorName: targetActor.name
+  });
+
+  await CONFIG.Item.documentClass.create(stubData, { parent: targetActor });
+
+  const isPartial = moveQty < flagQty;
+  if (isPartial) {
+    // Partial pickup: decrement the source actor's stored quantity and leave
+    // the token in place. The synthetic actor delta isn't relevant here —
+    // generic data lives in flags which inherit from base; writing through
+    // setInteractiveData on the (synthetic) actor updates the right blob.
+    dbg("xfer:_pickupItemGeneric", "partial pickup — decrementing source qty", { flagQty, moveQty, remaining: flagQty - moveQty });
+    await adapter.setInteractiveData(sourceActor, {
+      itemData: { ...(interactiveData.itemData ?? {}), quantity: flagQty - moveQty }
+    });
+  } else {
+    // Full pickup: remove the source token from the scene. The actor itself
+    // may persist as a template — mirrors the model-backed pickup behavior.
+    dbg("xfer:_pickupItemGeneric", "full pickup — deleting source token", { tokenId });
+    const scene = game.scenes.get(sceneId);
+    await scene.deleteEmbeddedDocuments("Token", [tokenId]);
+  }
+
+  notifyItemAction("PickedUp", stubData.name);
+  dbg("xfer:_pickupItemGeneric", "generic pickup complete");
+  return true;
+}
+
+/**
+ * Pull a single content row out of a generic container's `contents[]` flag
+ * array and create a stub item for it on the target actor. Source container
+ * token stays in place — only the row is removed.
+ *
+ * @param {Actor} sourceActor - The container actor (synthetic token actor).
+ * @param {Actor} targetActor - The destination character actor.
+ * @param {string} contentId  - id of the row to pick up.
+ * @param {number|null} quantity - Partial-stack quantity (null = full).
+ * @returns {Promise<boolean>}
+ */
+async function _pickupContentRow(sourceActor, targetActor, contentId, quantity) {
+  const adapter = getAdapter();
+  const interactiveData = adapter.getInteractiveData(sourceActor);
+  const row = (interactiveData.contents ?? []).find(c => c.id === contentId);
+
+  dbg("xfer:_pickupContentRow", {
+    sourceActorName: sourceActor.name, contentId,
+    rowFound: !!row, targetActorName: targetActor.name
+  });
+
+  if (!row) {
+    dbg("xfer:_pickupContentRow", "row not found in source contents, bail");
+    ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoItems"));
+    return false;
+  }
+
+  const lootType = adapter.defaultLootItemType;
+  if (!lootType) {
+    dbg("xfer:_pickupContentRow", "no loot item type configured, bail");
+    ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.TransferError"));
+    return false;
+  }
+
+  const flagQty = row.quantity ?? 1;
+  const moveQty = quantity == null
+    ? flagQty
+    : Math.max(1, Math.min(Math.floor(quantity), flagQty));
+
+  const stubData = buildGenericStubItem({
+    name: row.name || "Item",
+    img: row.img,
+    description: row.description ?? "",
+    quantity: moveQty,
+    lootType
+  });
+
+  dbg("xfer:_pickupContentRow", "creating stub on target", { stubName: stubData.name, lootType, moveQty });
+  await CONFIG.Item.documentClass.create(stubData, { parent: targetActor });
+
+  // Remove the row from the container's contents[]. Partial pickups
+  // decrement quantity; full pickups drop the row entirely.
+  const newContents = (interactiveData.contents ?? [])
+    .map(c => c.id === contentId
+      ? (moveQty < flagQty ? { ...c, quantity: flagQty - moveQty } : null)
+      : c)
+    .filter(c => c != null);
+  await adapter.setInteractiveData(sourceActor, { contents: newContents });
+
+  notifyItemAction("PickedUp", stubData.name);
+  dbg("xfer:_pickupContentRow", "row pickup complete");
+  return true;
+}
+
+/**
  * @param {string} sourceActorId
  * @param {string} itemId
  * @param {string} sceneId
@@ -239,7 +458,9 @@ export async function depositItem(sourceActorId, itemId, sceneId, tokenId, quant
   dbg("xfer:depositItem", "resolved item and actors", {
     itemName: item.name, itemId: item.id,
     sourceActorName: sourceActor.name, targetActorName: targetActor.name,
-    targetIsContainer: targetActor.system?.isContainer, targetIsLocked: targetActor.system?.isLocked, targetIsOpen: targetActor.system?.isOpen,
+    targetIsContainer: adapter.isInteractiveContainer(targetActor),
+    targetIsLocked: adapter.isInteractiveLocked(targetActor),
+    targetIsOpen: adapter.isInteractiveOpen(targetActor),
     sourceQty, moveQty
   });
 
@@ -248,6 +469,28 @@ export async function depositItem(sourceActorId, itemId, sceneId, tokenId, quant
   if (!validateContainerAccess(targetActor, { checkOpen: true })) {
     dbg("xfer:depositItem", "validateContainerAccess failed");
     return false;
+  }
+
+  // Generic container target: append a content row to its flag blob rather
+  // than creating an embedded Item document (the target has no actor.items
+  // collection and the system would reject the create anyway). Source is
+  // still decremented on its real actor.
+  if (adapter.constructor.SYSTEM_ID === "generic" && adapter.isInteractiveContainer(targetActor)) {
+    const row = {
+      id: foundry.utils.randomID(),
+      name: item.name,
+      img: item.img,
+      description: item.system?.description?.value ?? item.system?.description ?? "",
+      quantity: moveQty
+    };
+    const current = adapter.getInteractiveData(targetActor);
+    dbg("xfer:depositItem", "generic container deposit: appending content row", { rowName: row.name, qty: moveQty });
+    await adapter.setInteractiveData(targetActor, {
+      contents: [...(current.contents ?? []), row]
+    });
+    await decrementOrDeleteItem(item, moveQty);
+    notifyItemAction("Deposited", item.name);
+    return true;
   }
 
   const toCreate = await adapter.flattenItemsForCreate([item]);
@@ -368,16 +611,17 @@ export function checkProximity(interactiveActor, { silent = false, range = "inte
 
 export async function updateContainerTokenImage(tokenDoc, isOpen) {
   const actor = tokenDoc.actor;
+  const adapter = getAdapter();
+  const openImage = adapter.getInteractiveOpenImage(actor);
   dbg("xfer:updateContainerTokenImage", {
     tokenId: tokenDoc.id, isOpen, actorName: actor?.name,
-    isContainer: actor?.system?.isContainer, openImage: actor?.system?.openImage,
+    isContainer: adapter.isInteractiveContainer(actor), openImage,
     currentSrc: tokenDoc.texture?.src, actorImg: actor?.img
   });
-  if (!actor?.system?.isContainer) {
+  if (!adapter.isInteractiveContainer(actor)) {
     dbg("xfer:updateContainerTokenImage", "not a container actor, bail");
     return;
   }
-  const openImage = actor.system.openImage;
   if (!openImage) {
     dbg("xfer:updateContainerTokenImage", "no openImage configured, bail");
     return;
@@ -393,10 +637,13 @@ export async function updateContainerTokenImage(tokenDoc, isOpen) {
 }
 
 export async function setContainerOpen(actor, newIsOpen, { silent = false } = {}) {
-  dbg("xfer:setContainerOpen", { actorName: actor.name, actorId: actor.id, currentIsOpen: actor.system.isOpen, newIsOpen, isLocked: actor.system.isLocked, isSynthetic: !!actor.token, isGM: game.user.isGM });
-  if (newIsOpen && actor.system.isLocked) {
+  const adapter = getAdapter();
+  const currentIsOpen = adapter.isInteractiveOpen(actor);
+  const currentIsLocked = adapter.isInteractiveLocked(actor);
+  dbg("xfer:setContainerOpen", { actorName: actor.name, actorId: actor.id, currentIsOpen, newIsOpen, isLocked: currentIsLocked, isSynthetic: !!actor.token, isGM: game.user.isGM });
+  if (newIsOpen && currentIsLocked) {
     dbg("xfer:setContainerOpen", "actor is locked, cannot open");
-    if (!silent) ui.notifications.warn(actor.system.lockedDisplayMessage);
+    if (!silent) ui.notifications.warn(adapter.getInteractiveLockedMessage(actor));
     return false;
   }
   const tokenDoc = actor.token;
@@ -409,7 +656,9 @@ export async function setContainerOpen(actor, newIsOpen, { silent = false } = {}
     "toggleOpen",
     { sceneId: tokenDoc?.parent.id, tokenId: tokenDoc?.id, isOpen: newIsOpen },
     async () => {
-      await actor.update({ "system.isOpen": newIsOpen });
+      // Route through the adapter: model-backed adapters write to
+      // `system.isOpen`; the generic adapter writes the equivalent flag.
+      await adapter.setInteractiveOpenState(actor, newIsOpen);
       if (tokenDoc) await updateContainerTokenImage(tokenDoc, newIsOpen);
     }
   );
@@ -417,13 +666,18 @@ export async function setContainerOpen(actor, newIsOpen, { silent = false } = {}
 }
 
 export async function toggleContainerLocked(actor) {
-  const sys = actor.system;
-  const wasOpen = !sys.isLocked && sys.isOpen;
-  dbg("xfer:toggleContainerLocked", { actorName: actor.name, actorId: actor.id, currentIsLocked: sys.isLocked, currentIsOpen: sys.isOpen, wasOpen, newIsLocked: !sys.isLocked });
-  const updates = { "system.isLocked": !sys.isLocked };
-  if (wasOpen) updates["system.isOpen"] = false;
-  dbg("xfer:toggleContainerLocked", "firing actor.update", { updates });
-  await actor.update(updates);
+  const adapter = getAdapter();
+  const currentIsLocked = adapter.isInteractiveLocked(actor);
+  const currentIsOpen = adapter.isInteractiveOpen(actor);
+  const wasOpen = !currentIsLocked && currentIsOpen;
+  dbg("xfer:toggleContainerLocked", { actorName: actor.name, actorId: actor.id, currentIsLocked, currentIsOpen, wasOpen, newIsLocked: !currentIsLocked });
+  // Flip the lock state, and if the container was open also close it so a
+  // newly-locked container is also closed (otherwise the open state would
+  // remain stuck on a locked container, which is nonsensical).
+  await adapter.setInteractiveLockedState(actor, !currentIsLocked);
+  if (wasOpen) {
+    await adapter.setInteractiveOpenState(actor, false);
+  }
   if (wasOpen && actor.token) {
     dbg("xfer:toggleContainerLocked", "container was open, updating token image to closed");
     await updateContainerTokenImage(actor.token, false);

--- a/scripts/utils/actorHelpers.mjs
+++ b/scripts/utils/actorHelpers.mjs
@@ -1,15 +1,35 @@
 import { INTERACTIVE_TYPES } from "../constants.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 
 export function isInteractiveActor(actor) {
   return !!actor && INTERACTIVE_TYPES.has(actor.type);
 }
 
+/**
+ * True if the actor is an interactive container.
+ *
+ * Routes through `adapter.isInteractiveContainer` so generic-mode containers
+ * (whose state lives in `flags["pick-up-stix"].interactive` rather than
+ * `actor.system.isContainer`) are detected correctly. Falls back to the
+ * legacy `actor.system?.isContainer` read if the adapter hasn't loaded yet
+ * (which would only happen if called from very early init).
+ */
 export function isInteractiveContainer(actor) {
-  return isInteractiveActor(actor) && !!actor.system?.isContainer;
+  if (!isInteractiveActor(actor)) return false;
+  try {
+    return getAdapter().isInteractiveContainer(actor);
+  } catch {
+    return !!actor.system?.isContainer;
+  }
 }
 
 export function isInteractiveItemMode(actor) {
-  return isInteractiveActor(actor) && !actor.system?.isContainer;
+  if (!isInteractiveActor(actor)) return false;
+  try {
+    return !getAdapter().isInteractiveContainer(actor);
+  } catch {
+    return !actor.system?.isContainer;
+  }
 }
 
 export function getTokenActor(sceneId, tokenId) {

--- a/scripts/utils/containerAccess.mjs
+++ b/scripts/utils/containerAccess.mjs
@@ -1,6 +1,7 @@
 import { checkProximity } from "../transfer/ItemTransfer.mjs";
 import { isItemLocked } from "./itemFlags.mjs";
 import { notifyContainerClosed } from "./notify.mjs";
+import { getAdapter } from "../adapter/index.mjs";
 import { dbg } from "./debugLog.mjs";
 
 export function validateContainerAccess(actor, {
@@ -9,18 +10,24 @@ export function validateContainerAccess(actor, {
   checkProximity: doProximity = false,
   silent = false
 } = {}) {
-  const sys = actor.system;
+  // Route all state reads through the adapter so generic mode (where the
+  // actor's system fields are absent because the system wiped our data
+  // model) gets the same gates as the model-backed adapters.
+  const adapter = getAdapter();
+  const isLocked = adapter.isInteractiveLocked(actor);
+  const isContainer = adapter.isInteractiveContainer(actor);
+  const isOpen = adapter.isInteractiveOpen(actor);
   dbg("access:validateContainerAccess", {
     actorName: actor.name, actorId: actor.id,
     checkLocked, checkOpen, doProximity,
-    isLocked: sys.isLocked, isContainer: sys.isContainer, isOpen: sys.isOpen
+    isLocked, isContainer, isOpen
   });
-  if (checkLocked && sys.isLocked) {
+  if (checkLocked && isLocked) {
     dbg("access:validateContainerAccess", "FAIL: actor is locked");
-    if (!silent) ui.notifications.warn(sys.lockedDisplayMessage);
+    if (!silent) ui.notifications.warn(adapter.getInteractiveLockedMessage(actor));
     return false;
   }
-  if (checkOpen && sys.isContainer && !sys.isOpen) {
+  if (checkOpen && isContainer && !isOpen) {
     dbg("access:validateContainerAccess", "FAIL: container is closed");
     if (!silent) notifyContainerClosed();
     return false;

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -41,6 +41,18 @@
   cursor: pointer;
 }
 
+/* Constrain the header portrait directly. dnd5e's own CSS sizes
+   `.document-image` via the --dnd5e-document-image-size variable, but on
+   systems without dnd5e's stylesheet the image renders at the source's
+   natural dimensions. Apply the same 96px target via a non-namespaced
+   selector so generic mode matches dnd5e. */
+.pick-up-stix.sheet .sheet-header .document-image {
+  flex: 0 0 96px;
+  width: 96px;
+  height: 96px;
+  object-fit: contain;
+}
+
 .pick-up-stix.sheet .sheet-header .document-name {
   flex: 1;
   font-size: var(--font-size-32);

--- a/templates/container-view-generic.hbs
+++ b/templates/container-view-generic.hbs
@@ -1,0 +1,41 @@
+<section class="pick-up-stix generic-container-view">
+  <header class="sheet-header">
+    <img class="document-image" src="{{img}}" alt="{{name}}" />
+    <h1>{{name}}</h1>
+  </header>
+  <div class="description">{{{descriptionHTML}}}</div>
+
+  {{#if showContents}}
+    <ol class="ii-contents-list">
+      {{#each contents}}
+        <li class="ii-contents-row" data-content-id="{{id}}" draggable="true">
+          {{!-- draggable="false" on the inner image so clicks on it bubble
+                up to the row instead of triggering the browser's own image
+                drag, which would put the image URL in dataTransfer instead
+                of our InteractiveContent payload. --}}
+          <img class="ii-contents-img" src="{{img}}" alt="{{name}}" draggable="false" />
+          <span class="ii-contents-name">{{name}}</span>
+          {{#if showQuantity}}<span class="ii-contents-quantity">×{{quantity}}</span>{{/if}}
+          {{#if ../isTokenActor}}
+            <button type="button" class="ii-row-control ii-pickup-btn"
+                    data-content-id="{{id}}"
+                    title="{{localize 'INTERACTIVE_ITEMS.HUD.PickUp'}}">
+              <i class="fa-solid fa-hand"></i>
+            </button>
+          {{/if}}
+          {{#if ../isGM}}
+            <button type="button" class="ii-row-control ii-delete"
+                    data-action="deleteContent" data-content-id="{{id}}"
+                    title="{{localize 'INTERACTIVE_ITEMS.Sheet.DeleteItem'}}">
+              <i class="fa-solid fa-trash-can"></i>
+            </button>
+          {{/if}}
+        </li>
+      {{else}}
+        <li class="ii-contents-empty">{{localize "INTERACTIVE_ITEMS.Container.Empty"}}</li>
+      {{/each}}
+    </ol>
+  {{else}}
+    <div class="pick-up-stix-contents-hidden">{{hiddenMessage}}</div>
+  {{/if}}
+</section>

--- a/templates/item-config-generic.hbs
+++ b/templates/item-config-generic.hbs
@@ -1,0 +1,142 @@
+<section class="item-config generic">
+  {{#if needsMode}}
+    <div class="needs-mode-prompt">
+      <p>{{localize "INTERACTIVE_ITEMS.Sheet.NeedsModeGeneric"}}</p>
+    </div>
+  {{else if needsItem}}
+    <div class="needs-item-prompt">
+      <i class="fa-solid fa-arrow-down"></i>
+      <p>{{localize "INTERACTIVE_ITEMS.Sheet.NeedsItem"}}</p>
+      <img class="needs-item-icon" src="modules/pick-up-stix/icons/interactive-item-icon.svg" alt="" />
+    </div>
+  {{else}}
+    <header class="sheet-header">
+      <img class="document-image ii-clickable-image" src="{{img}}" alt="{{name}}"
+           data-action="editActorImage" />
+      <input type="text" name="data.name" value="{{name}}"
+             placeholder="{{localize 'INTERACTIVE_ITEMS.Sheet.Name'}}" />
+    </header>
+
+    {{!-- Quick-open button: switches to the player-facing item/container view
+          (the sheet players see when they click the placed token). --}}
+    {{#if isContainer}}
+      <button type="button" data-action="openContainerSheet">
+        <i class="fa-solid fa-up-right-from-square"></i>
+        {{localize "INTERACTIVE_ITEMS.Sheet.ViewContainerSheet"}}
+      </button>
+    {{else}}
+      <button type="button" data-action="openItemSheet">
+        <i class="fa-solid fa-up-right-from-square"></i>
+        {{localize "INTERACTIVE_ITEMS.Sheet.ViewItemSheet"}}
+      </button>
+    {{/if}}
+
+    <fieldset>
+      <legend>{{localize "INTERACTIVE_ITEMS.Sheet.ConfigLegend"}}</legend>
+
+      {{!-- Description: collapsible card; swaps to a compact prose-mirror
+            in place when the user clicks the feather. On save, the editor's
+            save event clears the editing target and the card returns. --}}
+      <div class="item-descriptions">
+        {{#if editingDescription}}
+          <div class="card description editing">
+            <div class="header"><span>{{localize "INTERACTIVE_ITEMS.Sheet.Description"}}</span></div>
+            <prose-mirror name="data.description" value="{{description}}"
+                          class="sized" compact></prose-mirror>
+          </div>
+        {{else}}
+          <div class="card description collapsible{{#unless descriptionEnriched}} empty{{/unless}}{{#unless (lookup expanded 'data.description')}} collapsed{{/unless}}"
+               data-action="toggleCollapsed" data-expand-id="data.description" data-target="data.description">
+            <div class="header">
+              <span>{{localize "INTERACTIVE_ITEMS.Sheet.Description"}}</span>
+              {{#if isEditable}}
+              <button type="button" class="unbutton control-button always-interactive" data-action="editDescription"
+                      aria-label="{{localize 'INTERACTIVE_ITEMS.Sheet.Description'}}" data-target="data.description">
+                <i class="fas fa-feather" inert></i>
+              </button>
+              {{/if}}
+            </div>
+            <div class="details collapsible-content">
+              <div class="editor editor-content wrapper">{{{description}}}</div>
+            </div>
+          </div>
+        {{/if}}
+      </div>
+
+      {{#if isContainer}}
+        <div class="form-group">
+          <label>{{localize "INTERACTIVE_ITEMS.Sheet.OpenImage"}}</label>
+          <div class="form-fields">
+            <file-picker name="data.openImage" type="image" value="{{openImage}}"></file-picker>
+          </div>
+        </div>
+      {{else}}
+        <div class="form-group">
+          <label>{{localize "INTERACTIVE_ITEMS.Sheet.Quantity"}}</label>
+          <div class="form-fields">
+            <input type="number" name="data.itemData.quantity"
+                   min="1" step="1" value="{{itemData.quantity}}" />
+          </div>
+        </div>
+      {{/if}}
+
+      <div class="form-group">
+        <label>{{localize "INTERACTIVE_ITEMS.Sheet.LockedMessage"}}</label>
+        <div class="form-fields">
+          <input type="text" name="data.lockedMessage" value="{{lockedMessage}}" />
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label>{{localize "INTERACTIVE_ITEMS.Sheet.LimitedName"}}</label>
+        <div class="form-fields">
+          <input type="text" name="data.limitedName" value="{{limitedName}}" />
+        </div>
+      </div>
+
+      {{!-- Limited-view description: same per-card switch as the main
+            description above so the editor appears in place when clicked. --}}
+      <div class="item-descriptions">
+        {{#if editingLimitedDescription}}
+          <div class="card description editing">
+            <div class="header"><span>{{localize "INTERACTIVE_ITEMS.Sheet.LimitedDescription"}}</span></div>
+            <prose-mirror name="data.limitedDescription" value="{{limitedDescription}}"
+                          class="sized" compact></prose-mirror>
+          </div>
+        {{else}}
+          <div class="card description collapsible{{#unless limitedDescriptionEnriched}} empty{{/unless}}{{#unless (lookup expanded 'data.limitedDescription')}} collapsed{{/unless}}"
+               data-action="toggleCollapsed" data-expand-id="data.limitedDescription" data-target="data.limitedDescription">
+            <div class="header">
+              <span>{{localize "INTERACTIVE_ITEMS.Sheet.LimitedDescription"}}</span>
+              {{#if isEditable}}
+              <button type="button" class="unbutton control-button always-interactive" data-action="editDescription"
+                      aria-label="{{localize 'INTERACTIVE_ITEMS.Sheet.LimitedDescription'}}" data-target="data.limitedDescription">
+                <i class="fas fa-feather" inert></i>
+              </button>
+              {{/if}}
+            </div>
+            <div class="details collapsible-content">
+              <div class="editor editor-content wrapper">{{{limitedDescription}}}</div>
+            </div>
+          </div>
+        {{/if}}
+      </div>
+
+      <div class="form-group">
+        <label>{{localize "INTERACTIVE_ITEMS.Sheet.InteractionRange"}}</label>
+        <div class="form-fields">
+          <input type="number" name="data.interactionRange"
+                 min="0" step="0.5" value="{{interactionRange}}" />
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label>{{localize "INTERACTIVE_ITEMS.Sheet.InspectionRange"}}</label>
+        <div class="form-fields">
+          <input type="number" name="data.inspectionRange"
+                 min="0" step="0.5" value="{{inspectionRange}}" />
+        </div>
+      </div>
+    </fieldset>
+  {{/if}}
+</section>

--- a/templates/item-view-generic.hbs
+++ b/templates/item-view-generic.hbs
@@ -1,0 +1,12 @@
+<section class="pick-up-stix generic-item-view">
+  <header class="sheet-header">
+    <img class="document-image" src="{{itemData.img}}" alt="{{itemData.name}}" />
+    <div class="title">
+      <h1>{{itemData.name}}</h1>
+      {{#if showQuantity}}
+        <span class="quantity">{{localize "INTERACTIVE_ITEMS.Sheet.Quantity"}}: {{itemData.quantity}}</span>
+      {{/if}}
+    </div>
+  </header>
+  <div class="description">{{{descriptionHTML}}}</div>
+</section>


### PR DESCRIPTION
## Summary

Makes Pick-Up-Stix usable on any Foundry v13/v14 system, not just dnd5e and pf2e.

When the active system has no dedicated adapter, the module falls back to a new **generic adapter** that stores all interactive-object state in actor flags (`flags["pick-up-stix"].interactive`) and renders its own custom item/container/config sheets. No reliance on `actor.system` fields or embedded `actor.items`, so systems like Eventide RP System that wholesale-replace `CONFIG.Actor.documentClass` / `CONFIG.Item.documentClass` / `CONFIG.Actor.dataModels` work transparently.

dnd5e and pf2e adapters are functionally unchanged. The dispatcher gets thin adapter-mediated abstractions (`isInteractiveContainer`, `isInteractiveOpen`, `getInteractiveDisplayName`, etc.) whose model-backed defaults match the existing behavior, so both paths coexist behind one `InteractiveItemSheet`.

## Architecture

| Aspect | dnd5e / pf2e | generic |
|---|---|---|
| Data store | `actor.system.*` via `InteractiveItemModel` + embedded `actor.items` | `flags["pick-up-stix"].interactive.*` only |
| Item view sheet | system's native `item.sheet` | custom `GenericInteractiveItemView` |
| Container view sheet | system's native (`ContainerSheet` / `ContainerSheetPF2e`) | custom `GenericInteractiveContainerView` |
| GM config sheet | adapter-specific (V2 dnd5e / V1 pf2e) | custom `GenericInteractiveItemConfigSheet` (V2) |
| Container contents | embedded items with parent-pointer | flag array of `{id, name, img, description, quantity}` |
| Pickup result | native `Item.create` with item's data | native `Item.create` with a stub item of a configurable type |
| Identification | system's native field | always identified — UI hidden via capability flag |

## What's new

- New `scripts/adapter/generic/` package: index, data, identification, container, sheets, hooks, plus three custom V2 sheets (configSheet, itemView, containerView).
- New `SystemAdapter` capability flag `supportsIdentification` (default false; dnd5e/pf2e opt in true) gating every identify UI surface.
- New `SystemAdapter` dispatcher / state accessors with model-backed defaults: `isInteractiveContainer`, `hasInteractiveEmbeddedItem`, `getInteractiveDisplayName`, `getInteractiveLimitedName`, `getInteractiveLimitedDescription`, `isInteractiveOpen` / `setInteractiveOpenState`, `isInteractiveLocked` / `setInteractiveLockedState`, `getInteractiveLockedMessage`, `getInteractiveOpenImage`.
- `loadAdapter()` falls back to the generic adapter on missing system-specific import.
- `module.json` drops `relationships.systems` so the module installs on any system.
- One-time GM warning notification on first launch in generic mode; per-system "seen" client setting.
- `genericPickupItemType` world setting with heuristic auto-detection + `DialogV2.prompt` fallback at first launch.

## Notes

- Custom sheets cover the full pickup / deposit / drag-from-row / canvas-placement flows including partial-stack quantity prompts.
- `Token._canControl` libWrapper denies left-click control on interactive tokens when in player view (real players and GMs with override disabled) — closes a pre-existing UX bug where the selection outline was hidden but keyboard movement still worked.
- Toggling GM Override off now releases any currently-controlled interactive tokens.
- README has a Generic-system mode section explaining the trade-offs.