### PR TITLE
ci: publish to Foundry VTT API after each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,17 +53,18 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # A tag-push event carries no branch name, so resolve the branch the tag was
-          # created on from git. --points-at matches only branches whose TIP is exactly the
-          # tagged commit (precise); --contains would also match every ancestor branch
-          # (e.g. develop, when a release/* branch was cut from it) and head -1 would pick
-          # the wrong one alphabetically. When more than one branch shares the tagged tip,
-          # prefer a release/* branch, since releases are cut from those.
-          POINTS=$(git branch -r --points-at "$TAG" | grep -v HEAD | sed 's|origin/||' | xargs -n1)
-          SOURCE_BRANCH=$(echo "$POINTS" | grep '^release/' | head -1)
-          [ -z "$SOURCE_BRANCH" ] && SOURCE_BRANCH=$(echo "$POINTS" | head -1)
-          [ -z "$SOURCE_BRANCH" ] && SOURCE_BRANCH="master"
-          echo "Resolved source branch: $SOURCE_BRANCH"
+          # Prefer release/* branches; fall back to any non-mainline branch; then master.
+          BRANCHES=$(git branch -r --contains "$TAG" | grep -v HEAD | sed 's|[[:space:]]*origin/||')
+          SOURCE_BRANCH=$(echo "$BRANCHES" | grep '^release/' | head -1)
+          if [ -z "$SOURCE_BRANCH" ]; then
+            SOURCE_BRANCH=$(echo "$BRANCHES" | grep -v '^develop$\|^main$\|^master$' | head -1)
+          fi
+          if [ -z "$SOURCE_BRANCH" ]; then
+            SOURCE_BRANCH=$(echo "$BRANCHES" | head -1)
+          fi
+          if [ -z "$SOURCE_BRANCH" ]; then
+            SOURCE_BRANCH="master"
+          fi
           cp module.json /tmp/module.json
           git checkout "$SOURCE_BRANCH"
           cp /tmp/module.json module.json
@@ -72,3 +73,74 @@ jobs:
           git push origin "$SOURCE_BRANCH"
           git tag -f "$TAG" HEAD
           git push origin "refs/tags/$TAG" --force
+
+      - name: Publish to Foundry VTT (dry-run, then release)
+        env:
+          FOUNDRY_TOKEN: ${{ secrets.FOUNDRY_PACKAGE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FOUNDRY_TOKEN:-}" ]; then
+            echo "::error::FOUNDRY_PACKAGE_RELEASE_TOKEN secret is not set"
+            exit 1
+          fi
+
+          API="https://foundryvtt.com/_api/packages/release_version/"
+          PKG_ID=$(jq -r '.id' module.json)
+          MIN=$(jq -r '.compatibility.minimum // ""' module.json)
+          VERIFIED=$(jq -r '.compatibility.verified // ""' module.json)
+          MAX=$(jq -r '.compatibility.maximum // ""' module.json)
+          # Per-release manifest = module.json at the tag (now points to the commit
+          # with the bumped version/download, after the retag step above).
+          MANIFEST_URL="https://raw.githubusercontent.com/kamcknig/pick-up-stix/refs/tags/$TAG/module.json"
+          NOTES_URL="https://github.com/kamcknig/pick-up-stix/releases/tag/$TAG"
+
+          # raw.githubusercontent.com may briefly serve a stale ref; wait until the
+          # tagged manifest reports the version we're releasing before submitting.
+          echo "Waiting for $MANIFEST_URL to report version $VERSION..."
+          for i in $(seq 1 12); do
+            remote_version=$(curl -fsSL "$MANIFEST_URL" 2>/dev/null | jq -r '.version // ""' 2>/dev/null || echo "")
+            [ "$remote_version" = "$VERSION" ] && { echo "Manifest is live (version $remote_version)."; break; }
+            echo "Attempt $i: got '${remote_version:-<none>}', expected '$VERSION'; retrying in 10s..."
+            sleep 10
+            [ "$i" = "12" ] && { echo "::error::Tagged manifest never reported version $VERSION."; exit 1; }
+          done
+
+          # Build the request body; $1 is the boolean value for "dry-run".
+          build_payload() {
+            jq -n \
+              --arg id "$PKG_ID" \
+              --argjson dryrun "$1" \
+              --arg version "$VERSION" \
+              --arg manifest "$MANIFEST_URL" \
+              --arg notes "$NOTES_URL" \
+              --arg min "$MIN" --arg verified "$VERIFIED" --arg max "$MAX" \
+              '{id: $id, "dry-run": $dryrun, release: {version: $version, manifest: $manifest, notes: $notes, compatibility: {minimum: $min, verified: $verified, maximum: $max}}}'
+          }
+
+          # POST a release request; $1 is the "dry-run" boolean. Returns non-zero
+          # unless the API responds 200 with status "success".
+          post_release() {
+            local body http status
+            body=$(build_payload "$1")
+            http=$(curl -sS -o /tmp/fvtt-resp.json -w '%{http_code}' -X POST "$API" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: $FOUNDRY_TOKEN" \
+              -d "$body")
+            echo "HTTP $http"
+            cat /tmp/fvtt-resp.json; echo
+            status=$(jq -r '.status // ""' /tmp/fvtt-resp.json)
+            [ "$http" = "200" ] && [ "$status" = "success" ]
+          }
+
+          echo "Validating release $VERSION via dry-run..."
+          if ! post_release true; then
+            echo "::error::Foundry dry-run failed; not publishing."
+            exit 1
+          fi
+
+          echo "Dry-run succeeded. Publishing release $VERSION to Foundry..."
+          if ! post_release false; then
+            echo "::error::Foundry release failed."
+            exit 1
+          fi
+          echo "Foundry release published."


### PR DESCRIPTION
## Summary

- Adds a **Foundry VTT package publish** step to the release workflow, mirroring the `combat-spell-timer` repo's approach
- Dry-run first — only proceeds to the real publish if the dry-run reports success
- Waits for `raw.githubusercontent.com` to serve the newly tagged `module.json` at the correct version before submitting (up to 12 × 10 s retries)
- Reads `compatibility.minimum/verified/maximum` directly from `module.json` — no hardcoding
- Requires the `FOUNDRY_PACKAGE_RELEASE_TOKEN` secret to be set on the repo; fails with a clear error if it's missing

Also aligns the **source-branch resolution** in the "Commit updated module.json" step to use `--contains` with explicit mainline-branch filtering (the pattern from `combat-spell-timer`), which handles release branches cut from develop more robustly than the previous `--points-at` approach.