### PR TITLE
feat(vendor): only stack consumables when purchasing multiples

### DIFF
--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -76,6 +76,21 @@ export default class SystemAdapter {
   isPhysicalItem(item) { _abstract("isPhysicalItem"); }
 
   /**
+   * Whether purchasing multiple of `item` should keep them as a single stack
+   * (quantity N) rather than splitting into N separate documents of quantity 1.
+   *
+   * Default: `true` — preserve the legacy "one stack" behavior for any system
+   * without a specific opinion. The dnd5e adapter overrides this so only
+   * consumables stack; every other item type splits on purchase.
+   *
+   * @param {Item} _item
+   * @returns {boolean}
+   */
+  stacksOnPurchase(_item) {
+    return true;
+  }
+
+  /**
    * Read the current quantity (stack size) of a physical item. Returns 1
    * for items that don't have a quantity field (e.g. spells, features).
    *

--- a/scripts/adapter/dnd5e/purchase.mjs
+++ b/scripts/adapter/dnd5e/purchase.mjs
@@ -109,6 +109,18 @@ export const Dnd5ePurchase = {
     return true;
   },
 
+  /**
+   * Only consumables stack when purchased in bulk; every other dnd5e item type
+   * (weapon, equipment, tool, container, loot) splits into separate qty-1
+   * documents so the buyer receives distinct inventory entries.
+   *
+   * @param {Item} item
+   * @returns {boolean}
+   */
+  stacksOnPurchase(item) {
+    return item?.type === "consumable";
+  },
+
   async creditVendorCp(vendor, cp) {
     const currency = foundry.utils.deepClone(vendor.system?.currency ?? {});
     for ( const [denom, n] of Object.entries(coinsFromCp(cp)) ) currency[denom] = (currency[denom] ?? 0) + n;

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -18,6 +18,38 @@ function stripEquipmentState(itemData) {
   delete itemData.system.prepared;
 }
 
+/**
+ * Build the inventory item-data to create on a buyer for `qty` units of a purchased `item`.
+ *
+ * Consumables (per `adapter.stacksOnPurchase`) land as a single stack of `qty`; every other
+ * item type splits into `qty` separate documents of quantity 1, so non-stacking gear arrives
+ * as distinct inventory entries rather than one fictitious stack. Notification copy is
+ * unaffected — callers still report the aggregate qty per distinct item.
+ *
+ * @param {Item} item              - the vendor's source item.
+ * @param {number} qty             - units purchased (already clamped to stock by the caller).
+ * @param {object} adapter         - the active system adapter.
+ * @returns {object[]} one or more plain item-data objects ready for createDocuments.
+ */
+function buildPurchasedItemData(item, qty, adapter) {
+  const base = item.toObject();
+  delete base._id;
+  stripEquipmentState(base);
+
+  if ( adapter.stacksOnPurchase(item) ) {
+    adapter.setItemDataQuantity(base, qty);
+    dbg("xfer:buildPurchasedItemData", "stacking (consumable)", { name: base.name, qty });
+    return [base];
+  }
+
+  dbg("xfer:buildPurchasedItemData", "splitting into qty-1 documents", { name: base.name, qty });
+  return Array.from({ length: qty }, () => {
+    const copy = foundry.utils.deepClone(base);
+    adapter.setItemDataQuantity(copy, 1);
+    return copy;
+  });
+}
+
 function stampInteractiveIdentity(itemData, actor, { embeddedItemData } = {}) {
   const descriptionValue = itemData.system?.description?.value ?? "";
 
@@ -621,16 +653,11 @@ export async function purchaseItem(vendorActorId, itemId, buyerActorId, quantity
     return false;
   }
 
-  // Add the stack to the buyer — this create renders the buyer's OWN sheet once, reflecting the
-  // already-debited gold + the new item (so an open character sheet stays current). It does not
-  // touch the vendor sheet. The vendor stock decrement is render-suppressed; the vendor credit
-  // below is the vendor sheet's single render.
-  const data = item.toObject();
-  delete data._id;
-  stripEquipmentState(data);
-  adapter.setItemDataQuantity(data, qty);
-  dbg("xfer:purchaseItem", "creating item on buyer", { name: data.name, qty, buyer: buyer.id });
-  await CONFIG.Item.documentClass.createDocuments([data], { parent: buyer });
+  // Add the purchased item(s) to the buyer. Consumables land as one stack of `qty`; other types
+  // split into `qty` qty-1 documents. This create renders the buyer's OWN sheet once.
+  const toCreate = buildPurchasedItemData(item, qty, adapter);
+  dbg("xfer:purchaseItem", "creating item(s) on buyer", { name: item.name, qty, docs: toCreate.length, buyer: buyer.id });
+  await CONFIG.Item.documentClass.createDocuments(toCreate, { parent: buyer });
   await decrementOrDeleteItem(item, qty, { render: false });
 
   // Credit the vendor LAST and let it render → exactly one re-render on every client.
@@ -701,11 +728,7 @@ export async function purchaseCart(vendorActorId, cartItems, buyerActorId) {
   const toUpdate = [];
   const toDelete = [];
   for ( const { item, qty } of resolved ) {
-    const data = item.toObject();
-    delete data._id;
-    stripEquipmentState(data);
-    adapter.setItemDataQuantity(data, qty);
-    toCreate.push(data);
+    toCreate.push(...buildPurchasedItemData(item, qty, adapter));
 
     const stock = adapter.getItemQuantity(item);
     if ( qty >= stock ) {


### PR DESCRIPTION
## Summary

- Non-consumable items (weapons, equipment, tools, containers, loot) bought in quantities > 1 now arrive in the buyer's inventory as separate qty-1 documents instead of a single stack
- Consumables continue to stack as before (one entry with quantity N)
- Notifications, currency math, vendor stock decrement, and render-suppression are unchanged

## Implementation

- Added `stacksOnPurchase(item)` predicate to the `SystemAdapter` base class (default `true` — legacy single-stack for any system without an opinion)
- dnd5e adapter (`Dnd5ePurchase` mixin) overrides it to return `item.type === "consumable"`
- Added a shared `buildPurchasedItemData(item, qty, adapter)` helper in `ItemTransfer.mjs` that both `purchaseItem` and `purchaseCart` route through — consumables get one stack of N, everything else gets N qty-1 documents