### PR TITLE
fix(hud): close token HUD on other clients when an item is picked up

### DIFF
--- a/scripts/socket/SocketHandler.mjs
+++ b/scripts/socket/SocketHandler.mjs
@@ -9,7 +9,14 @@ const SOCKET_NAME = "module.pick-up-stix";
 export function registerSocket() {
   game.socket.on(SOCKET_NAME, async (payload) => {
     dbg("socket:received", { action: payload.action, data: payload.data, isGM: game.user.isGM });
-    // Only the active GM processes socket requests
+
+    // Broadcast actions handled by every client (not just the GM).
+    if (payload.action === "closeTokenHud") {
+      closeTokenHudIfMatching(payload.data?.sceneId, payload.data?.tokenId);
+      return;
+    }
+
+    // Only the active GM processes the remaining socket requests
     if (!game.user.isGM) {
       dbg("socket:received", "not GM, ignoring socket event");
       return;
@@ -79,4 +86,16 @@ export function registerSocket() {
 export function emitSocketEvent(action, data) {
   dbg("socket:emit", { action, data });
   game.socket.emit(SOCKET_NAME, { action, data });
+}
+
+// Close the Token HUD on this client if it's currently bound to the given
+// scene/token. `game.socket.emit` does not echo to the sender, so the emitter
+// must also invoke this directly when it wants its own HUD dismissed.
+export function closeTokenHudIfMatching(sceneId, tokenId) {
+  const hud = canvas?.tokens?.hud;
+  const hudToken = hud?.object;
+  if (hud?.rendered && hudToken?.document?.id === tokenId && hudToken?.scene?.id === sceneId) {
+    dbg("socket:closeTokenHud", "closing HUD on this client", { sceneId, tokenId });
+    hud.clear();
+  }
 }

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -1,6 +1,7 @@
 import { getTokenActor, isInteractiveActor } from "../utils/actorHelpers.mjs";
 import { getAdapter } from "../adapter/index.mjs";
 import { dispatchGM } from "../utils/gmDispatch.mjs";
+import { emitSocketEvent, closeTokenHudIfMatching } from "../socket/SocketHandler.mjs";
 import { notifyItemAction, notifyTransferError } from "../utils/notify.mjs";
 import { validateContainerAccess, validateItemAccess } from "../utils/containerAccess.mjs";
 import { dbg } from "../utils/debugLog.mjs";
@@ -91,6 +92,12 @@ function getPlayerPositionOverride(tokenId) {
  */
 export async function pickupItem(sceneId, tokenId, itemId, targetActorId, quantity = null) {
   dbg("xfer:pickupItem", { sceneId, tokenId, itemId, targetActorId, quantity });
+  // Dismiss any open Token HUD bound to this token on every client — pickup
+  // mutates or deletes the source so a stale HUD would lie. The emitter does
+  // not receive its own broadcast echo, so close locally as well (matters when
+  // a player triggers pickup and the GM has the same HUD open).
+  emitSocketEvent("closeTokenHud", { sceneId, tokenId });
+  closeTokenHudIfMatching(sceneId, tokenId);
   const result = getTokenActor(sceneId, tokenId);
   const targetActor = game.actors.get(targetActorId);
 


### PR DESCRIPTION
## Summary
- Broadcast a `closeTokenHud` socket event from `pickupItem` so every client viewing the source token dismisses its open Token HUD.
- `pickupItem` runs on the active GM regardless of who initiated, and `game.socket.emit` does not echo to the sender, so the emitter also calls a new shared helper `closeTokenHudIfMatching` locally — this covers the case where a player triggers pickup and the GM has the same HUD open.
- Backport of #36 to release/2.0.