### PR TITLE
fix(light): edit inventory item snapshot, not the source actor

### DIFF
--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -525,6 +525,29 @@ export default class SystemAdapter {
     return item.update({ "flags.pick-up-stix.tokenState.system.lightActive": !!active });
   }
 
+  /**
+   * Persist a partial update to an inventory item's carried-light snapshot
+   * (`flags["pick-up-stix"].tokenState.system.{emittedLight,lightActive}`).
+   * Mirrors `setInteractiveLightData` but writes to the item-level snapshot
+   * rather than the actor template, so editing one carrier's light does not
+   * touch the source actor template or any other picked-up copy.
+   *
+   * The `tokenState` flag path is uniform across all systems, so no adapter
+   * override is required.
+   *
+   * @param {Item} item
+   * @param {object} partial
+   * @param {object}  [partial.light]  - Partial LightData-shape object; replaces emittedLight.
+   * @param {boolean} [partial.active] - New lightActive state.
+   * @returns {Promise<Item>}
+   */
+  async setItemCarriedLightData(item, partial) {
+    const update = {};
+    if (partial.light !== undefined) update["flags.pick-up-stix.tokenState.system.emittedLight"] = partial.light;
+    if (partial.active !== undefined) update["flags.pick-up-stix.tokenState.system.lightActive"] = !!partial.active;
+    return item.update(update);
+  }
+
   // === Sheet delegation ======================================================
 
   /**

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -374,7 +374,6 @@ function _injectItemContextMenuEntries(item, menuItems) {
   if (!game.user.isGM) return;
   const iiFlags = getItemIIFlags(item);
   if (!iiFlags?.sourceActorId) return;
-  const sourceActorId = getItemSourceActorId(item);
 
   const isIdentified = isItemIdentified(item);
   menuItems.push({
@@ -386,14 +385,11 @@ function _injectItemContextMenuEntries(item, menuItems) {
     callback: () => toggleItemIdentification(item)
   });
 
-  // Override dnd5e's "Edit" to open our config sheet instead.
-  const editEntry = menuItems.find(e => e.name === "DND5E.ContextMenuActionEdit");
-  if (editEntry) {
-    editEntry.callback = () => {
-      const sourceActor = game.actors.get(sourceActorId);
-      if (sourceActor?.sheet?.renderConfig) sourceActor.sheet.renderConfig();
-    };
-  }
+  // Leave the system's default "Edit" entry alone so right-click → Edit on a
+  // picked-up item opens the item's own native sheet. That sheet receives the
+  // module's header injection (open/lock/identify/light/configure) and the
+  // lightbulb there routes at the item's per-item snapshot. Editing the
+  // source-actor template is still reachable from the Actors directory.
 }
 
 /**
@@ -578,19 +574,38 @@ function _resolveSheetRoot(app, html) {
 }
 
 /**
- * Build a lightbulb header button bound to an actor. Active state reflects
- * whether any light radius is configured (dim > 0 || bright > 0), independent
- * of the lightActive on/off toggle (which lives on inventory row icons).
- * Clicking opens the InteractiveLightConfig dialog for the actor.
+ * Build a lightbulb header button bound to a light target (an Actor for
+ * template editing, or an Item for per-item snapshot editing). Active state
+ * reflects whether any light radius is configured (dim > 0 || bright > 0),
+ * independent of the lightActive on/off toggle (which lives on inventory row
+ * icons). Clicking opens the InteractiveLightConfig dialog for the target.
  *
  * @param {object} args
  * @param {SystemAdapter} args.adapter
- * @param {Actor} args.actor
+ * @param {Actor|Item} args.target  - Source actor template, or inventory item snapshot.
  * @returns {HTMLElement}
  */
-function _createInteractiveLightButton({ adapter, actor }) {
-  const { light } = adapter.getInteractiveLightData(actor);
+function _createInteractiveLightButton({ adapter, target }) {
+  // `documentName` is a static field on every Foundry Document subclass; using
+  // it keeps the item-vs-actor branch system-agnostic (works for Item5e,
+  // ItemPF2e, generic Item, etc. without depending on CONFIG.Item.documentClass
+  // identity).
+  const docName = target?.documentName ?? target?.constructor?.documentName;
+  const isItemTarget = docName === "Item";
+  const { light } = isItemTarget
+    ? adapter.getItemCarriedLightData(target)
+    : adapter.getInteractiveLightData(target);
   const hasLight = (light?.dim ?? 0) > 0 || (light?.bright ?? 0) > 0;
+  dbg("lightBtn:create", {
+    targetUuid: target?.uuid,
+    targetName: target?.name,
+    docName,
+    isItemTarget,
+    lightColor: light?.color,
+    lightDim: light?.dim,
+    lightBright: light?.bright,
+    hasLight
+  });
 
   return createAdapterHeaderButton({
     adapter,
@@ -603,7 +618,7 @@ function _createInteractiveLightButton({ adapter, actor }) {
     onClick: async (ev) => {
       ev.preventDefault();
       const { default: InteractiveLightConfig } = await import("./sheets/InteractiveLightConfig.mjs");
-      InteractiveLightConfig.forActor(actor).render({ force: true });
+      InteractiveLightConfig.forTarget(target).render({ force: true });
     }
   });
 }
@@ -727,7 +742,29 @@ function _injectInteractiveSheetHeaderControls({ actor, app, html }) {
   }
 
   // Light-emission config button — always present regardless of identification support.
-  orderedNodes.push(_createInteractiveLightButton({ adapter, actor: configActor }));
+  //
+  // When the rendered item carries its own pick-up-stix tokenState snapshot
+  // (every picked-up item and deposited container content stamps one at
+  // pickup/deposit), route the lightbulb at the item so edits land on that
+  // independent snapshot rather than the source-actor template. Otherwise
+  // (source actor's own embedded item sheet, with no snapshot) fall back to
+  // the interactive actor for template editing. Matches the "items are
+  // unlinked snapshots once picked up" convention.
+  const sheetItem = app?.item;
+  const sheetItemFlags = sheetItem?.flags?.["pick-up-stix"];
+  const itemHasSnapshot = !!sheetItemFlags?.tokenState;
+  const lightTarget = itemHasSnapshot ? sheetItem : configActor;
+  dbg("inject:lightTarget", {
+    sheetItemUuid: sheetItem?.uuid,
+    sheetItemName: sheetItem?.name,
+    hasFlags: !!sheetItemFlags,
+    hasSourceActorId: !!sheetItemFlags?.sourceActorId,
+    hasTokenState: !!sheetItemFlags?.tokenState,
+    tokenStateEmittedLightColor: sheetItemFlags?.tokenState?.system?.emittedLight?.color,
+    routedTo: itemHasSnapshot ? "item" : "actor",
+    configActorName: configActor?.name
+  });
+  orderedNodes.push(_createInteractiveLightButton({ adapter, target: lightTarget }));
 
   orderedNodes.push(createAdapterHeaderButton({
     adapter,

--- a/scripts/sheets/InteractiveLightConfig.mjs
+++ b/scripts/sheets/InteractiveLightConfig.mjs
@@ -1,14 +1,16 @@
 /**
- * InteractiveLightConfig — ApplicationV2 form for editing an interactive actor's
- * emitted-light data. Reuses Foundry's stock `templates/scene/token/light.hbs`
- * template so the UI matches the Token Light tab across v13 and v14. The template
- * already exposes dim/bright/color/animation/advanced fields via `lightFields`
- * (a `foundry.data.LightData` schema slice) and `source.light.*` bindings, giving
+ * InteractiveLightConfig — ApplicationV2 form for editing emitted-light data.
+ * Accepts either an interactive Actor (template editing — source actor's
+ * `system.emittedLight`) or an inventory Item (per-item snapshot editing —
+ * `flags["pick-up-stix"].tokenState.system.emittedLight`). Reuses Foundry's
+ * stock `templates/scene/token/light.hbs` template so the UI matches the
+ * Token Light tab across v13 and v14. The template already exposes
+ * dim/bright/color/animation/advanced fields via `lightFields` (a
+ * `foundry.data.LightData` schema slice) and `source.light.*` bindings, giving
  * us v14's `priority` field automatically without any version-gating.
  *
- * The form auto-submits on every change (`submitOnChange: true`) so the GM sees
- * live feedback on the actor. Per-actor singleton cache mirrors the pattern used by
- * `Dnd5eInteractiveItemConfigSheet.forActor`.
+ * The form auto-submits on every change (`submitOnChange: true`) so the GM
+ * sees live feedback. Per-target singleton cache keyed by document UUID.
  */
 
 import { getAdapter } from "../adapter/index.mjs";
@@ -17,42 +19,98 @@ import { dbg } from "../utils/debugLog.mjs";
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 
 /**
- * GM-only light-emission editor for a `pick-up-stix.interactiveItem` actor.
+ * GM-only light-emission editor.
  *
- * Opens via the lightbulb header button (Phase 3). Persists changes through
- * `adapter.setInteractiveLightData` so dnd5e, pf2e, and generic actors are all
- * covered without branching.
+ * Persists changes through `adapter.setInteractiveLightData` for an actor
+ * target, or `adapter.setItemCarriedLightData` for an item target — so dnd5e,
+ * pf2e, and generic actors are all covered without branching, and inventory
+ * items get their own independent snapshot updated rather than the source
+ * actor template.
  */
 export default class InteractiveLightConfig extends HandlebarsApplicationMixin(ApplicationV2) {
 
-  /** @type {Map<string, InteractiveLightConfig>} Per-actor singleton cache keyed by actor UUID. */
+  /** @type {Map<string, InteractiveLightConfig>} Per-target singleton cache keyed by document UUID. */
   static #instances = new Map();
 
   /**
-   * Resolve the light-config sheet for a given actor, creating a new instance on
-   * first call and returning the cached instance on subsequent calls.
+   * Resolve the light-config sheet for a given target document (Actor or Item),
+   * creating a new instance on first call and returning the cached instance on
+   * subsequent calls.
    *
-   * @param {Actor} actor
+   * @param {Actor|Item} target
    * @returns {InteractiveLightConfig}
    */
-  static forActor(actor) {
-    const key = actor.uuid;
+  static forTarget(target) {
+    const key = target.uuid;
     let sheet = InteractiveLightConfig.#instances.get(key);
     if (!sheet) {
-      sheet = new InteractiveLightConfig({ actor });
+      sheet = new InteractiveLightConfig({ target });
       InteractiveLightConfig.#instances.set(key, sheet);
     }
     return sheet;
   }
 
   /**
+   * Back-compat factory used by the actor-template editing entry points
+   * (source actor config sheets, container views). Equivalent to
+   * `forTarget(actor)`.
+   *
+   * @param {Actor} actor
+   * @returns {InteractiveLightConfig}
+   */
+  static forActor(actor) {
+    return InteractiveLightConfig.forTarget(actor);
+  }
+
+  /**
    * @param {object} options
-   * @param {Actor} options.actor - The interactive actor whose light this form edits.
+   * @param {Actor|Item} [options.target] - The interactive actor or inventory item whose light this form edits.
+   * @param {Actor}      [options.actor]  - Back-compat alias for `target` when the caller is the actor-only path.
    */
   constructor(options = {}) {
     super(options);
-    /** @type {Actor} */
-    this.actor = options.actor;
+    /** @type {Actor|Item} */
+    this.target = options.target ?? options.actor;
+  }
+
+  /**
+   * True when this form is editing an Item's per-item snapshot rather than an
+   * Actor template. Uses `documentName` (a static field exposed on every
+   * Foundry Document subclass) so detection is system-agnostic — any system's
+   * Item subclass returns "Item" without depending on CONFIG.Item.documentClass
+   * identity.
+   */
+  get isItemTarget() {
+    return (this.target?.documentName ?? this.target?.constructor?.documentName) === "Item";
+  }
+
+  /**
+   * Read the current light data from the appropriate location based on
+   * target type. Coerces a null/undefined snapshot into `{}` so the form
+   * template binds cleanly on items that were picked up before light data
+   * was first configured.
+   *
+   * @returns {{ light: object, active: boolean }}
+   */
+  #readLight() {
+    const adapter = getAdapter();
+    const data = this.isItemTarget
+      ? adapter.getItemCarriedLightData(this.target)
+      : adapter.getInteractiveLightData(this.target);
+    return { light: data.light ?? {}, active: !!data.active };
+  }
+
+  /**
+   * Persist a partial light update to the correct location for the target
+   * type — actor `system.emittedLight` (template) or item flag snapshot.
+   *
+   * @param {{ light?: object, active?: boolean }} partial
+   */
+  #writeLight(partial) {
+    const adapter = getAdapter();
+    return this.isItemTarget
+      ? adapter.setItemCarriedLightData(this.target, partial)
+      : adapter.setInteractiveLightData(this.target, partial);
   }
 
   static DEFAULT_OPTIONS = {
@@ -82,14 +140,23 @@ export default class InteractiveLightConfig extends HandlebarsApplicationMixin(A
 
   /** @override */
   get title() {
-    return `${game.i18n.localize("INTERACTIVE_ITEMS.Light.Title")}: ${this.actor.name}`;
+    return `${game.i18n.localize("INTERACTIVE_ITEMS.Light.Title")}: ${this.target.name}`;
   }
 
   /** @override */
   async _prepareContext(options) {
     const ctx = await super._prepareContext(options);
-    const adapter = getAdapter();
-    const { light } = adapter.getInteractiveLightData(this.actor);
+    const { light } = this.#readLight();
+    dbg("light-config:prepareContext", {
+      targetUuid: this.target?.uuid,
+      targetName: this.target?.name,
+      targetDocName: this.target?.documentName ?? this.target?.constructor?.documentName,
+      isItemTarget: this.isItemTarget,
+      lightKeys: light ? Object.keys(light) : null,
+      lightColor: light?.color,
+      lightDim: light?.dim,
+      lightBright: light?.bright
+    });
 
     // The token light.hbs template references source.light.* and lightFields.*.
     // Crucially, lightFields MUST come from TokenDocument's embedded copy (where
@@ -133,10 +200,9 @@ export default class InteractiveLightConfig extends HandlebarsApplicationMixin(A
    * @this {InteractiveLightConfig}
    */
   static async #onSubmit(event, form, formData) {
-    const adapter = getAdapter();
     const expanded = foundry.utils.expandObject(formData.object);
     const newLight = expanded.light ?? {};
-    const { light: oldLight } = adapter.getInteractiveLightData(this.actor);
+    const { light: oldLight } = this.#readLight();
 
     const oldHasRadii = !!oldLight
       && ((oldLight.dim ?? 0) > 0 || (oldLight.bright ?? 0) > 0);
@@ -154,19 +220,20 @@ export default class InteractiveLightConfig extends HandlebarsApplicationMixin(A
     else if (!newHasRadii && oldHasRadii) partial.active = false;
 
     dbg("light-config:submit", {
-      actorId: this.actor.id,
+      targetUuid: this.target.uuid,
+      isItemTarget: this.isItemTarget,
       lightKeys: Object.keys(newLight),
       oldHasRadii, newHasRadii,
       activeChange: partial.active
     });
 
-    await adapter.setInteractiveLightData(this.actor, partial);
+    await this.#writeLight(partial);
   }
 
   /** @override */
   async close(options = {}) {
-    dbg("light-config:close", { actorId: this.actor?.id });
-    InteractiveLightConfig.#instances.delete(this.actor?.uuid);
+    dbg("light-config:close", { targetUuid: this.target?.uuid });
+    InteractiveLightConfig.#instances.delete(this.target?.uuid);
     return super.close(options);
   }
 }


### PR DESCRIPTION
## Summary

Editing the emitted-light properties of a picked-up interactive item from a player's inventory had no effect on the carrier's emitted light. The form opened on the source actor's template instead of the item's own snapshot, so writes landed on `actor.system.emittedLight` while the carried-light pipeline kept reading the stale `item.flags["pick-up-stix"].tokenState.system.emittedLight` snapshot.

Two things were responsible:

1. Right-click → Edit on a picked-up interactive item was overridden in `_injectItemContextMenuEntries` to open the source actor's interactive config sheet (`actor.sheet.renderConfig()`) instead of the item's own sheet. The lightbulb on that config sheet targets the actor template.
2. `InteractiveLightConfig` only knew how to read/write an actor's `system.emittedLight`. Even reaching it from an item sheet would have written to the actor.

## Changes

- `scripts/pick-up-stix.mjs`
  - Drop the dnd5e `DND5E.ContextMenuActionEdit` override so picked-up items open their own native sheet, where the existing header injection (open/lock/identify/light/configure) still applies.
  - Generalize the header lightbulb target: when the rendered item carries `flags["pick-up-stix"].tokenState`, route the lightbulb at the item; otherwise (source actor's own embedded item sheet) fall back to the source actor for template editing.
  - Use `documentName` instead of `instanceof CONFIG.Item.documentClass` for the item-vs-actor branch so the check stays system-agnostic (dnd5e, pf2e, generic).
  - Light-related `dbg()` traces to help diagnose future routing issues.
- `scripts/sheets/InteractiveLightConfig.mjs`
  - Accept either an Actor or an Item as the form `target`. Cache key, title, read, and write all dispatch by target type.
  - Add `forTarget(target)` factory; `forActor(actor)` becomes a thin back-compat wrapper used by every existing entry point (source actor's config sheets, generic container view, etc.).
- `scripts/adapter/SystemAdapter.mjs`
  - Add `setItemCarriedLightData(item, partial)` mirror of `setInteractiveLightData` that writes to `flags["pick-up-stix"].tokenState.system.{emittedLight,lightActive}`. Uniform across systems — no adapter override required.

## Behavior after the fix

- **Canvas token → cog → header lightbulb** (unchanged) — edits the synthetic actor's `system.emittedLight`; `_syncPlacedTokensLight` updates `tokenDoc.light` so the placed token reflects the new color.
- **Pickup** (unchanged) — `stampInteractiveIdentity` snapshots the synthetic actor's current `system.emittedLight` onto the item's `tokenState.system.emittedLight`.
- **Inventory item → right-click Edit → header lightbulb** (fixed) — opens `InteractiveLightConfig` targeted at the item; submits write to `flags["pick-up-stix"].tokenState.system.{emittedLight,lightActive}`; the existing `updateItem` hook in `canvas/carriedLights.mjs` reinitializes the synthetic source on the carrier and the player's emission refreshes in real time.
- **Source actor template editing** — still reachable by opening the source actor from the Actors directory; its config sheet's lightbulb continues to edit the actor template.

Matches the existing snapshot-at-pickup convention already documented in `_syncPlacedTokensLight` (picked-up items and already-placed tokens are independent snapshots — edits to the source actor template do not propagate to existing copies).