### PR TITLE
fix(vendor): FA6-compatible shop-visibility icon for Foundry v13

### DIFF
--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -288,7 +288,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
       const cell = document.createElement("div");
       cell.className = "item-detail ii-row-controls-cell pus-shop-toggle-cell";
       cell.appendChild(createRowControl({
-        iconClass: "fa-solid fa-box-arrow-down-arrow-up",
+        iconClass: "fa-solid fa-store",
         titleKey: "INTERACTIVE_ITEMS.Vendor.ToggleShopVisible",
         extraClass: "pick-up-stix-shop-toggle",
         active: visible,
@@ -331,7 +331,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     const cell = document.createElement("div");
     cell.className = "ii-row-controls-cell pus-shop-toggle-cell";
     cell.appendChild(createRowControl({
-      iconClass: "fa-solid fa-box-arrow-down-arrow-up",
+      iconClass: "fa-solid fa-store",
       titleKey: "INTERACTIVE_ITEMS.Vendor.ToggleAllShop",
       extraClass: "pick-up-stix-shop-toggle",
       active: allVisible,

--- a/templates/vendor/shop.hbs
+++ b/templates/vendor/shop.hbs
@@ -46,7 +46,7 @@
         <a class="ii-row-control shop-toggle {{#if this.shopVisible}}active{{/if}}"
            data-action="toggleShopVisible"
            data-tooltip="{{ localize "INTERACTIVE_ITEMS.Vendor.ToggleShopVisible" }}">
-          <i class="fa-solid fa-box-arrow-down-arrow-up"></i>
+          <i class="fa-solid fa-store"></i>
         </a>
         {{else}}
         <span class="shop-toggle-empty"></span>


### PR DESCRIPTION
## Problem

On **Foundry v13**, the GM's shop-visibility toggle was invisible on the vendor's Inventory tab (and Shop-tab rows) — the control was present in the DOM but rendered as a blank glyph.

## Root cause

Foundry **v13 ships Font Awesome 6**; **v14 ships Font Awesome 7**. The icon used (`fa-box-arrow-down-arrow-up`) is **FA7-only**, so it doesn't exist in FA6 and painted nothing on v13. dnd5e's own (older) icons in the same rows still rendered, which is why only our toggle looked missing.

## Fix

Swap the shop-visibility icon to `fa-store`, which:
- exists in both FA6 and FA7 (works on v13 and v14),
- is distinct from the cart toggle (`fa-basket-shopping`) and buy button (`fa-coins`),
- matches the Shop-tab icon thematically.