### PR TITLE
chore(install-tracker): include moduleId in payload

### DIFF
--- a/scripts/utils/installTracker.mjs
+++ b/scripts/utils/installTracker.mjs
@@ -139,6 +139,7 @@ function _shouldSendInstallRecord(state, currentVersion) {
  */
 function _buildPayload(moduleVersion) {
   return {
+    moduleId: MODULE_ID,
     system: game.system.id,
     systemVersion: game.system.version,
     foundryVersion: game.version,


### PR DESCRIPTION
## Summary
- Add `moduleId` field to the install-tracker request payload so the endpoint can distinguish records by module.