### PR TITLE
feat(lighting): light-emitting interactive items

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Interactive objects display through the active system's own item and container s
 - **Drag items from container contents** -- Items in a container's contents listing can be dragged out to the canvas (placed as an interactive token) or onto another character/container sheet (transfers ownership).
 - **Configurable defaults** -- Module settings for default container images (open and closed), default interaction and inspection ranges, actor folder organization, and folder color.
 
+### Light-emitting Items
+
+- **Per-item light configuration** -- Configure dim/bright radius, color, animation, and advanced lighting options for any interactive item via a lightbulb button in the sheet header (matches Foundry's standard Token Light tab).
+- **Carry-on-pickup** -- When a player picks up a lit item (torch, lantern, etc.), the carrier token emits the item's light additively to its own token-light; the carrier's own light is never overwritten. Movement updates the light position smoothly.
+- **Container gating** -- Items inside an interactive container emit light only while the container is open; closing suppresses the emission.
+- **On/off toggle** -- A lightbulb HUD button on canvas tokens (GM) and a row icon in inventories / container contents (GM or item owner) toggle emission without losing the configured radii.
+
 ### Architecture Highlights
 
 - **System adapter** -- All system-specific surfaces are isolated behind a `SystemAdapter` contract; one concrete adapter per supported system. Core code never branches on `game.system.id`, which keeps adding a new system to a single module under `scripts/adapter/`.

--- a/lang/en.json
+++ b/lang/en.json
@@ -193,6 +193,15 @@
         "Label": "Pickup item type:"
       }
     },
+    "Light": {
+      "Title": "Light Emission",
+      "ConfigureActive": "Light Emission (Configured)",
+      "ConfigureInactive": "Light Emission",
+      "ToggleOn": "Turn Light On",
+      "ToggleOff": "Turn Light Off",
+      "RowTooltipActive": "Light On (click to turn off)",
+      "RowTooltipInactive": "Light Off (click to turn on)"
+    },
     "Limited": {
       "DefaultContainerName": "A container of some sort",
       "DefaultItemName": "A {type} of some sort",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pick-up-stix",
   "title": "Pick-Up-Stix",
   "description": "Place interactive items and containers on the map for players to inspect, pick up, and interact with.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "compatibility": {
     "minimum": "13",
     "verified": "14"

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -451,6 +451,80 @@ export default class SystemAdapter {
     return actor?.system?.openImage ?? null;
   }
 
+  // === Light emission =========================================================
+
+  /**
+   * Read the configured emitted-light data and on/off state for an interactive
+   * actor. Model-backed adapters (dnd5e, pf2e) read from `actor.system.emittedLight`
+   * and `actor.system.lightActive`. The flag-backed generic adapter overrides this
+   * to read from the equivalent flag blob.
+   *
+   * `light` may be a zeroed-out default object when nothing has been configured;
+   * callers should treat `(dim ?? 0) <= 0 && (bright ?? 0) <= 0` as "no emission".
+   *
+   * @param {Actor} actor
+   * @returns {{ light: object, active: boolean }}
+   */
+  getInteractiveLightData(actor) {
+    return {
+      light: actor?.system?.emittedLight?.toObject?.() ?? actor?.system?.emittedLight ?? {},
+      active: !!actor?.system?.lightActive
+    };
+  }
+
+  /**
+   * Persist a partial update to the actor's emitted-light data and/or active
+   * flag. Model-backed adapters write to `actor.system.emittedLight` /
+   * `actor.system.lightActive`; the generic adapter overrides this to write
+   * the equivalent flag blob.
+   *
+   * @param {Actor} actor
+   * @param {object} partial
+   * @param {object}  [partial.light]  - Partial LightData-shape object; merged into existing emittedLight.
+   * @param {boolean} [partial.active] - New on/off state.
+   * @returns {Promise<Actor>}
+   */
+  async setInteractiveLightData(actor, partial) {
+    const update = {};
+    if (partial.light !== undefined) update["system.emittedLight"] = partial.light;
+    if (partial.active !== undefined) update["system.lightActive"] = !!partial.active;
+    return actor.update(update);
+  }
+
+  /**
+   * Read the carried-light data persisted onto an inventory item's flag payload
+   * (`flags["pick-up-stix"].tokenState.system.emittedLight` / `.lightActive`).
+   * Used by the carried-lights pipeline to decide whether a token should emit
+   * an additional synthetic source for this item.
+   *
+   * The default implementation is system-agnostic — every adapter stores
+   * `tokenState` identically, so no subclass override is needed.
+   *
+   * @param {Item} item
+   * @returns {{ light: object|null, active: boolean }}
+   */
+  getItemCarriedLightData(item) {
+    const sys = item?.flags?.["pick-up-stix"]?.tokenState?.system;
+    return {
+      light: sys?.emittedLight ?? null,
+      active: !!sys?.lightActive
+    };
+  }
+
+  /**
+   * Toggle the carried-light active flag on an inventory item. The change
+   * propagates to the carried-lights pipeline via the `updateItem` hook.
+   * No adapter override is needed — the `tokenState` flag path is uniform
+   * across all systems.
+   *
+   * @param {Item} item
+   * @param {boolean} active
+   * @returns {Promise<Item>}
+   */
+  async setItemCarriedLightActive(item, active) {
+    return item.update({ "flags.pick-up-stix.tokenState.system.lightActive": !!active });
+  }
+
   // === Sheet delegation ======================================================
 
   /**

--- a/scripts/adapter/dnd5e/configSheet.mjs
+++ b/scripts/adapter/dnd5e/configSheet.mjs
@@ -263,11 +263,11 @@ export default class Dnd5eInteractiveItemConfigSheet extends HandlebarsApplicati
   }
 
   /**
-   * Inject Open/Close (containers only), Lock, and Identify toggles into the
-   * config window's own header. Buttons are removed and re-added on every
-   * render so their on/off state stays in sync with `system.isOpen`/`isLocked`/
-   * `isIdentified`. Inserted immediately after `.window-title` so they sit
-   * left of dnd5e/V2's right-aligned system controls (ellipsis, close).
+   * Inject Open/Close (containers only), Lock, Identify, and Light toggles
+   * into the config window's own header. Buttons are removed and re-added on
+   * every render so their on/off state stays in sync with `system.isOpen` /
+   * `isLocked` / `isIdentified` / emittedLight. Inserted immediately after
+   * `.window-title` so they sit left of dnd5e/V2's right-aligned controls.
    */
   #injectHeaderToggles(header) {
     header.querySelectorAll(".ii-config-toggle").forEach(el => el.remove());
@@ -308,6 +308,25 @@ export default class Dnd5eInteractiveItemConfigSheet extends HandlebarsApplicati
       labelOnKey: identCfg.labelOnKey,
       labelOffKey: identCfg.labelOffKey,
       action: "toggleIdentified"
+    }));
+
+    // Light-emission config button — active state reflects whether any radius
+    // is configured (dim > 0 || bright > 0), not the lightActive on/off flag.
+    const emitted = system.emittedLight;
+    const hasLight = (emitted?.dim ?? 0) > 0 || (emitted?.bright ?? 0) > 0;
+    const actor = this.actor;
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-config-toggle",
+      active: hasLight,
+      iconOn: "fa-lightbulb",
+      iconOff: "fa-lightbulb",
+      labelOnKey: "INTERACTIVE_ITEMS.Light.ConfigureActive",
+      labelOffKey: "INTERACTIVE_ITEMS.Light.ConfigureInactive",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        const { default: InteractiveLightConfig } = await import("../../sheets/InteractiveLightConfig.mjs");
+        InteractiveLightConfig.forActor(actor).render({ force: true });
+      }
     }));
 
     const title = header.querySelector(".window-title");

--- a/scripts/adapter/dnd5e/sheets.mjs
+++ b/scripts/adapter/dnd5e/sheets.mjs
@@ -20,7 +20,13 @@ export const Dnd5eSheets = {
   async renderContainerView(actor, options = {}) {
     const item = actor.system.containerItem;
     if (!item) return null;
-    return item.sheet.render({ force: true, ...options });
+    // dnd5e's ItemSheet5e (and therefore ContainerSheet) defaults to
+    // window.resizable=false. Interactive container sheets need to be
+    // resizable so GMs can grow the window to see the full contents
+    // list. Patch the cached sheet instance's options before rendering.
+    const sheet = item.sheet;
+    if (sheet?.options?.window) sheet.options.window.resizable = true;
+    return sheet.render({ force: true, ...options });
   },
 
   /**

--- a/scripts/adapter/generic/configSheet.mjs
+++ b/scripts/adapter/generic/configSheet.mjs
@@ -137,8 +137,8 @@ export default class GenericInteractiveItemConfigSheet
   }
 
   /**
-   * Inject Lock and (containers only) Open/Close toggles into the config
-   * window's own header. Mirrors the dnd5e config sheet's
+   * Inject Lock, (containers only) Open/Close, and Light toggles into the
+   * config window's own header. Mirrors the dnd5e config sheet's
    * `#injectHeaderToggles` but reads state via the adapter so the buttons
    * reflect the flag-backed values rather than `actor.system.*`. Identify
    * is intentionally omitted — generic mode has supportsIdentification:false.
@@ -150,6 +150,7 @@ export default class GenericInteractiveItemConfigSheet
     const isContainer = adapter.isInteractiveContainer(this.actor);
     const isOpen = adapter.isInteractiveOpen(this.actor);
     const isLocked = adapter.isInteractiveLocked(this.actor);
+    const actor = this.actor;
     const buttons = [];
 
     if (isContainer) {
@@ -172,6 +173,23 @@ export default class GenericInteractiveItemConfigSheet
       labelOnKey: "INTERACTIVE_ITEMS.Sheet.StateLocked",
       labelOffKey: "INTERACTIVE_ITEMS.Sheet.StateUnlocked",
       action: "toggleLock"
+    }));
+
+    // Light-emission config button — active state reflects configured radius.
+    const { light } = adapter.getInteractiveLightData(actor);
+    const hasLight = (light?.dim ?? 0) > 0 || (light?.bright ?? 0) > 0;
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-config-toggle",
+      active: hasLight,
+      iconOn: "fa-lightbulb",
+      iconOff: "fa-lightbulb",
+      labelOnKey: "INTERACTIVE_ITEMS.Light.ConfigureActive",
+      labelOffKey: "INTERACTIVE_ITEMS.Light.ConfigureInactive",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        const { default: InteractiveLightConfig } = await import("../../sheets/InteractiveLightConfig.mjs");
+        InteractiveLightConfig.forActor(actor).render({ force: true });
+      }
     }));
 
     const title = header.querySelector(".window-title");

--- a/scripts/adapter/generic/containerView.mjs
+++ b/scripts/adapter/generic/containerView.mjs
@@ -118,10 +118,20 @@ export default class GenericInteractiveContainerView
     // template doesn't correspond to anything in the world.
     context.isTokenActor = !!this.actor.token;
 
-    context.contents = (data.contents ?? []).map(c => ({
-      ...c,
-      showQuantity: (c.quantity ?? 1) > 1
-    }));
+    context.contents = (data.contents ?? []).map(c => {
+      // A content row has configured light when its own `emittedLight` record
+      // has a non-zero radius. Phase 4 deposits don't include light data yet
+      // (that arrives in Phase 6), so this will be false for all existing rows
+      // until a future phase writes emittedLight into the deposit payload.
+      const emitted = c.emittedLight;
+      const lightConfigured = !!emitted && ((emitted.dim ?? 0) > 0 || (emitted.bright ?? 0) > 0);
+      return {
+        ...c,
+        showQuantity: (c.quantity ?? 1) > 1,
+        lightConfigured,
+        lightActive: !!c.lightActive
+      };
+    });
 
     // Contents-visibility gate — same logic as the dnd5e/pf2e contents-hide
     // decorators, but evaluated inline since this sheet owns its own rendering.
@@ -184,12 +194,19 @@ export default class GenericInteractiveContainerView
     this.element.querySelectorAll(".ii-pickup-btn").forEach(btn => {
       btn.addEventListener("click", (event) => this.#onPickupClick(event, btn));
     });
+
+    // Wire lightbulb toggle buttons on content rows that have a configured
+    // emission. These only appear when the row's `lightConfigured` flag is true
+    // (set in _prepareContext from the row's own `emittedLight` data).
+    this.element.querySelectorAll(".ii-light-toggle-row").forEach(btn => {
+      btn.addEventListener("click", (event) => this.#onLightToggleClick(event, btn));
+    });
   }
 
   /**
-   * Inject Open/Close + Lock + Configure window-header toggles. Matches the
-   * dnd5e/pf2e shared decorator's order. Identify is intentionally omitted
-   * (generic mode has supportsIdentification:false).
+   * Inject Open/Close + Lock + Light + Configure window-header toggles.
+   * Matches the dnd5e/pf2e shared decorator's order. Identify is
+   * intentionally omitted (generic mode has supportsIdentification:false).
    */
   #injectHeaderToggles(header) {
     header.querySelectorAll(".ii-containerview-toggle").forEach(el => el.remove());
@@ -223,6 +240,23 @@ export default class GenericInteractiveContainerView
       onClick: (ev) => {
         ev.preventDefault();
         toggleContainerLocked(actor);
+      }
+    }));
+
+    // Light-emission config button — active state reflects configured radius.
+    const { light } = adapter.getInteractiveLightData(actor);
+    const hasLight = (light?.dim ?? 0) > 0 || (light?.bright ?? 0) > 0;
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-containerview-toggle",
+      active: hasLight,
+      iconOn: "fa-lightbulb",
+      iconOff: "fa-lightbulb",
+      labelOnKey: "INTERACTIVE_ITEMS.Light.ConfigureActive",
+      labelOffKey: "INTERACTIVE_ITEMS.Light.ConfigureInactive",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        const { default: InteractiveLightConfig } = await import("../../sheets/InteractiveLightConfig.mjs");
+        InteractiveLightConfig.forActor(actor).render({ force: true });
       }
     }));
 
@@ -474,6 +508,40 @@ export default class GenericInteractiveContainerView
       { sceneId, tokenId, itemId: null, targetActorId: targetActor.id, quantity: chosenQty, contentId },
       async () => pickupItem(sceneId, tokenId, null, targetActor.id, chosenQty, contentId)
     );
+  }
+
+  /**
+   * Toggle the `lightActive` flag on the content row identified by
+   * `data-content-id`. Permitted for GMs and owners of the actor. The row's
+   * `emittedLight` and `lightActive` fields live directly on the content record
+   * in the flag blob (not on an Item document), so we toggle them by rewriting
+   * the `contents` array via `adapter.setInteractiveData`.
+   *
+   * @param {MouseEvent} event
+   * @param {HTMLElement} btn - Button carrying `data-content-id`.
+   */
+  async #onLightToggleClick(event, btn) {
+    event.preventDefault();
+    event.stopPropagation();
+    const allowed = game.user.isGM || this.actor?.isOwner;
+    if (!allowed) return;
+    const contentId = btn?.dataset?.contentId;
+    if (!contentId) return;
+    const adapter = getAdapter();
+    const data = adapter.getInteractiveData(this.actor);
+    const rowIndex = (data.contents ?? []).findIndex(c => c.id === contentId);
+    if (rowIndex < 0) {
+      dbg("generic-container-view:onLightToggleClick", "content row not found", { contentId });
+      return;
+    }
+    const row = data.contents[rowIndex];
+    const next = !row.lightActive;
+    dbg("generic-container-view:onLightToggleClick", { contentId, from: row.lightActive, to: next });
+    const newContents = data.contents.map((c, i) =>
+      i === rowIndex ? { ...c, lightActive: next } : c
+    );
+    await adapter.setInteractiveData(this.actor, { contents: newContents });
+    this.render();
   }
 
   /**

--- a/scripts/adapter/generic/data.mjs
+++ b/scripts/adapter/generic/data.mjs
@@ -23,7 +23,15 @@ export function makeDefaultInteractiveData() {
     interactionRange: 1,
     inspectionRange: 4,
     itemData: null,   // mode="item":      {name, img, description, quantity}
-    contents: []      // mode="container": Array<{id, name, img, description, quantity}>
+    contents: [],     // mode="container": Array<{id, name, img, description, quantity}>
+    /** LightData-shaped object for this actor's configured emission; null = unconfigured. */
+    emittedLight: null,
+    /**
+     * Whether the configured light emission is currently active. Default true
+     * so newly-configured items start emitting immediately; players toggle
+     * via the row lightbulb in inventories / container contents.
+     */
+    lightActive: true
   };
 }
 
@@ -148,5 +156,31 @@ export const GenericData = {
   /** Read openImage from the flag blob — actor.system has no such field on generic. */
   getInteractiveOpenImage(actor) {
     return this.getInteractiveData(actor).openImage ?? null;
+  },
+
+  /**
+   * Read light emission config from the flag blob.
+   * Falls back to an empty object (no emission) when not yet configured.
+   *
+   * @param {Actor} actor
+   * @returns {{ light: object, active: boolean }}
+   */
+  getInteractiveLightData(actor) {
+    const data = this.getInteractiveData(actor);
+    return { light: data.emittedLight ?? {}, active: !!data.lightActive };
+  },
+
+  /**
+   * Persist partial light-emission data into the flag blob.
+   *
+   * @param {Actor} actor
+   * @param {{ light?: object, active?: boolean }} partial
+   * @returns {Promise<Actor>}
+   */
+  async setInteractiveLightData(actor, partial) {
+    const patch = {};
+    if (partial.light !== undefined) patch.emittedLight = partial.light;
+    if (partial.active !== undefined) patch.lightActive = !!partial.active;
+    return this.setInteractiveData(actor, patch);
   }
 };

--- a/scripts/adapter/generic/hooks.mjs
+++ b/scripts/adapter/generic/hooks.mjs
@@ -16,8 +16,16 @@ export const GenericHooks = {
   registerContainerViewHooks(_handlers) {
     dbg("generic-hooks:registerContainerViewHooks", "no-op — generic mode uses its own container view sheet");
   },
-  registerActorInventoryHooks(_callback) {
-    dbg("generic-hooks:registerActorInventoryHooks", "no-op — identify UI is hidden in generic mode");
+  registerActorInventoryHooks(callback) {
+    // Subscribe to the base Foundry render hook so PC/NPC inventories on
+    // unknown systems get decorated when their markup happens to expose
+    // [data-item-id] rows (the heuristic used by the shared row decorator).
+    // Identify controls are still suppressed by supportsIdentification:false
+    // inside the callback; what the callback DOES inject in generic mode is
+    // the light-toggle row icon for items carrying a non-zero light radius.
+    // Graceful no-op when the active system's sheet uses different markup.
+    dbg("generic-hooks:registerActorInventoryHooks", "subscribing to renderActorSheet for light-row decoration");
+    Hooks.on("renderActorSheet", callback);
   },
   registerContainerDropGate(_callback) {
     dbg("generic-hooks:registerContainerDropGate", "no-op — generic container sheet handles its own drops");

--- a/scripts/adapter/generic/itemView.mjs
+++ b/scripts/adapter/generic/itemView.mjs
@@ -118,6 +118,11 @@ export default class GenericInteractiveItemView
     if (header) this.#injectHeaderToggles(header);
   }
 
+  /**
+   * Inject Lock, Light, and Configure toggles into the GM-only window header.
+   * Open/Close is omitted (items have no open state). Identify is omitted —
+   * generic mode has supportsIdentification:false.
+   */
   #injectHeaderToggles(header) {
     header.querySelectorAll(".ii-itemview-toggle").forEach(el => el.remove());
 
@@ -136,6 +141,23 @@ export default class GenericInteractiveItemView
       onClick: (ev) => {
         ev.preventDefault();
         toggleContainerLocked(actor);
+      }
+    }));
+
+    // Light-emission config button — active state reflects configured radius.
+    const { light } = adapter.getInteractiveLightData(actor);
+    const hasLight = (light?.dim ?? 0) > 0 || (light?.bright ?? 0) > 0;
+    buttons.push(createStateToggleButton({
+      extraClass: "ii-itemview-toggle",
+      active: hasLight,
+      iconOn: "fa-lightbulb",
+      iconOff: "fa-lightbulb",
+      labelOnKey: "INTERACTIVE_ITEMS.Light.ConfigureActive",
+      labelOffKey: "INTERACTIVE_ITEMS.Light.ConfigureInactive",
+      onClick: async (ev) => {
+        ev.preventDefault();
+        const { default: InteractiveLightConfig } = await import("../../sheets/InteractiveLightConfig.mjs");
+        InteractiveLightConfig.forActor(actor).render({ force: true });
       }
     }));
 

--- a/scripts/adapter/pf2e/configSheet.mjs
+++ b/scripts/adapter/pf2e/configSheet.mjs
@@ -229,6 +229,17 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
     const icon = system.isIdentified ? identCfg.iconOn : identCfg.iconOff;
     const labelKey = system.isIdentified ? identCfg.labelOnKey : identCfg.labelOffKey;
     updateToggle(".ii-toggle-identify", `${family} ${icon}`, game.i18n.localize(labelKey));
+
+    // Light toggle — icon is always fa-lightbulb; tooltip reflects configured state.
+    const emitted = system.emittedLight;
+    const hasLight = (emitted?.dim ?? 0) > 0 || (emitted?.bright ?? 0) > 0;
+    updateToggle(
+      ".ii-toggle-light",
+      "fas fa-lightbulb",
+      game.i18n.localize(hasLight
+        ? "INTERACTIVE_ITEMS.Light.ConfigureActive"
+        : "INTERACTIVE_ITEMS.Light.ConfigureInactive")
+    );
   }
 
   /**
@@ -252,6 +263,26 @@ export default class Pf2eInteractiveItemConfigSheet extends foundry.appv1.sheets
     if (!this.isEditable) return buttons;
 
     const system = this.actor.system;
+
+    // Light (will end up at position 3 — between identify and system buttons).
+    // The unshift order is reversed relative to the desired final order:
+    //   unshift light → unshift identify → unshift lock → unshift open (if container)
+    //   final: [open?, lock, identify, light, ...super]
+    const emitted = system.emittedLight;
+    const hasLight = (emitted?.dim ?? 0) > 0 || (emitted?.bright ?? 0) > 0;
+    const actor = this.actor;
+    buttons.unshift({
+      label: "",
+      tooltip: game.i18n.localize(hasLight
+        ? "INTERACTIVE_ITEMS.Light.ConfigureActive"
+        : "INTERACTIVE_ITEMS.Light.ConfigureInactive"),
+      class: "ii-toggle-light",
+      icon: "fas fa-lightbulb",
+      onclick: async () => {
+        const { default: InteractiveLightConfig } = await import("../../sheets/InteractiveLightConfig.mjs");
+        InteractiveLightConfig.forActor(actor).render({ force: true });
+      }
+    });
 
     // Identify (will end up at position 2 — third from left)
     const identCfg = getAdapter().getIdentifyButtonConfig(system.isIdentified);

--- a/scripts/canvas/carriedLights.mjs
+++ b/scripts/canvas/carriedLights.mjs
@@ -1,0 +1,416 @@
+/**
+ * Carried-light synthetic source manager.
+ *
+ * When an inventory item carries an active light configuration (its
+ * `flags["pick-up-stix"].tokenState.system.lightActive` is true and the snapshot
+ * has a non-zero dim/bright radius), this module registers a per-(token, item)
+ * `PointLightSource` into `canvas.effects.lightSources` with a custom sourceId
+ * (`pus-light:<tokenId>:<itemId>`). The source coexists with the token's own
+ * `Token.<id>` source so the token visually emits BOTH lights — the player's own
+ * vision/light AND the carried item's emission.
+ *
+ * The manager rebuilds sources in response to:
+ *   - canvasReady — initial pass over every placeable.
+ *   - drawToken (mid-session token adds) — initial pass for that token.
+ *   - updateToken (x/y/elevation/level changes) — re-position carried sources.
+ *   - deleteToken — destroy all sources for that token.
+ *   - createItem/updateItem/deleteItem on the token's actor — re-evaluate
+ *     which items contribute and toggle their sources.
+ *   - updateActor on an interactive container token (isOpen flip) — enable /
+ *     disable contents-driven emission.
+ *   - updateActor on a generic actor (flags.pick-up-stix.interactive change) —
+ *     re-evaluate contents-driven emission when the contents array mutates.
+ *
+ * For interactive container tokens, sources are only created when the container
+ * is OPEN; closing the container destroys all contents-driven sources.
+ */
+
+import { isInteractiveActor, isInteractiveContainer } from "../utils/actorHelpers.mjs";
+import { getAdapter } from "../adapter/index.mjs";
+import { dbg } from "../utils/debugLog.mjs";
+
+/** sourceId prefix to keep our synthetic sources distinguishable from Foundry's. */
+const PREFIX = "pus-light";
+
+/**
+ * Build the canonical sourceId for a given (token, item) pair.
+ *
+ * @param {string} tokenId
+ * @param {string} itemId
+ * @returns {string}
+ */
+function makeSourceId(tokenId, itemId) {
+  return `${PREFIX}:${tokenId}:${itemId}`;
+}
+
+/**
+ * Return every item (or item-like record) on the actor whose carried-light
+ * snapshot is currently active and has a non-zero radius.
+ *
+ * For interactive container tokens (generic mode), the container's contents
+ * live in its flag blob as plain objects rather than Item documents. This
+ * function wraps those records into a minimal item-like shape so the rest of
+ * the pipeline can treat them uniformly.
+ *
+ * For model-backed actors (dnd5e / pf2e), items are real Item documents and
+ * `adapter.getItemCarriedLightData(item)` reads from the standard tokenState
+ * flag payload.
+ *
+ * @param {Actor} actor
+ * @returns {Array<Item|{id: string, flags: object}>}
+ */
+function getEmittingItems(actor) {
+  if (!actor) return [];
+  const adapter = getAdapter();
+
+  // Generic interactive containers store their contents in the flag blob.
+  // Each content row has its own emittedLight / lightActive fields (written
+  // by the deposit paths in placement.mjs and ItemTransfer.mjs).
+  if (adapter.constructor.SYSTEM_ID === "generic" && isInteractiveContainer(actor)) {
+    const data = adapter.getInteractiveData(actor);
+    return (data.contents ?? []).filter(c =>
+      c?.lightActive
+      && c?.emittedLight
+      && ((c.emittedLight.dim ?? 0) > 0 || (c.emittedLight.bright ?? 0) > 0)
+    ).map(c => ({
+      id: c.id,
+      // Wrap content data into the tokenState flag shape that buildSourceData and
+      // the adapter's getItemCarriedLightData both read from.
+      flags: {
+        "pick-up-stix": {
+          tokenState: {
+            system: {
+              emittedLight: c.emittedLight,
+              lightActive: true
+            }
+          }
+        }
+      }
+    }));
+  }
+
+  // Model-backed actors: items are real documents with flag payloads.
+  return (actor.items?.contents ?? []).filter(item => {
+    const { light, active } = adapter.getItemCarriedLightData(item);
+    if (!active || !light) return false;
+    if ((light.dim ?? 0) <= 0 && (light.bright ?? 0) <= 0) return false;
+    return true;
+  });
+}
+
+/**
+ * Build the data payload the PointLightSource consumes. Mirrors the shape
+ * `Token#_getLightSourceData()` constructs: the LightData fields, plus an
+ * origin (x, y, elevation) derived from the carrier token's position.
+ *
+ * The light field values come from the item's carried-light snapshot rather
+ * than the carrier's own `tokenDoc.light`, so the carrier's own light is
+ * completely unaffected.
+ *
+ * @param {Token} tokenObj  The carrier token placeable.
+ * @param {{id: string, flags: object}|Item} item  Item or item-like record.
+ * @returns {object}
+ */
+function buildSourceData(tokenObj, item) {
+  const adapter = getAdapter();
+  const { light } = adapter.getItemCarriedLightData(item);
+  // Fallback: read directly from the wrapped flag shape (used by the generic
+  // container path whose item-like objects have that shape set explicitly).
+  const lightData = light ?? item.flags?.["pick-up-stix"]?.tokenState?.system?.emittedLight ?? {};
+
+  const tokenDoc = tokenObj.document;
+  // getLightOrigin() exists on v14 (elevation-aware); v13 tokens lack it.
+  // Fall back to the explicit center/elevation pair that v13 uses. Note that
+  // `tokenObj.center` reads through `document.getCenterPoint()` which Foundry
+  // interpolates per-frame during animation — so this expression yields the
+  // live animated position when called from refreshToken, and the destination
+  // when called from updateToken/drawToken.
+  const origin = tokenDoc.getLightOrigin?.() ?? {
+    x: tokenObj.center.x,
+    y: tokenObj.center.y,
+    elevation: tokenDoc.elevation ?? 0
+  };
+
+  // Scale grid-unit radii to pixels. `Token#getLightRadius(units)` is what
+  // Foundry's own token-light pipeline uses internally — passing raw grid
+  // values straight to a PointLightSource yields a malformed source that
+  // doesn't emit (only a tiny indicator renders).
+  const dimPx = tokenObj.getLightRadius(lightData.dim ?? 0);
+  const brightPx = tokenObj.getLightRadius(lightData.bright ?? 0);
+
+  return {
+    ...lightData,
+    x: origin.x,
+    y: origin.y,
+    elevation: origin.elevation,
+    level: tokenDoc.level,
+    rotation: tokenDoc.rotation ?? 0,
+    dim: dimPx,
+    bright: brightPx,
+    externalRadius: tokenObj.externalRadius ?? 0,
+    seed: tokenDoc.getFlag?.("core", "animationSeed") ?? 0,
+    preview: false,
+    disabled: false
+  };
+}
+
+/**
+ * Ensure a synthetic PointLightSource exists (or is refreshed) for one
+ * (token, item) pair. Creates the source on first call; on subsequent calls
+ * re-initializes it in-place (cheap data swap, no shader rebuild) and
+ * re-registers it via `add()`.
+ *
+ * @param {Token} tokenObj
+ * @param {{id: string, flags: object}|Item} item
+ * @returns {PointLightSource}
+ */
+function ensureSource(tokenObj, item) {
+  const sourceId = makeSourceId(tokenObj.id, item.id);
+  const SourceCls = CONFIG.Canvas.lightSourceClass;
+  let source = canvas.effects.lightSources.get(sourceId);
+  if (!source) {
+    source = new SourceCls({ sourceId, object: tokenObj });
+    dbg("carriedLights:create", { sourceId, tokenId: tokenObj.id, itemId: item.id });
+  }
+  source.initialize(buildSourceData(tokenObj, item));
+  source.add();
+  return source;
+}
+
+/**
+ * Destroy the synthetic source for a (token, item) pair if one exists. This
+ * removes the source from `canvas.effects.lightSources` and tears down its
+ * internal state.
+ *
+ * @param {string} tokenId
+ * @param {string} itemId
+ */
+function destroySource(tokenId, itemId) {
+  const sourceId = makeSourceId(tokenId, itemId);
+  const source = canvas.effects.lightSources.get(sourceId);
+  if (!source) return;
+  dbg("carriedLights:destroy", { sourceId });
+  source.destroy();
+}
+
+/**
+ * Reconcile every carried-light source for `tokenObj` with the actor's current
+ * inventory (or flag-blob contents for generic containers). Adds missing
+ * sources, re-initializes existing ones with current position data, and
+ * destroys those whose item is no longer present or no longer active.
+ *
+ * For interactive container tokens, sources are only created when the
+ * container is open; closing the container causes all contents-driven sources
+ * to be destroyed.
+ *
+ * Skips silently when the canvas lighting pipeline is not available (scene
+ * swaps, teardown).
+ *
+ * @param {Token} tokenObj  The carrier token placeable.
+ */
+export function syncTokenCarriedLights(tokenObj) {
+  if (!canvas?.effects?.lightSources) return;
+
+  const actor = tokenObj.actor;
+  if (!actor) {
+    dbg("carriedLights:sync", "no actor on token, skip", { tokenId: tokenObj.id });
+    return;
+  }
+
+  const isContainer = isInteractiveContainer(actor);
+  const containerOpen = isContainer ? getAdapter().isInteractiveOpen(actor) : true;
+
+  dbg("carriedLights:sync", {
+    tokenId: tokenObj.id,
+    actorName: actor.name,
+    isContainer,
+    containerOpen
+  });
+
+  // Container items only emit while the container is open.
+  const desired = (isContainer && !containerOpen) ? [] : getEmittingItems(actor);
+  const desiredIds = new Set(desired.map(i => i.id));
+
+  // Destroy stale sources keyed under this token that are no longer in the
+  // desired set (item removed, toggled off, or container closed).
+  const prefix = `${PREFIX}:${tokenObj.id}:`;
+  for (const [sid] of canvas.effects.lightSources.entries()) {
+    if (!sid.startsWith(prefix)) continue;
+    const itemId = sid.slice(prefix.length);
+    if (!desiredIds.has(itemId)) {
+      dbg("carriedLights:sync", "destroying stale source", { sid });
+      destroySource(tokenObj.id, itemId);
+    }
+  }
+
+  // Create / refresh sources for the desired set.
+  for (const item of desired) ensureSource(tokenObj, item);
+
+  // Trigger a perception re-composite whenever any source changed.
+  if (desired.length > 0 || [...canvas.effects.lightSources.keys()].some(k => k.startsWith(prefix))) {
+    canvas.perception.update({ refreshLighting: true, refreshVision: true });
+  }
+}
+
+/**
+ * Cheap per-frame position refresh used during token animation. Re-initializes
+ * existing synthetic sources for this token with the current animated position
+ * without re-evaluating the inventory or destroying/recreating anything.
+ *
+ * Called from the `refreshToken` hook on `refreshPosition` flags so the carried
+ * light tracks the token's PIXI animation smoothly instead of snapping to the
+ * destination on commit and staying there.
+ *
+ * @param {Token} tokenObj
+ */
+function refreshCarriedLightPositions(tokenObj) {
+  if (!canvas?.effects?.lightSources) return;
+  const prefix = `${PREFIX}:${tokenObj.id}:`;
+  let any = false;
+  for (const [sid, source] of canvas.effects.lightSources.entries()) {
+    if (!sid.startsWith(prefix)) continue;
+    const itemId = sid.slice(prefix.length);
+    // Reconstruct the item-like wrapper from the actor so getEmittingItems
+    // ordering / wrapping doesn't matter — we just need the carried-light data.
+    const actor = tokenObj.actor;
+    if (!actor) continue;
+    let item = actor.items?.get?.(itemId);
+    if (!item) {
+      // Generic container content row — pull from flag blob.
+      const data = getAdapter().getInteractiveData(actor);
+      const row = (data.contents ?? []).find(c => c.id === itemId);
+      if (!row) continue;
+      item = {
+        id: itemId,
+        flags: { "pick-up-stix": { tokenState: { system: { emittedLight: row.emittedLight, lightActive: true } } } }
+      };
+    }
+    source.initialize(buildSourceData(tokenObj, item));
+    any = true;
+  }
+  if (any) canvas.perception.update({ refreshLighting: true, refreshVision: true });
+}
+
+/**
+ * Destroy every synthetic source associated with `tokenId`. Called when a
+ * token is deleted so no orphaned sources remain in the scene's light pipeline.
+ *
+ * @param {string} tokenId
+ */
+export function destroyTokenCarriedLights(tokenId) {
+  if (!canvas?.effects?.lightSources) return;
+
+  const prefix = `${PREFIX}:${tokenId}:`;
+  const toDestroy = [];
+  for (const [sid] of canvas.effects.lightSources.entries()) {
+    if (sid.startsWith(prefix)) toDestroy.push(sid.slice(prefix.length));
+  }
+
+  if (!toDestroy.length) return;
+
+  dbg("carriedLights:destroyAll", { tokenId, count: toDestroy.length });
+  for (const itemId of toDestroy) destroySource(tokenId, itemId);
+  canvas.perception.update({ refreshLighting: true, refreshVision: true });
+}
+
+/**
+ * Wire all lifecycle hooks that drive carried-light source management. Called
+ * once from `pick-up-stix.mjs` init after `registerQtyBadge()`.
+ */
+export function registerCarriedLights() {
+
+  // Full re-pass after every scene draw. Covers scene switches and initial load.
+  Hooks.on("canvasReady", () => {
+    if (!canvas?.effects?.lightSources) return;
+    dbg("carriedLights:canvasReady", "syncing all token carried lights");
+    for (const t of canvas.tokens?.placeables ?? []) syncTokenCarriedLights(t);
+  });
+
+  // Mid-session token additions — run initial sync for the new placeable.
+  Hooks.on("drawToken", (token) => {
+    if (!canvas?.effects?.lightSources) return;
+    dbg("carriedLights:drawToken", { tokenId: token.id });
+    syncTokenCarriedLights(token);
+  });
+
+  // Movement / elevation changes — re-initialize every carried source on
+  // this token so the light origin tracks the token's new position. This
+  // fires once at update commit; the per-frame interpolation is handled by
+  // the refreshToken hook below.
+  Hooks.on("updateToken", (tokenDoc, changes) => {
+    if (!canvas?.effects?.lightSources) return;
+    if (!("x" in changes) && !("y" in changes) && !("elevation" in changes) && !("level" in changes)) return;
+    const obj = canvas.tokens?.get(tokenDoc.id);
+    if (!obj) return;
+    dbg("carriedLights:updateToken", { tokenId: tokenDoc.id, movedKeys: Object.keys(changes).filter(k => ["x","y","elevation","level"].includes(k)) });
+    syncTokenCarriedLights(obj);
+  });
+
+  // Per-frame position refresh during animation. Foundry's _onAnimationUpdate
+  // sets refreshPosition on every animated frame; without this hook our
+  // synthetic sources would snap to the destination at update-commit and stay
+  // there while the token visual animates over to it.
+  Hooks.on("refreshToken", (token, flags) => {
+    if (!flags?.refreshPosition && !flags?.refreshElevation) return;
+    refreshCarriedLightPositions(token);
+  });
+
+  // Token removal — destroy all synthetic sources for it.
+  Hooks.on("deleteToken", (tokenDoc) => {
+    dbg("carriedLights:deleteToken", { tokenId: tokenDoc.id });
+    destroyTokenCarriedLights(tokenDoc.id);
+  });
+
+  // Inventory mutations — re-evaluate which items on this actor emit light.
+  const onItemChange = (item) => {
+    const actor = item?.parent;
+    if (!actor) return;
+    if (!canvas?.effects?.lightSources) return;
+    const tokens = canvas.tokens?.placeables.filter(
+      t => t.actor?.id === actor.id || t.actor?.uuid === actor.uuid
+    ) ?? [];
+    dbg("carriedLights:itemChange", { actorName: actor.name, tokenCount: tokens.length });
+    for (const t of tokens) syncTokenCarriedLights(t);
+  };
+
+  Hooks.on("createItem", onItemChange);
+
+  Hooks.on("updateItem", (item, changes) => {
+    // Fast-path: only re-sync when light-relevant fields changed.
+    const lightActiveChanged = foundry.utils.hasProperty(changes ?? {}, "flags.pick-up-stix.tokenState.system.lightActive");
+    const emittedLightChanged = foundry.utils.hasProperty(changes ?? {}, "flags.pick-up-stix.tokenState.system.emittedLight");
+    if (!lightActiveChanged && !emittedLightChanged) return;
+    dbg("carriedLights:updateItem", { itemId: item.id, lightActiveChanged, emittedLightChanged });
+    onItemChange(item);
+  });
+
+  Hooks.on("deleteItem", onItemChange);
+
+  // Container open/close gate — re-sync when the open state flips.
+  // Also re-syncs generic containers when the contents array mutates
+  // (new deposit / row removal changes which items should emit).
+  Hooks.on("updateActor", (actor, changes) => {
+    if (!canvas?.effects?.lightSources) return;
+    if (!isInteractiveActor(actor)) return;
+
+    // Model-backed container: isOpen lives at system.isOpen.
+    const modelIsOpenChanged = foundry.utils.hasProperty(changes, "system.isOpen");
+    // Generic container: isOpen lives inside the flag blob.
+    const genericFlagChanged = foundry.utils.hasProperty(changes, "flags.pick-up-stix.interactive");
+
+    if (!modelIsOpenChanged && !genericFlagChanged) return;
+
+    // Only re-sync interactive container tokens; player tokens pick up items
+    // whose light is driven by updateItem hooks above, not by updateActor.
+    if (!isInteractiveContainer(actor)) return;
+
+    const tokens = canvas.tokens?.placeables.filter(t => t.actor?.id === actor.id) ?? [];
+    dbg("carriedLights:updateActor", {
+      actorName: actor.name,
+      modelIsOpenChanged,
+      genericFlagChanged,
+      tokenCount: tokens.length
+    });
+    for (const t of tokens) syncTokenCarriedLights(t);
+  });
+}

--- a/scripts/canvas/placement.mjs
+++ b/scripts/canvas/placement.mjs
@@ -204,6 +204,16 @@ async function _createGenericInteractiveActor(item, img, moveQty, ephemeral) {
     ?? item.system?.description
     ?? "";
 
+  // Re-placement round-trip: when an item carrying a tokenState snapshot is
+  // dropped back to the canvas (PC inventory drag-out or container row drag),
+  // pull the snapshotted light data into the new actor's flag blob so the
+  // preCreateToken hook can bake it back into tokenDoc.light. Without this,
+  // light configuration is lost on the generic path because the new actor's
+  // flags would start blank.
+  const snapshotSys = item.flags?.["pick-up-stix"]?.tokenState?.system;
+  const snapshotEmittedLight = snapshotSys?.emittedLight ?? null;
+  const snapshotLightActive = snapshotSys?.lightActive;
+
   const interactiveData = {
     mode: "item",
     name: item.name,
@@ -214,7 +224,9 @@ async function _createGenericInteractiveActor(item, img, moveQty, ephemeral) {
       img,
       description,
       quantity: moveQty
-    }
+    },
+    emittedLight: snapshotEmittedLight,
+    lightActive: snapshotLightActive ?? true
   };
 
   // Honor the configured template-vs-ephemeral folder split so generic
@@ -607,9 +619,19 @@ async function depositActorToTarget(droppedActor, targetToken) {
 
     if (targetIsInteractiveContainer) {
       // Generic container target: append a content row to its flag blob.
-      const row = { id: foundry.utils.randomID(), name, img, description, quantity };
+      // Carry the source actor's emittedLight/lightActive into the row so the
+      // carried-lights pipeline and the row lightbulb toggle read the right values.
+      const row = {
+        id: foundry.utils.randomID(),
+        name,
+        img,
+        description,
+        quantity,
+        emittedLight: droppedData.emittedLight ?? null,
+        lightActive: !!droppedData.lightActive
+      };
       const current = adapter.getInteractiveData(targetActor);
-      dbg("place:depositActorToTarget", "generic→generic-container: appending content row", { rowName: name });
+      dbg("place:depositActorToTarget", "generic→generic-container: appending content row", { rowName: name, lightActive: row.lightActive });
       await adapter.setInteractiveData(targetActor, {
         contents: [...(current.contents ?? []), row]
       });
@@ -682,9 +704,19 @@ async function depositCanvasTokenToTarget(tokenDoc, targetToken, { quantity = nu
     const isPartial = moveQty < flagQty;
 
     if (targetIsInteractiveContainer) {
-      const row = { id: foundry.utils.randomID(), name, img, description, quantity: moveQty };
+      // Carry the source actor's emittedLight/lightActive into the row so the
+      // carried-lights pipeline and the row lightbulb toggle read the right values.
+      const row = {
+        id: foundry.utils.randomID(),
+        name,
+        img,
+        description,
+        quantity: moveQty,
+        emittedLight: sourceData.emittedLight ?? null,
+        lightActive: !!sourceData.lightActive
+      };
       const current = adapter.getInteractiveData(targetActor);
-      dbg("place:depositCanvasTokenToTarget", "generic→generic-container: appending content row", { rowName: name, qty: moveQty });
+      dbg("place:depositCanvasTokenToTarget", "generic→generic-container: appending content row", { rowName: name, qty: moveQty, lightActive: row.lightActive });
       await adapter.setInteractiveData(targetActor, {
         contents: [...(current.contents ?? []), row]
       });

--- a/scripts/hud/InteractiveTokenHUD.mjs
+++ b/scripts/hud/InteractiveTokenHUD.mjs
@@ -369,6 +369,33 @@ function onRenderTokenHUD(app, html, context, options) {
     col.appendChild(identifyBtn);
   }
 
+  // GM-only light toggle. Visible only when the actor has a non-zero radius
+  // configured — turning a light "on" with no radii would do nothing visible,
+  // and the GM can always configure radii via the lightbulb header button on
+  // any of the actor's sheets. Active state mirrors `lightActive`; click
+  // flips it via the adapter, which propagates to the canvas via the Phase 5
+  // updateActor → _syncPlacedTokensLight pipeline.
+  if (isGM) {
+    const lightAdapter = getAdapter();
+    const { light: emittedLight, active: lightActive } = lightAdapter.getInteractiveLightData(actor);
+    const hasRadii = !!emittedLight
+      && ((emittedLight.dim ?? 0) > 0 || (emittedLight.bright ?? 0) > 0);
+    if (hasRadii) {
+      const lightBtn = createHUDButton(
+        "fa-lightbulb",
+        game.i18n.localize(lightActive
+          ? "INTERACTIVE_ITEMS.Light.ToggleOff"
+          : "INTERACTIVE_ITEMS.Light.ToggleOn"),
+        async () => {
+          dbg("hud:lightToggle", { actorName: actor.name, from: lightActive, to: !lightActive });
+          await lightAdapter.setInteractiveLightData(actor, { active: !lightActive });
+        }
+      );
+      if (lightActive) lightBtn.classList.add("ii-hud-active");
+      col.appendChild(lightBtn);
+    }
+  }
+
   if (isGM) {
     const configBtn = createHUDButton(
       "fa-gear",

--- a/scripts/models/InteractiveItemModel.mjs
+++ b/scripts/models/InteractiveItemModel.mjs
@@ -50,7 +50,20 @@ export default class InteractiveItemModel extends InteractiveModelMixin(TypeData
       unidentifiedName: new fields.StringField({ required: false, initial: "" }),
       unidentifiedDescription: new fields.HTMLField({ required: false, initial: "" }),
       limitedName: new fields.StringField({ required: false, initial: "" }),
-      limitedDescription: new fields.HTMLField({ required: false, initial: "" })
+      limitedDescription: new fields.HTMLField({ required: false, initial: "" }),
+      /**
+       * Full Foundry LightData configuration for this interactive item's
+       * emission. Defaults to a zeroed-out, non-emitting light so existing
+       * worlds that pre-date this field deserialise safely as "no light".
+       */
+      emittedLight: new fields.EmbeddedDataField(foundry.data.LightData),
+      /**
+       * Whether the configured light emission is currently active. Default true
+       * so that newly-configured items (radii set via InteractiveLightConfig)
+       * start emitting immediately without requiring a separate row-icon click.
+       * Players still toggle this via the row lightbulb in inventories.
+       */
+      lightActive: new fields.BooleanField({ initial: true })
     };
   }
 

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -4,6 +4,7 @@ import InteractiveItemSheet from "./sheets/InteractiveItemSheet.mjs";
 import { registerTokenHUD } from "./hud/InteractiveTokenHUD.mjs";
 import { registerPlacement, _handleTokenMoveWithOverlap } from "./canvas/placement.mjs";
 import { registerQtyBadge } from "./canvas/qtyBadge.mjs";
+import { registerCarriedLights } from "./canvas/carriedLights.mjs";
 import { registerSocket } from "./socket/SocketHandler.mjs";
 import { pickupItem, depositItem, setPlayerPositionOverride, toggleItemIdentification, buildInteractiveItemData, checkProximity, assignContainerParent, setContainerOpen, toggleContainerLocked, getPlayerCandidateTokens } from "./transfer/ItemTransfer.mjs";
 import { INTERACTIVE_TYPES } from "./constants.mjs";
@@ -341,6 +342,7 @@ Hooks.once("init", async () => {
   registerTokenHUD();
   registerPlacement();
   registerQtyBadge();
+  registerCarriedLights();
 });
 
 /**
@@ -390,20 +392,68 @@ function _injectItemContextMenuEntries(item, menuItems) {
 }
 
 /**
- * Injects GM-only row controls (lock, identify, delete) into each inventory
- * row of a non-interactive actor sheet. Identify branches on the round-trip
- * flag: items picked up from interactive tokens (sourceActorId set) toggle
- * via the cached identifiedData/unidentifiedData payloads; plain inventory
+ * Returns true when the item's carried-light snapshot has a configured non-zero
+ * emission radius. Items without any carried-light data return false, hiding the
+ * row lightbulb entirely for non-light items.
+ *
+ * @param {Item} item
+ * @param {SystemAdapter} [adapter]
+ * @returns {boolean}
+ */
+function _itemHasCarriedLight(item, adapter = getAdapter()) {
+  const { light } = adapter.getItemCarriedLightData(item);
+  return !!light && ((light.dim ?? 0) > 0 || (light.bright ?? 0) > 0);
+}
+
+/**
+ * Build a row-level lightbulb toggle icon for an inventory item whose
+ * carried-light snapshot has a non-zero emission radius. The active state
+ * reflects the live `lightActive` flag on the item's tokenState payload.
+ * Click is permitted for GMs always and for the owner of the parent actor
+ * so players can toggle their own carried torches.
+ *
+ * Returns null when the item has no carried-light data (hides the icon for
+ * non-light items).
+ *
+ * @param {Item} item
+ * @returns {HTMLElement|null}
+ */
+function _buildRowLightToggle(item) {
+  const adapter = getAdapter();
+  if (!_itemHasCarriedLight(item, adapter)) return null;
+  const { active } = adapter.getItemCarriedLightData(item);
+  return createRowControl({
+    iconClass: "fa-solid fa-lightbulb",
+    titleKey: active
+      ? "INTERACTIVE_ITEMS.Light.RowTooltipActive"
+      : "INTERACTIVE_ITEMS.Light.RowTooltipInactive",
+    extraClass: `pick-up-stix-light-toggle${active ? " active" : ""}`,
+    active,
+    onClick: async () => {
+      const allowed = game.user.isGM || item.actor?.isOwner;
+      if (!allowed) return;
+      dbg("row:lightToggle", { itemId: item.id, from: active, to: !active });
+      await adapter.setItemCarriedLightActive(item, !active);
+    }
+  });
+}
+
+/**
+ * Injects row controls (lock, identify, delete — GM-only; light toggle for all)
+ * into each inventory row of a non-interactive actor sheet. Identify branches on
+ * the round-trip flag: items picked up from interactive tokens (sourceActorId set)
+ * toggle via the cached identifiedData/unidentifiedData payloads; plain inventory
  * items just flip the system's native identified flag through the adapter.
  *
  * The identify icon is suppressed on systems that already render a native
- * inventory identify control (pf2e); lock and delete are added uniformly.
+ * inventory identify control (pf2e); lock and delete are added uniformly for GMs.
+ * The light toggle is added for any user when the item has a configured carried
+ * light emission.
  *
  * @param {ActorSheet} app - The rendered actor sheet application.
  * @param {HTMLElement|jQuery} html - The sheet's root element.
  */
 function _injectActorInventoryIdentifyToggles(app, html) {
-  if (!game.user.isGM) return;
   if (isInteractiveActor(app.actor)) return;
   const root = html instanceof HTMLElement ? html : html?.[0];
   if (!root) return;
@@ -414,16 +464,17 @@ function _injectActorInventoryIdentifyToggles(app, html) {
   const skipIdentify = adapter.capabilities.hasNativeInventoryIdentify
     || !adapter.capabilities.supportsIdentification;
 
-  // Add an empty, label-less header cell to each items-section header so the
-  // row's controls column has a matching slot in the header. dnd5e's inventory
-  // headers and rows are sibling flex layouts whose column widths are set by
-  // class selectors — using the same class on both keeps them aligned.
-  root.querySelectorAll(".items-section .items-header.header").forEach(header => {
-    if (header.querySelector(".ii-row-controls-cell")) return;
-    const cell = document.createElement("div");
-    cell.className = "item-header ii-row-controls-cell";
-    header.appendChild(cell);
-  });
+  // Header column cell injection is GM-only — it adds an empty spacer to keep
+  // the column header aligned with the row controls. Non-GM users may still
+  // get a controls cell on individual rows when a light toggle is warranted.
+  if (game.user.isGM) {
+    root.querySelectorAll(".items-section .items-header.header").forEach(header => {
+      if (header.querySelector(".ii-row-controls-cell")) return;
+      const cell = document.createElement("div");
+      cell.className = "item-header ii-row-controls-cell";
+      header.appendChild(cell);
+    });
+  }
 
   root.querySelectorAll("[data-item-id]").forEach(el => {
     const itemId = el.dataset.itemId;
@@ -433,39 +484,54 @@ function _injectActorInventoryIdentifyToggles(app, html) {
     if (!itemRow) return;
     if (itemRow.querySelector(":scope > .ii-row-controls-cell")) return;
 
-    const isInteractive = !!getItemSourceActorId(item);
+    // Determine whether a light toggle should appear for this item. Non-GMs
+    // only see this icon (no lock/wand/trash), so skip the whole row when
+    // there is no light to show and the viewer is not a GM.
+    const lightToggle = _buildRowLightToggle(item);
+    if (!game.user.isGM && !lightToggle) return;
+
     const cell = document.createElement("div");
     cell.className = "item-detail ii-row-controls-cell";
 
-    const isLocked = isItemLocked(item);
-    cell.appendChild(createRowControl({
-      iconClass: `fas ${isLocked ? "fa-lock" : "fa-lock-open"}`,
-      titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleLock",
-      onClick: async () => {
-        await item.update({
-          "flags.pick-up-stix.tokenState.system.isLocked": !isLocked
-        });
-      }
-    }));
+    if (game.user.isGM) {
+      const isInteractive = !!getItemSourceActorId(item);
 
-    if (!skipIdentify) {
+      const isLocked = isItemLocked(item);
       cell.appendChild(createRowControl({
-        iconClass: "fa-solid fa-wand-sparkles",
-        titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleIdentified",
-        extraClass: "pick-up-stix-identify-toggle",
-        active: adapter.isItemIdentified(item),
+        iconClass: `fas ${isLocked ? "fa-lock" : "fa-lock-open"}`,
+        titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleLock",
         onClick: async () => {
-          if (isInteractive) await toggleItemIdentification(item);
-          else await adapter.performIdentifyToggle(item);
+          await item.update({
+            "flags.pick-up-stix.tokenState.system.isLocked": !isLocked
+          });
         }
       }));
+
+      if (!skipIdentify) {
+        cell.appendChild(createRowControl({
+          iconClass: "fa-solid fa-wand-sparkles",
+          titleKey: "INTERACTIVE_ITEMS.Sheet.ToggleIdentified",
+          extraClass: "pick-up-stix-identify-toggle",
+          active: adapter.isItemIdentified(item),
+          onClick: async () => {
+            if (isInteractive) await toggleItemIdentification(item);
+            else await adapter.performIdentifyToggle(item);
+          }
+        }));
+      }
     }
 
-    cell.appendChild(createRowControl({
-      iconClass: "fa-solid fa-trash-can",
-      titleKey: "INTERACTIVE_ITEMS.Sheet.DeleteItem",
-      onClick: async () => { await item.delete({ deleteContents: true }); }
-    }));
+    // Light toggle is visible to any user (GMs always, players if they own the
+    // actor) when the item has a configured non-zero emission radius.
+    if (lightToggle) cell.appendChild(lightToggle);
+
+    if (game.user.isGM) {
+      cell.appendChild(createRowControl({
+        iconClass: "fa-solid fa-trash-can",
+        titleKey: "INTERACTIVE_ITEMS.Sheet.DeleteItem",
+        onClick: async () => { await item.delete({ deleteContents: true }); }
+      }));
+    }
 
     itemRow.appendChild(cell);
   });
@@ -507,13 +573,45 @@ function _resolveSheetRoot(app, html) {
 }
 
 /**
- * Inject the module's header toggles — open/close (containers only), lock,
- * identify, configure — into a system's native item or container sheet header.
+ * Build a lightbulb header button bound to an actor. Active state reflects
+ * whether any light radius is configured (dim > 0 || bright > 0), independent
+ * of the lightActive on/off toggle (which lives on inventory row icons).
+ * Clicking opens the InteractiveLightConfig dialog for the actor.
  *
- * Always emits the four buttons in canonical left-to-right order
- * (`open, lock, identify, configure`) regardless of which decorator callback
- * triggered the render. Existing module buttons are removed and re-created on
- * every call so the order stays stable across re-renders.
+ * @param {object} args
+ * @param {SystemAdapter} args.adapter
+ * @param {Actor} args.actor
+ * @returns {HTMLElement}
+ */
+function _createInteractiveLightButton({ adapter, actor }) {
+  const { light } = adapter.getInteractiveLightData(actor);
+  const hasLight = (light?.dim ?? 0) > 0 || (light?.bright ?? 0) > 0;
+
+  return createAdapterHeaderButton({
+    adapter,
+    extraClass: "ii-light-toggle-btn",
+    active: hasLight,
+    iconOn: "fa-lightbulb",
+    iconOff: "fa-lightbulb",
+    labelOnKey: "INTERACTIVE_ITEMS.Light.ConfigureActive",
+    labelOffKey: "INTERACTIVE_ITEMS.Light.ConfigureInactive",
+    onClick: async (ev) => {
+      ev.preventDefault();
+      const { default: InteractiveLightConfig } = await import("./sheets/InteractiveLightConfig.mjs");
+      InteractiveLightConfig.forActor(actor).render({ force: true });
+    }
+  });
+}
+
+/**
+ * Inject the module's header toggles — open/close (containers only), lock,
+ * identify, light, configure — into a system's native item or container sheet
+ * header.
+ *
+ * Always emits the five buttons in canonical left-to-right order
+ * (`open, lock, identify, light, configure`) regardless of which decorator
+ * callback triggered the render. Existing module buttons are removed and
+ * re-created on every call so the order stays stable across re-renders.
  *
  * Inserts the group immediately after `.window-title` so the buttons sit on
  * the *left* of any system-injected header buttons (Sheet, Prototype Token,
@@ -547,7 +645,7 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   // Remove any existing module toggles so the rebuild produces a stable order.
   // The native identify button (if any) is intentionally NOT in this list —
   // we relocate it into the canonical slot below rather than recreating it.
-  header.querySelectorAll(".ii-open-toggle-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-configure-btn")
+  header.querySelectorAll(".ii-open-toggle-btn, .ii-lock-toggle-btn, .ii-identify-toggle-btn, .ii-light-toggle-btn, .ii-configure-btn")
     .forEach(el => el.remove());
 
   const adapter = getAdapter();
@@ -623,6 +721,9 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
     }
   }
 
+  // Light-emission config button — always present regardless of identification support.
+  orderedNodes.push(_createInteractiveLightButton({ adapter, actor: configActor }));
+
   orderedNodes.push(createAdapterHeaderButton({
     adapter,
     kind: "config",
@@ -658,13 +759,32 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
 function _injectContainerSheetRowControls({ actor, app, html }) {
   if (!isInteractiveContainer(actor)) return;
 
+  // Add an empty, label-less header cell so the data-row controls column has a
+  // matching slot in the items-header. Without this, dnd5e's column widths
+  // (set via class selectors) don't reserve space for our controls and the
+  // PRICE/WEIGHT/QUANTITY headers drift right of their data cells.
+  html.querySelectorAll(".items-section .items-header.header").forEach(header => {
+    if (header.querySelector(".ii-row-controls-cell")) return;
+    const cell = document.createElement("div");
+    cell.className = "item-header ii-row-controls-cell";
+    header.appendChild(cell);
+  });
+
   html.querySelectorAll(".item-list [data-item-id]").forEach(row => {
     const itemId = row.dataset.itemId;
     if (row.querySelector(".ii-row-control, .ii-pickup-btn")) return;
 
     const item = actor.items.get(itemId);
     const itemRow = row.querySelector(".item-row");
-    const target = itemRow || row;
+    if (!itemRow) return;
+    if (itemRow.querySelector(":scope > .ii-row-controls-cell")) return;
+
+    // Wrap all injected controls in a single `.item-detail.ii-row-controls-cell`
+    // so they occupy ONE flex column rather than each becoming a separate child
+    // of `.item-row` — appending raw controls pushes dnd5e's price/weight/qty
+    // cells out of alignment with their header columns.
+    const target = document.createElement("div");
+    target.className = "item-detail ii-row-controls-cell";
 
     if (actor.token) {
       const pickupBtn = createRowControl({
@@ -712,6 +832,14 @@ function _injectContainerSheetRowControls({ actor, app, html }) {
       target.appendChild(pickupBtn);
     }
 
+    // Light toggle — visible to players and GMs when the item has a configured
+    // non-zero emission radius. Placement after the pickup hand mirrors the
+    // order used in the pf2e Contents-tab and the PC inventory row.
+    if (item) {
+      const lightToggle = _buildRowLightToggle(item);
+      if (lightToggle) target.appendChild(lightToggle);
+    }
+
     if (isModuleGM() && item) {
       const isInteractive = !!getItemSourceActorId(item);
 
@@ -748,6 +876,11 @@ function _injectContainerSheetRowControls({ actor, app, html }) {
         onClick: async () => { await item.delete({ deleteContents: true }); }
       }));
     }
+
+    // Only attach the wrapper cell when it actually has children, so item rows
+    // with no applicable controls (player viewing non-pickup, non-light items)
+    // don't get an empty cell that still consumes column width.
+    if (target.children.length > 0) itemRow.appendChild(target);
   });
 }
 
@@ -1160,11 +1293,14 @@ function _buildContainerContentsHeader({ isTokenActor = false } = {}) {
 
 /**
  * Build one inventory-style row representing an item inside the container.
- * Icons (lock / identify / configure / delete) are decorative for now — the
- * caller wires no click handlers per the current spec.
+ * Wires pickup (token-actor only), light-toggle, lock, identify, and delete
+ * controls inline. The light toggle is only rendered when the item has a
+ * configured non-zero emission radius.
  *
  * @param {Item} item
  * @param {SystemAdapter} adapter
+ * @param {object} [options]
+ * @param {boolean} [options.isTokenActor=false]
  * @returns {HTMLLIElement}
  */
 function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {}) {
@@ -1302,6 +1438,28 @@ function _buildContainerContentRow(item, adapter, { isTokenActor = false } = {})
         if (!game.user.isGM) notifyItemAction("PickedUp", item.name);
       }
     ));
+  }
+
+  // Light toggle — visible to players and GMs when the item has a configured
+  // non-zero emission radius. Uses _buildContentRowControl to match the icon
+  // style of the surrounding lock/identify/delete controls.
+  if (_itemHasCarriedLight(item, adapter)) {
+    const { active: lightActive } = adapter.getItemCarriedLightData(item);
+    const lightA = _buildContentRowControl(
+      "fa-lightbulb",
+      lightActive
+        ? "INTERACTIVE_ITEMS.Light.RowTooltipActive"
+        : "INTERACTIVE_ITEMS.Light.RowTooltipInactive",
+      "fa-solid",
+      async () => {
+        const allowed = game.user.isGM || item.actor?.isOwner;
+        if (!allowed) return;
+        dbg("contents:lightToggle", { itemName: item.name, itemId: item.id, from: lightActive, to: !lightActive });
+        await adapter.setItemCarriedLightActive(item, !lightActive);
+      }
+    );
+    if (lightActive) lightA.classList.add("active");
+    controls.append(lightA);
   }
 
   // Lock / identify / delete — Lock and identify reflect the live state on
@@ -1696,6 +1854,32 @@ Hooks.on("preCreateToken", (tokenDoc, data, options, userId) => {
   if (!isContainer && !actor.system.isIdentified && system.unidentifiedImage) {
     updates.texture = { src: system.unidentifiedImage };
   }
+  // When the actor has an active light emission configured, bake it into the
+  // token's light field at creation time. EmbeddedDataField(LightData) normalises
+  // the plain object on the server so we can pass it verbatim.
+  //
+  // Prefer the snapshot's light data over the base actor's. When an item is
+  // re-placed from a player's inventory (or a container's contents) it carries
+  // tokenState.system.{emittedLight,lightActive} from the time of pickup —
+  // but `actor` here is the BASE actor, whose light may differ from the
+  // synthetic the item was picked up from. Falling back to the base actor's
+  // light covers fresh placements (no savedState) and generic actors whose
+  // _createGenericInteractiveActor already mirrors the source's light into
+  // the new actor's flag blob.
+  const savedSystem = savedState?.system;
+  const emittedLight = savedSystem?.emittedLight
+    ?? getAdapter().getInteractiveLightData(actor).light;
+  const lightActive = savedSystem
+    ? !!savedSystem.lightActive
+    : getAdapter().getInteractiveLightData(actor).active;
+  const hasEmission = !!emittedLight && ((emittedLight.dim ?? 0) > 0 || (emittedLight.bright ?? 0) > 0);
+  if (lightActive && hasEmission) {
+    dbg("hook:preCreateToken", "baking emittedLight into token.light", {
+      dim: emittedLight.dim, bright: emittedLight.bright,
+      fromSavedState: !!savedSystem?.emittedLight
+    });
+    updates.light = emittedLight;
+  }
   updates.sort = -1;
   tokenDoc.updateSource(updates);
 });
@@ -2076,6 +2260,38 @@ async function _promptCreateKind(position) {
   });
 }
 
+/**
+ * Sync the bound token's `light` field to match the actor's current emitted-light
+ * configuration. Called only for **synthetic actors** (placed unlinked tokens whose
+ * actor is being edited in-place). For base-actor edits the module convention is that
+ * already-placed tokens are independent snapshots and do NOT receive propagated changes;
+ * the new light config only applies to tokens placed after the edit.
+ *
+ * When `lightActive` is false or no radius is configured, writes a zero-radius
+ * reset `{ dim: 0, bright: 0 }` to suppress any prior emission.
+ *
+ * GM-only — non-GM callers are silently ignored (they cannot update TokenDocuments).
+ *
+ * @param {Actor} actor - A synthetic actor (`actor.token` is set).
+ * @returns {Promise<void>}
+ */
+async function _syncPlacedTokensLight(actor) {
+  if (!game.user.isGM) {
+    dbg("syncPlacedTokensLight", "non-GM, bail");
+    return;
+  }
+  const tokenDoc = actor.token;
+  if (!tokenDoc) {
+    dbg("syncPlacedTokensLight", "no actor.token, bail (base-actor edit — no propagation by convention)");
+    return;
+  }
+  const { light: emitted, active } = getAdapter().getInteractiveLightData(actor);
+  const hasEmission = !!emitted && ((emitted.dim ?? 0) > 0 || (emitted.bright ?? 0) > 0);
+  const lightUpdate = (active && hasEmission) ? emitted : { dim: 0, bright: 0 };
+  dbg("syncPlacedTokensLight", "updating token.light", { tokenId: tokenDoc.id, active, hasEmission, dim: lightUpdate.dim, bright: lightUpdate.bright });
+  await tokenDoc.update({ light: lightUpdate });
+}
+
 Hooks.on("updateActor", async (actor, changes, options, userId) => {
   dbg("hook:updateActor", {
     name: actor.name,
@@ -2177,7 +2393,17 @@ Hooks.on("updateActor", async (actor, changes, options, userId) => {
   }
 
   if (isSynthetic) {
-    dbg("hook:updateActor", "synthetic actor, skipping prototype-token name sync");
+    // When the user edits a placed token's actor (synthetic) and changes its light
+    // emission settings, propagate immediately to that specific token's light field.
+    // Base-actor edits are intentionally NOT propagated (module snapshot convention).
+    const emittedLightChanged = "emittedLight" in systemChanges;
+    const lightActiveChanged = "lightActive" in systemChanges;
+    if (emittedLightChanged || lightActiveChanged) {
+      dbg("hook:updateActor", "synthetic actor light change, syncing token light", { emittedLightChanged, lightActiveChanged });
+      await _syncPlacedTokensLight(actor);
+    } else {
+      dbg("hook:updateActor", "synthetic actor, skipping prototype-token name sync");
+    }
     return;
   }
 
@@ -2239,11 +2465,16 @@ Hooks.on("updateActor", (actor, changes) => {
   // own config sheet inject identify toggles whose icon and tooltip have to
   // refresh after a Mystify/Identify action; otherwise the visual stays stale
   // even though the underlying data updated correctly.
-  if (!("isLocked" in sys) && !("isOpen" in sys) && !("isIdentified" in sys)) {
-    dbg("hook:updateActor:rerender", { name: actor.name }, "no isLocked/isOpen/isIdentified change, bail");
+  //
+  // emittedLight / lightActive are in this set so the header lightbulb's
+  // active class refreshes after light radii are edited via InteractiveLightConfig
+  // (otherwise the icon stays in its prior visual state until the next manual re-render).
+  if (!("isLocked" in sys) && !("isOpen" in sys) && !("isIdentified" in sys)
+      && !("emittedLight" in sys) && !("lightActive" in sys)) {
+    dbg("hook:updateActor:rerender", { name: actor.name }, "no isLocked/isOpen/isIdentified/emittedLight/lightActive change, bail");
     return;
   }
-  dbg("hook:updateActor:rerender", { name: actor.name, id: actor.id, isLocked: sys.isLocked, isOpen: sys.isOpen, isIdentified: sys.isIdentified, sheetRendered: !!actor.system.embeddedItem?.sheet?.rendered });
+  dbg("hook:updateActor:rerender", { name: actor.name, id: actor.id, isLocked: sys.isLocked, isOpen: sys.isOpen, isIdentified: sys.isIdentified, emittedLightChanged: "emittedLight" in sys, lightActiveChanged: "lightActive" in sys, sheetRendered: !!actor.system.embeddedItem?.sheet?.rendered });
 
   // Re-render the embedded item's native sheet (dnd5e ContainerSheet / pf2e item sheets).
   const item = actor.system.embeddedItem;
@@ -2315,6 +2546,17 @@ Hooks.on("updateActor", (actor, changes) => {
 
   dbg("hook:updateActor:genericRerender", { actorName: actor.name, actorId: actor.id });
 
+  // When emittedLight or lightActive changed in the flag blob and this is a
+  // synthetic actor (placed token's actor being edited), propagate to the token's
+  // light field. Base-actor edits are not propagated (module snapshot convention).
+  const interactiveChanges = changes.flags?.["pick-up-stix"]?.interactive ?? {};
+  const lightDataChanged = "emittedLight" in interactiveChanges || "lightActive" in interactiveChanges;
+  if (lightDataChanged && actor.token) {
+    dbg("hook:updateActor:genericRerender", "generic light change on synthetic actor, syncing token light", { actorName: actor.name });
+    _syncPlacedTokensLight(actor)
+      .catch(err => console.error(`${MODULE_ID} | generic light sync failed:`, err));
+  }
+
   // Walk both AppV1 (ui.windows) and AppV2 (foundry.applications.instances)
   // registries to find the open generic view, if any.
   for (const app of Object.values(ui.windows)) {
@@ -2337,19 +2579,20 @@ Hooks.on("updateActor", (actor, changes) => {
   }
 });
 
-// Re-render container views when a deposited item's lock flag or stack
-// quantity changes so the Contents-tab row stays current. Scoped narrowly:
-// deposited items (i.e. *not* the wrapping container's embedded backpack)
-// on interactive container actors. The main updateItem hook below handles
-// identification changes for the wrapped item.
+// Re-render container views when a deposited item's lock flag, light-active
+// flag, or stack quantity changes so the Contents-tab row stays current.
+// Scoped narrowly: deposited items (i.e. *not* the wrapping container's
+// embedded backpack) on interactive container actors. The main updateItem
+// hook below handles identification changes for the wrapped item.
 Hooks.on("updateItem", (item, changes) => {
   const actor = item.parent;
   if (!isInteractiveActor(actor) || !actor.system?.isContainer) return;
   if (item.id === actor.system.embeddedItem?.id) return;
   const lockChanged = foundry.utils.hasProperty(changes, "flags.pick-up-stix.tokenState.system.isLocked");
+  const lightChanged = foundry.utils.hasProperty(changes, "flags.pick-up-stix.tokenState.system.lightActive");
   const qtyChanged = foundry.utils.hasProperty(changes, "system.quantity");
-  if (!lockChanged && !qtyChanged) return;
-  dbg("hook:updateItem:rowRerender", { itemName: item.name, itemId: item.id, lockChanged, qtyChanged });
+  if (!lockChanged && !lightChanged && !qtyChanged) return;
+  dbg("hook:updateItem:rowRerender", { itemName: item.name, itemId: item.id, lockChanged, lightChanged, qtyChanged });
   _rerenderContainerViews(actor);
 });
 

--- a/scripts/sheets/InteractiveLightConfig.mjs
+++ b/scripts/sheets/InteractiveLightConfig.mjs
@@ -1,0 +1,172 @@
+/**
+ * InteractiveLightConfig — ApplicationV2 form for editing an interactive actor's
+ * emitted-light data. Reuses Foundry's stock `templates/scene/token/light.hbs`
+ * template so the UI matches the Token Light tab across v13 and v14. The template
+ * already exposes dim/bright/color/animation/advanced fields via `lightFields`
+ * (a `foundry.data.LightData` schema slice) and `source.light.*` bindings, giving
+ * us v14's `priority` field automatically without any version-gating.
+ *
+ * The form auto-submits on every change (`submitOnChange: true`) so the GM sees
+ * live feedback on the actor. Per-actor singleton cache mirrors the pattern used by
+ * `Dnd5eInteractiveItemConfigSheet.forActor`.
+ */
+
+import { getAdapter } from "../adapter/index.mjs";
+import { dbg } from "../utils/debugLog.mjs";
+
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+
+/**
+ * GM-only light-emission editor for a `pick-up-stix.interactiveItem` actor.
+ *
+ * Opens via the lightbulb header button (Phase 3). Persists changes through
+ * `adapter.setInteractiveLightData` so dnd5e, pf2e, and generic actors are all
+ * covered without branching.
+ */
+export default class InteractiveLightConfig extends HandlebarsApplicationMixin(ApplicationV2) {
+
+  /** @type {Map<string, InteractiveLightConfig>} Per-actor singleton cache keyed by actor UUID. */
+  static #instances = new Map();
+
+  /**
+   * Resolve the light-config sheet for a given actor, creating a new instance on
+   * first call and returning the cached instance on subsequent calls.
+   *
+   * @param {Actor} actor
+   * @returns {InteractiveLightConfig}
+   */
+  static forActor(actor) {
+    const key = actor.uuid;
+    let sheet = InteractiveLightConfig.#instances.get(key);
+    if (!sheet) {
+      sheet = new InteractiveLightConfig({ actor });
+      InteractiveLightConfig.#instances.set(key, sheet);
+    }
+    return sheet;
+  }
+
+  /**
+   * @param {object} options
+   * @param {Actor} options.actor - The interactive actor whose light this form edits.
+   */
+  constructor(options = {}) {
+    super(options);
+    /** @type {Actor} */
+    this.actor = options.actor;
+  }
+
+  static DEFAULT_OPTIONS = {
+    classes: ["pick-up-stix", "interactive-light-config", "standard-form"],
+    position: { width: 520, height: "auto" },
+    window: {
+      contentClasses: ["standard-form"],
+      resizable: true,
+      icon: "fa-solid fa-lightbulb"
+    },
+    form: {
+      handler: InteractiveLightConfig.#onSubmit,
+      submitOnChange: true,
+      closeOnSubmit: false
+    },
+    tag: "form"
+  };
+
+  /**
+   * Reuse Foundry's stock token light template. It expects `source.light.*`,
+   * `lightFields`, `lightAnimations`, `colorationTechniques`, `gridUnits`,
+   * `rootId`, and `tab` — all prepared in `_prepareContext`.
+   */
+  static PARTS = {
+    light: { template: "templates/scene/token/light.hbs" }
+  };
+
+  /** @override */
+  get title() {
+    return `${game.i18n.localize("INTERACTIVE_ITEMS.Light.Title")}: ${this.actor.name}`;
+  }
+
+  /** @override */
+  async _prepareContext(options) {
+    const ctx = await super._prepareContext(options);
+    const adapter = getAdapter();
+    const { light } = adapter.getInteractiveLightData(this.actor);
+
+    // The token light.hbs template references source.light.* and lightFields.*.
+    // Crucially, lightFields MUST come from TokenDocument's embedded copy (where
+    // each sub-field's `fieldPath` is "light.dim", "light.bright", …). The base
+    // `foundry.data.LightData.schema.fields.*` has fieldPath "dim", "bright" with
+    // no "light." prefix, so {{formInput}} would emit `<input name="dim">` and
+    // the submitted formData wouldn't nest under `light` — `expanded.light` would
+    // be empty and nothing would persist. Pulling from BaseToken's localized
+    // embedded copy gives both the correct fieldPath AND the localized labels.
+    ctx.rootId = this.id;
+    ctx.source = { light };
+    ctx.lightFields = foundry.documents.BaseToken.schema.fields.light.fields;
+
+    // Use only light animations (not darkness animations) since interactive items
+    // are not expected to be darkness sources in the typical workflow.
+    ctx.lightAnimations = CONFIG.Canvas.lightAnimations;
+
+    // AdaptiveLightingShader lives at the same path on both v13 and v14; the
+    // SHADER_TECHNIQUES property powers the coloration select choices.
+    ctx.colorationTechniques =
+      foundry.canvas?.rendering?.shaders?.AdaptiveLightingShader?.SHADER_TECHNIQUES ?? {};
+
+    ctx.gridUnits = canvas.scene?.grid?.units || game.i18n.localize("GridUnits");
+
+    // The token/light.hbs template wraps its content in a `<div class="tab ...">` that
+    // reads tab.active, tab.group, and tab.id. We render this as a standalone form
+    // with no tab navigation, so we supply a stub that keeps the wrapper always active.
+    ctx.tab = { active: true, group: "light", id: "light" };
+
+    return ctx;
+  }
+
+  /**
+   * Form-change handler. Expands the flat form data into a nested object and
+   * persists it via the adapter so model-backed (dnd5e, pf2e) and flag-backed
+   * (generic) actors are both handled transparently.
+   *
+   * @param {Event} event
+   * @param {HTMLFormElement} form
+   * @param {import("@common/ux/form-data-extended.mjs").FormDataExtended} formData
+   * @this {InteractiveLightConfig}
+   */
+  static async #onSubmit(event, form, formData) {
+    const adapter = getAdapter();
+    const expanded = foundry.utils.expandObject(formData.object);
+    const newLight = expanded.light ?? {};
+    const { light: oldLight } = adapter.getInteractiveLightData(this.actor);
+
+    const oldHasRadii = !!oldLight
+      && ((oldLight.dim ?? 0) > 0 || (oldLight.bright ?? 0) > 0);
+    const newHasRadii = (newLight.dim ?? 0) > 0 || (newLight.bright ?? 0) > 0;
+
+    // Auto-couple lightActive to radii TRANSITIONS so the GM doesn't have to
+    // touch a separate toggle when configuring a torch for the first time:
+    //   - going from "no radii" to "any radii" → turn light on (active=true)
+    //   - going from "any radii" to "no radii" → turn light off (active=false)
+    //   - other edits (e.g. color, animation, radii adjustments while already on)
+    //     leave the explicit on/off state alone so a player's row-icon toggle
+    //     is not silently reversed by an unrelated GM edit.
+    const partial = { light: newLight };
+    if (newHasRadii && !oldHasRadii) partial.active = true;
+    else if (!newHasRadii && oldHasRadii) partial.active = false;
+
+    dbg("light-config:submit", {
+      actorId: this.actor.id,
+      lightKeys: Object.keys(newLight),
+      oldHasRadii, newHasRadii,
+      activeChange: partial.active
+    });
+
+    await adapter.setInteractiveLightData(this.actor, partial);
+  }
+
+  /** @override */
+  async close(options = {}) {
+    dbg("light-config:close", { actorId: this.actor?.id });
+    InteractiveLightConfig.#instances.delete(this.actor?.uuid);
+    return super.close(options);
+  }
+}

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -235,7 +235,7 @@ export async function pickupItem(sceneId, tokenId, itemId, targetActorId, quanti
  * @param {string} args.lootType
  * @returns {object}
  */
-export function buildGenericStubItem({ name, img, description, quantity, lootType }) {
+export function buildGenericStubItem({ name, img, description, quantity, lootType, emittedLight = null, lightActive = false }) {
   const Model = CONFIG.Item.dataModels?.[lootType];
   const descField = Model?.schema?.fields?.description;
 
@@ -254,6 +254,24 @@ export function buildGenericStubItem({ name, img, description, quantity, lootTyp
     stubData.system.description = description ?? "";
   }
   // else: no description field declared on this item type — skip it.
+
+  // Persist carried-light data so the inventory-row lightbulb (Phase 4) can
+  // read it back via adapter.getItemCarriedLightData(). The shape mirrors the
+  // tokenState payload that model-backed pickups produce via stampInteractiveIdentity,
+  // keeping the row decorator system-agnostic.
+  const hasLight = emittedLight
+    && ((emittedLight.dim ?? 0) > 0 || (emittedLight.bright ?? 0) > 0);
+  if (hasLight) {
+    stubData.flags = stubData.flags ?? {};
+    stubData.flags["pick-up-stix"] = {
+      tokenState: {
+        system: {
+          emittedLight,
+          lightActive: !!lightActive
+        }
+      }
+    };
+  }
 
   return stubData;
 }
@@ -324,10 +342,17 @@ async function _pickupItemGeneric(sourceActor, tokenDoc, targetActor, quantity, 
     ? flagQty
     : Math.max(1, Math.min(Math.floor(quantity), flagQty));
 
-  const stubData = buildGenericStubItem({ name, img, description, quantity: moveQty, lootType });
+  const stubData = buildGenericStubItem({
+    name, img, description, quantity: moveQty, lootType,
+    // Propagate the source actor's configured light emission so the inventory-row
+    // lightbulb appears for stacked / picked-up torches and the carrier emits in Phase 6.
+    emittedLight: interactiveData.emittedLight,
+    lightActive: interactiveData.lightActive
+  });
 
   dbg("xfer:_pickupItemGeneric", "creating stub item on target", {
-    stubName: stubData.name, lootType, moveQty, targetActorName: targetActor.name
+    stubName: stubData.name, lootType, moveQty, targetActorName: targetActor.name,
+    hasLight: !!stubData.flags?.["pick-up-stix"]?.tokenState?.system?.emittedLight
   });
 
   await CONFIG.Item.documentClass.create(stubData, { parent: targetActor });
@@ -399,7 +424,11 @@ async function _pickupContentRow(sourceActor, targetActor, contentId, quantity) 
     img: row.img,
     description: row.description ?? "",
     quantity: moveQty,
-    lootType
+    lootType,
+    // Container content rows carry their own light data when deposited via
+    // Phase 6's deposit pipeline; default to no light when absent.
+    emittedLight: row.emittedLight,
+    lightActive: row.lightActive
   });
 
   dbg("xfer:_pickupContentRow", "creating stub on target", { stubName: stubData.name, lootType, moveQty });
@@ -476,15 +505,21 @@ export async function depositItem(sourceActorId, itemId, sceneId, tokenId, quant
   // collection and the system would reject the create anyway). Source is
   // still decremented on its real actor.
   if (adapter.constructor.SYSTEM_ID === "generic" && adapter.isInteractiveContainer(targetActor)) {
+    // Pull carried-light snapshot from the item's tokenState flag payload so
+    // the content row remembers the light configuration for the carried-lights
+    // pipeline (carriedLights.mjs) and the row lightbulb toggle (Phase 4).
+    const tokenSys = item?.flags?.["pick-up-stix"]?.tokenState?.system ?? {};
     const row = {
       id: foundry.utils.randomID(),
       name: item.name,
       img: item.img,
       description: item.system?.description?.value ?? item.system?.description ?? "",
-      quantity: moveQty
+      quantity: moveQty,
+      emittedLight: tokenSys.emittedLight ?? null,
+      lightActive: !!tokenSys.lightActive
     };
     const current = adapter.getInteractiveData(targetActor);
-    dbg("xfer:depositItem", "generic container deposit: appending content row", { rowName: row.name, qty: moveQty });
+    dbg("xfer:depositItem", "generic container deposit: appending content row", { rowName: row.name, qty: moveQty, lightActive: row.lightActive });
     await adapter.setInteractiveData(targetActor, {
       contents: [...(current.contents ?? []), row]
     });

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -90,14 +90,24 @@
  * dnd5e renders the items-section header and each row as sibling flex
  * containers; column widths come from per-cell class selectors. Adding a
  * matched class to a header cell and a row cell keeps them aligned.
+ *
+ * Use an explicit fixed `width` with `border-box` so the empty header cell
+ * and the icon-filled data cell occupy exactly the same horizontal slot —
+ * `min-width` would let the data cell grow past the header (icons total
+ * ~22px × N + 4px gap), which pushes price/weight/quantity columns out of
+ * alignment with their headers. The width chosen fits the typical GM control
+ * set (light + lock + identify + trash = 4 icons) plus the 8px right padding
+ * that keeps the trash off the row boundary.
  */
 .dnd5e2 .items-section .items-header .ii-row-controls-cell,
 .dnd5e2 .items-section .item .ii-row-controls-cell {
-  width: 78px;
+  width: 120px;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 4px;
+  padding-right: 8px;
 }
 
 /* ===== GM Identification Toggle (injected into dnd5e character sheets) ===== */
@@ -123,6 +133,31 @@
 .pick-up-stix-identify-toggle:hover {
   opacity: 1;
   color: var(--item-control-active-color, var(--color-text-hyperlink));
+}
+
+/* ===== Light Toggle (injected into inventory rows with configured emission) ===== */
+
+.pick-up-stix-light-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-right: 4px;
+  font-size: 0.9em;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  opacity: 0.75;
+}
+
+.pick-up-stix-light-toggle.active {
+  color: #ffaa00;
+  opacity: 1;
+}
+
+.pick-up-stix-light-toggle:hover {
+  opacity: 1;
+  color: #ffaa00;
 }
 
 /* ===== Folder Trash Button ===== */
@@ -311,6 +346,12 @@
 }
 
 .ii-contents-control:hover {
+  opacity: 1;
+}
+
+/* Active state for the light-toggle icon inside the pf2e Contents-tab rows. */
+.ii-contents-control.active {
+  color: #ffaa00;
   opacity: 1;
 }
 

--- a/templates/container-view-generic.hbs
+++ b/templates/container-view-generic.hbs
@@ -23,6 +23,17 @@
               <i class="fa-solid fa-hand"></i>
             </button>
           {{/if}}
+          {{!-- Light toggle: only rendered for rows with a configured non-zero
+                emission radius. The active class is toggled server-side so the
+                rendered state always reflects the live flag value. --}}
+          {{#if lightConfigured}}
+            <button type="button"
+                    class="ii-row-control ii-light-toggle-row pick-up-stix-light-toggle{{#if lightActive}} active{{/if}}"
+                    data-content-id="{{id}}"
+                    title="{{#if lightActive}}{{localize 'INTERACTIVE_ITEMS.Light.RowTooltipActive'}}{{else}}{{localize 'INTERACTIVE_ITEMS.Light.RowTooltipInactive'}}{{/if}}">
+              <i class="fa-solid fa-lightbulb"></i>
+            </button>
+          {{/if}}
           {{#if ../isGM}}
             <button type="button" class="ii-row-control ii-delete"
                     data-action="deleteContent" data-content-id="{{id}}"


### PR DESCRIPTION
## Summary

Adds per-actor light emission settings to `pick-up-stix.interactiveItem` actors. A configured torch on the canvas shines from its own token. When picked up, the carrier emits an **additional** light source from their token without overwriting their own token-light. Inside an interactive container, items only emit while the container is open. The configuration round-trips intact through pickup / deposit / re-placement.

Works on Foundry **v13** and **v14**, across the **dnd5e**, **pf2e**, and **generic** adapters.

## Surfaces

- **Lightbulb header button** on every interactive sheet (GM config sheet, native dnd5e ItemSheet5e / ContainerSheet, pf2e item / container sheets, generic views). Opens a full Foundry-style Light editor that reuses `templates/scene/token/light.hbs`, so v14's `priority` field appears automatically and v13 omits it — same code path.
- **Row lightbulb toggle** in PC / NPC inventories, dnd5e ContainerSheet rows, pf2e Contents-tab rows, and the generic ContainerView. GM or item owner can flip on/off without losing configured radii.
- **GM HUD lightbulb** on canvas tokens with light configured — toggles on/off without opening a sheet.
- **Auto-coupling**: configuring radii for the first time turns the light on; clearing them turns it off. Edits that don't change the has-radii state leave the explicit on/off alone so a player's toggle isn't reversed by a GM color tweak.

## Architecture

- New schema fields `emittedLight: EmbeddedDataField(LightData)` and `lightActive: BooleanField({initial: true})` on `InteractiveItemModel`; equivalent flag keys on the generic adapter's blob.
- Four new `SystemAdapter` methods (`getInteractiveLightData` / `setInteractiveLightData` with generic overrides; `getItemCarriedLightData` / `setItemCarriedLightActive` system-agnostic on the unified `tokenState` payload).
- `preCreateToken` bakes `emittedLight` into `tokenDoc.light` when active, preferring the picked-up item's `savedState` snapshot over the base actor so re-placement preserves the configuration. `updateActor` syncs the synthetic token's light on live edits.
- `scripts/canvas/carriedLights.mjs` registers an additional `PointLightSource` per (carrier, carried-item) pair, keyed `pus-light:<tokenId>:<itemId>` in `canvas.effects.lightSources`. Coexists with the carrier's own `Token.<id>` source. Per-frame `refreshToken` hook re-positions sources during animation. Container tokens only emit contents-driven lights while open.
- Generic deposit paths carry `emittedLight` / `lightActive` into each new content-row record so the row decorator shows the lightbulb and `carriedLights` can register sources for items in generic containers.

## Tie-in fixes shipped with this work

- `GenericHooks.registerActorInventoryHooks` no longer a permanent no-op; subscribes to `renderActorSheet` so PC inventory rows can be decorated on unknown systems.
- `buildGenericStubItem` propagates light data onto the pickup stub's `tokenState`.
- dnd5e container sheet row controls wrapped in a single `.ii-row-controls-cell` with a matching header column, so the PRICE/WEIGHT/QUANTITY columns line up properly. Fixed-width + `border-box` keeps header and data columns identical regardless of icon count.
- Interactive container item sheets get `window.resizable=true`.
- `updateActor` re-render gate extended to fire on `emittedLight` / `lightActive` changes so the header lightbulb's active state refreshes after edits.

## Compatibility

Schema additions are additive with safe defaults. `lightActive` defaults to `true` so newly-configured items start emitting; existing actors with persisted `lightActive=false` keep that value. **No migration needed.**