### PR TITLE
feat(vendor): Favor pricing and slider UI

### DIFF
--- a/docs/vendor-flags.md
+++ b/docs/vendor-flags.md
@@ -1,0 +1,172 @@
+# Vendor Actor Flags
+
+Flags are stored on the vendor **actor** under the `pick-up-stix` scope. For linked
+tokens (the default) the flag lives on the base actor; for unlinked tokens it lives on
+the token's own delta — Foundry's standard routing applies.
+
+```js
+// Read
+actor.getFlag("pick-up-stix", "<key>");
+
+// Write
+await actor.setFlag("pick-up-stix", "<key>", value);
+```
+
+---
+
+## `favor`
+
+How favourably this vendor prices for the party.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Range** | `-5` to `5` |
+| **Default** | `0` (absent flag is treated as 0) |
+| **Introduced** | 4.0.6 |
+
+Each point shifts the sell price by [`favorFactor`](#favorfactor) percent:
+- Positive → discount (e.g. `+3` with factor `4` → 12% off)
+- Negative → surcharge (e.g. `-2` with factor `4` → 8% on top)
+- `0` → no change
+
+Fractions are always rounded **up** at the copper-piece level in the vendor's favour.
+
+```js
+// Give players a 12% discount
+await actor.setFlag("pick-up-stix", "favor", 3);
+
+// Make the vendor hostile (+20% surcharge at default factor)
+await actor.setFlag("pick-up-stix", "favor", -5);
+```
+
+---
+
+## `favorFactor`
+
+The percentage applied per Favor point.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Range** | `1` to `20` |
+| **Default** | `4` (absent flag is treated as 4) |
+| **Introduced** | 4.0.6 |
+
+The sell-price multiplier is `1 - (favor × favorFactor) / 100`.
+
+| `favor` | `favorFactor` | Multiplier |
+|---------|--------------|------------|
+| +5 | 4 | 0.80 (−20%) |
+| −5 | 4 | 1.20 (+20%) |
+| +5 | 10 | 0.50 (−50%) |
+| −3 | 6 | 1.18 (+18%) |
+
+```js
+// 10% per Favor point instead of the default 4%
+await actor.setFlag("pick-up-stix", "favorFactor", 10);
+```
+
+---
+
+## Utility helpers
+
+Exported from `scripts/utils/vendorPricing.mjs`.
+
+```js
+import {
+  getVendorFavor,
+  getVendorFavorFactor,
+  favorMultiplier,
+  vendorPriceMultiplier,
+} from "./scripts/utils/vendorPricing.mjs";
+```
+
+---
+
+### `getVendorFavor(vendor)`
+
+Reads the `favor` flag from a vendor actor and returns it clamped to
+`[FAVOR_MIN, FAVOR_MAX]`. Returns `0` if the flag is absent or non-numeric.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `vendor` | `Actor\|null` | The vendor actor (base or synthetic token actor) |
+
+**Returns** `number` — integer in `[-5, 5]`
+
+```js
+const favor = getVendorFavor(actor);  // e.g. 3
+```
+
+---
+
+### `getVendorFavorFactor(vendor)`
+
+Reads the `favorFactor` flag from a vendor actor and returns it clamped to
+`[FAVOR_FACTOR_MIN, FAVOR_FACTOR_MAX]`. Returns `FAVOR_FACTOR_DEFAULT` (`4`) if the
+flag is absent or non-numeric.
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `vendor` | `Actor\|null` | The vendor actor (base or synthetic token actor) |
+
+**Returns** `number` — integer in `[1, 20]`
+
+```js
+const factor = getVendorFavorFactor(actor);  // e.g. 4
+```
+
+---
+
+### `favorMultiplier(favor, factor?)`
+
+Computes the raw price multiplier from a Favor value and factor:
+`1 - (favor × factor) / 100`.
+
+Does **not** read any flags — pass pre-read values if you already have them, or use
+`vendorPriceMultiplier` to read from a vendor actor directly.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `favor` | `number` | — | Favor value (typically `[-5, 5]`) |
+| `factor` | `number` | `4` | Percentage per Favor point (typically `[1, 20]`) |
+
+**Returns** `number` — multiplier (e.g. `0.80` for −20%, `1.20` for +20%)
+
+```js
+favorMultiplier(5, 4);   // 0.80  (20% discount)
+favorMultiplier(-5, 4);  // 1.20  (20% surcharge)
+favorMultiplier(0, 4);   // 1.00  (no change)
+favorMultiplier(3, 10);  // 0.70  (30% discount)
+```
+
+---
+
+### `vendorPriceMultiplier(vendor)`
+
+Convenience wrapper — reads both `favor` and `favorFactor` flags from the vendor
+actor, clamps them, and returns the resulting multiplier. Equivalent to:
+
+```js
+favorMultiplier(getVendorFavor(vendor), getVendorFavorFactor(vendor))
+```
+
+**Parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `vendor` | `Actor\|null` | The vendor actor (base or synthetic token actor) |
+
+**Returns** `number` — price multiplier to apply to the item's base price
+
+```js
+const multiplier = vendorPriceMultiplier(actor);
+const adjustedPrice = basePrice * multiplier;
+```

--- a/lang/en.json
+++ b/lang/en.json
@@ -39,6 +39,26 @@
       "GenericPickupItemType": {
         "Name": "Generic Mode — Pickup Item Type",
         "Hint": "(Generic mode only) The item type used when a player picks up an interactive object. Set automatically on first launch when a likely candidate is detected; otherwise prompted via dialog. Change here if detection picked the wrong type."
+      },
+      "VendorFavorMin": {
+        "Name": "Vendor Favor — Minimum",
+        "Hint": "The lowest Favor value a vendor can be set to. Default: -5."
+      },
+      "VendorFavorMax": {
+        "Name": "Vendor Favor — Maximum",
+        "Hint": "The highest Favor value a vendor can be set to. Default: 5."
+      },
+      "VendorFavorFactorMin": {
+        "Name": "Vendor Favor Factor — Minimum",
+        "Hint": "The lowest Favor Factor (% per Favor point) a vendor can be set to. Default: 1."
+      },
+      "VendorFavorFactorMax": {
+        "Name": "Vendor Favor Factor — Maximum",
+        "Hint": "The highest Favor Factor (% per Favor point) a vendor can be set to. Default: 20."
+      },
+      "VendorFavorFactorDefault": {
+        "Name": "Vendor Favor Factor — Default",
+        "Hint": "The Favor Factor applied when a vendor has no Factor set. Default: 4."
       }
     },
     "FolderToggle": {
@@ -282,6 +302,10 @@
       "CartQty": "Quantity to buy",
       "AllShop": "All",
       "ToggleAllShop": "Add all to / remove all from shop",
+      "Favor": "Favor",
+      "FavorTooltip": "How favourably this vendor prices for the party. Positive is a discount, negative a surcharge.",
+      "FavorFactor": "Favor Factor",
+      "FavorFactorTooltip": "The percentage applied per Favor point. Default 4 means each Favor point shifts the price by 4%.",
       "Queue": {
         "SwitchTitle": "Switch shops?",
         "SwitchPrompt": "You're already in line at {from}. Joining {to} will leave {from}'s queue.",

--- a/scripts/adapter/dnd5e/purchase.mjs
+++ b/scripts/adapter/dnd5e/purchase.mjs
@@ -1,4 +1,5 @@
 import { dbg } from "../../utils/debugLog.mjs";
+import { vendorPriceMultiplier } from "../../utils/vendorPricing.mjs";
 
 /**
  * Given an exact copper-piece total, return the coarsest whole-coin denomination that
@@ -28,13 +29,13 @@ function denomFromCp(cp) {
  * @param {number} quantity
  * @returns {{ amount:number, denomination:string, cp:number }}
  */
-function chargeAmount(price, quantity) {
+function chargeAmount(price, quantity, multiplier = 1) {
   const conv = CONFIG.DND5E.currencies?.[price.denomination]?.conversion;
   if (!price.value || !conv) return { amount: 0, denomination: "gp", cp: 0 };
-  // Exact value in copper, rounding any sub-copper fraction UP (always favours the vendor).
+  // Exact value in copper, Favor-adjusted, rounding any sub-copper fraction UP.
   // Inner round to 1e-4 first kills float noise so a whole-cp value (e.g. 10.2 gp = 1020 cp)
   // doesn't get ceil'd up by a 1e-13 artifact.
-  const rawCp = (price.value * quantity / conv) * 100;
+  const rawCp = (price.value * quantity / conv) * 100 * multiplier;
   const cp = Math.ceil(Math.round(rawCp * 1e4) / 1e4);
   if (cp <= 0) return { amount: 0, denomination: "gp", cp: 0 };
   const { amount, denomination } = denomFromCp(cp);
@@ -68,7 +69,8 @@ export const Dnd5ePurchase = {
   },
 
   canAfford(buyer, item, quantity = 1) {
-    const { amount, denomination } = chargeAmount(this.getItemPrice(item), quantity);
+    const mult = vendorPriceMultiplier(item?.parent);
+    const { amount, denomination } = chargeAmount(this.getItemPrice(item), quantity, mult);
     if (amount <= 0) return true;                     // free
     if (!buyer) return false;
     const { CurrencyManager } = game.dnd5e.applications;
@@ -79,7 +81,7 @@ export const Dnd5ePurchase = {
   },
 
   getItemChargeCp(item, quantity = 1) {
-    return chargeAmount(this.getItemPrice(item), quantity).cp;
+    return chargeAmount(this.getItemPrice(item), quantity, vendorPriceMultiplier(item?.parent)).cp;
   },
 
   getActorWealthCp(actor) {

--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -1,14 +1,15 @@
 import { getAdapter } from "../index.mjs";
 import { dbg } from "../../utils/debugLog.mjs";
+import { getVendorFavor, getVendorFavorFactor, favorMultiplier } from "../../utils/vendorPricing.mjs";
 
 /* ---------- dnd5e display helpers (system-specific; kept in the dnd5e adapter) ---------- */
 
-/** Price as { display: ceil(gp), exact: gp, denomination }. */
-export function priceInGP(item) {
+/** Price as { display: ceil(gp), exact: gp, denomination }, Favor-adjusted. */
+export function priceInGP(item, favor = 0, factor = 4) {
   const { value, denomination } = item.system?.price ?? {};
   const conv = CONFIG.DND5E.currencies?.[denomination]?.conversion;
   if (!value || !conv) return { display: 0, exact: 0, denomination: denomination ?? "gp" };
-  const exact = value / conv;                       // 250 cp / 100 = 2.5 gp
+  const exact = (value / conv) * favorMultiplier(favor, factor);   // gp, Favor-adjusted
   return { display: Math.ceil(exact), exact, denomination };
 }
 
@@ -76,13 +77,20 @@ const COLUMNS = {
   price: {
     id: "price", header: "INTERACTIVE_ITEMS.Vendor.Col.Price", align: "end",
     cell(item) {
-      const { display, exact } = priceInGP(item);
+      const favor = getVendorFavor(item.parent);
+      const factor = getVendorFavorFactor(item.parent);
+      const base = priceInGP(item, 0, factor);        // unmodified item value
+      const sell = priceInGP(item, favor, factor);    // what the buyer pays (Favor-adjusted)
       const gp = game.i18n.localize("DND5E.CurrencyAbbrGP");
-      const fractional = exact !== Math.trunc(exact);
+      const fractional = sell.exact !== Math.trunc(sell.exact);
+      // Tint only priced items whose cost Favor actually shifts: cheaper = green, pricier = red.
+      let classes = "pus-price";
+      if (base.display > 0 && favor > 0) classes += " pus-price-down";
+      else if (base.display > 0 && favor < 0) classes += " pus-price-up";
       return {
-        text: `${display} ${gp}`,
-        tooltip: fractional ? `${Number(exact.toFixed(2))} ${gp}` : null,   // real price when not whole
-        classes: "pus-price"
+        text: `${sell.display} ${gp}`,
+        tooltip: fractional ? `${Number(sell.exact.toFixed(2))} ${gp}` : null,
+        classes
       };
     }
   }

--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -7,6 +7,7 @@ import { buildShop, DEFAULT_GROUPING } from "./shopGrouping.mjs";
 import { createRowControl } from "../../utils/domButtons.mjs";
 import { emitSocketEvent } from "../../socket/SocketHandler.mjs";
 import { getVendorQueue, findUserVendorQueues, promptVendorQueueSwitch } from "../../utils/vendorQueue.mjs";
+import { getVendorFavor, getVendorFavorFactor, getFavorMin, getFavorMax, getFavorFactorMin, getFavorFactorMax, getFavorFactorDefault } from "../../utils/vendorPricing.mjs";
 
 const NPCActorSheet = dnd5e.applications.actor.NPCActorSheet;
 
@@ -165,6 +166,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     this.#injectPortraitClip();                 // wrap the portrait so the figure masks at the frame
     this.#repositionEditToggle();               // move dnd5e's edit toggle next to the XP badge
     this.#repositionInitiativeDie();            // move initiative d20 above the vendor name (GM only)
+    this.#injectFavorControl();                 // Favor card replaces abilities on the Shop tab (GM)
     // Re-evaluate cart state and buy-button gating after core _toggleDisabled has run.
     // #refreshCart owns the disabled state for both basket toggles and buy buttons.
     this.#refreshCart();
@@ -238,6 +240,77 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
   }
 
   /**
+   * GM/owner npc-header only: inject a "Favor" card as a sibling of dnd5e's abilities
+   * card, then show whichever fits the active tab. The slider persists
+   * flags.pick-up-stix.favor on release (change), which re-renders the sheet and
+   * re-prices the shop (Phase 1). Idempotent — re-runs each render since dnd5e
+   * rebuilds the header part. Players render the storefront header (no abilities card),
+   * so this bails for them. (Foundry v13 + v14; abilities markup identical across both.)
+   */
+  #injectFavorControl() {
+    const abilities = this.element.querySelector(".sheet-header .ability-scores");
+    if ( !abilities ) return;   // not the GM npc-header, or dnd5e changed the layout
+    let favorCard = this.element.querySelector(".sheet-header .pus-vendor-favor");
+    if ( !favorCard ) {
+      const favor = getVendorFavor(this.actor);
+      const factor = getVendorFavorFactor(this.actor);
+      const sign = (v) => `${v > 0 ? "+" : ""}${v}`;
+      dbg("vendorSheet:injectFavorControl", { vendor: this.actor.id, favor, factor });
+      favorCard = document.createElement("div");
+      favorCard.className = "middle pus-vendor-favor card flexrow";
+      favorCard.innerHTML = `
+        <div class="pus-favor-controls">
+          <div class="pus-favor-control">
+            <label class="pus-favor-label" data-tooltip="${game.i18n.localize("INTERACTIVE_ITEMS.Vendor.FavorTooltip")}">
+              ${game.i18n.localize("INTERACTIVE_ITEMS.Vendor.Favor")}
+            </label>
+            <div class="pus-favor-slider">
+              <input type="range" class="pus-favor-range" data-flag="favor" min="${getFavorMin()}" max="${getFavorMax()}" step="1" value="${favor}" />
+              <span class="pus-favor-value">${sign(favor)}</span>
+            </div>
+          </div>
+          <div class="pus-favor-control">
+            <label class="pus-favor-label" data-tooltip="${game.i18n.localize("INTERACTIVE_ITEMS.Vendor.FavorFactorTooltip")}">
+              ${game.i18n.localize("INTERACTIVE_ITEMS.Vendor.FavorFactor")}
+            </label>
+            <div class="pus-favor-slider">
+              <input type="range" class="pus-favor-range" data-flag="favorFactor" min="${getFavorFactorMin()}" max="${getFavorFactorMax()}" step="1" value="${factor}" />
+              <span class="pus-favor-value">${factor}%</span>
+            </div>
+          </div>
+        </div>`;
+      abilities.after(favorCard);
+      // Wire both sliders with a shared handler — data-flag drives which flag to write.
+      for ( const range of favorCard.querySelectorAll(".pus-favor-range") ) {
+        const valueEl = range.closest(".pus-favor-slider").querySelector(".pus-favor-value");
+        const isFavor = range.dataset.flag === "favor";
+        const fmt = isFavor ? (v) => sign(v) : (v) => `${v}%`;
+        range.addEventListener("input", () => { valueEl.textContent = fmt(Number(range.value)); });
+        range.addEventListener("change", async () => {
+          const raw = Math.round(Number(range.value) || 0);
+          const v = isFavor
+            ? Math.max(getFavorMin(), Math.min(getFavorMax(), raw))
+            : Math.max(getFavorFactorMin(), Math.min(getFavorFactorMax(), raw || getFavorFactorDefault()));
+          dbg("vendorSheet:favorControlChange", { vendor: this.actor.id, flag: range.dataset.flag, value: v });
+          await this.actor.setFlag("pick-up-stix", range.dataset.flag, v);
+        });
+      }
+    }
+    this.#applyFavorTabVisibility(abilities, favorCard);
+  }
+
+  /** Show the Favor card on the Shop tab and the abilities card elsewhere (inline display
+   *  beats dnd5e's `.flexrow{display:flex}`). No-op when neither card is present. */
+  #applyFavorTabVisibility(abilities, favorCard) {
+    abilities ??= this.element.querySelector(".sheet-header .ability-scores");
+    favorCard ??= this.element.querySelector(".sheet-header .pus-vendor-favor");
+    if ( !abilities || !favorCard ) return;
+    const onShop = this.tabGroups.primary === "shop";
+    abilities.style.display = onShop ? "none" : "";
+    favorCard.style.display = onShop ? "" : "none";
+  }
+
+  /**
    * Re-evaluate subtitle truncation when a tab is shown. The GM's Shop tab is hidden
    * at first render (they land on an NPC tab), so the `_onRender` pass sees a zero-size
    * element and can't detect clipping; rerun once Shop becomes the active tab.
@@ -245,6 +318,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
   changeTab(tab, group, options) {
     super.changeTab(tab, group, options);
     if ( tab === "shop" ) this.#refreshSubtitleTooltips();
+    this.#applyFavorTabVisibility();            // swap abilities <-> Favor with the active tab
   }
 
   /**

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -195,6 +195,51 @@ Hooks.once("init", async () => {
     default: ""
   });
 
+  game.settings.register(MODULE_ID, "vendorFavorMin", {
+    name: "INTERACTIVE_ITEMS.Settings.VendorFavorMin.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorMin.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: -5
+  });
+
+  game.settings.register(MODULE_ID, "vendorFavorMax", {
+    name: "INTERACTIVE_ITEMS.Settings.VendorFavorMax.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorMax.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 5
+  });
+
+  game.settings.register(MODULE_ID, "vendorFavorFactorMin", {
+    name: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMin.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMin.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 1
+  });
+
+  game.settings.register(MODULE_ID, "vendorFavorFactorMax", {
+    name: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMax.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMax.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 20
+  });
+
+  game.settings.register(MODULE_ID, "vendorFavorFactorDefault", {
+    name: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorDefault.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorDefault.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 4
+  });
+
   // Hidden world setting that persists the install-tracker state (sent flag,
   // version, attempt count, last error). Managed entirely by installTracker.mjs.
   registerInstallTrackerSetting();

--- a/scripts/utils/vendorPricing.mjs
+++ b/scripts/utils/vendorPricing.mjs
@@ -1,0 +1,59 @@
+import { dbg } from "./debugLog.mjs";
+
+/**
+ * Vendor "Favor": how favourably a vendor prices for the party. Stored as the actor
+ * flag `flags.pick-up-stix.favor`. Each point shifts cost by FAVOR_STEP_PERCENT%:
+ * positive Favor discounts, negative Favor surcharges. Kept system-agnostic — the
+ * dnd5e adapter applies the multiplier to its own currency math.
+ */
+/** Hard-coded defaults — used as setting registration defaults and as fallbacks before `init`. */
+export const FAVOR_MIN = -5;
+export const FAVOR_MAX = 5;
+export const FAVOR_FACTOR_MIN = 1;
+export const FAVOR_FACTOR_MAX = 20;
+export const FAVOR_FACTOR_DEFAULT = 4;
+
+// Runtime setting readers — fall back to the constants when settings aren't available yet.
+const gs = (key, fallback) => { try { return game.settings.get("pick-up-stix", key); } catch { return fallback; } };
+
+/** Configured minimum Favor value (module setting `vendorFavorMin`, default −5). */
+export const getFavorMin = () => gs("vendorFavorMin", FAVOR_MIN);
+/** Configured maximum Favor value (module setting `vendorFavorMax`, default 5). */
+export const getFavorMax = () => gs("vendorFavorMax", FAVOR_MAX);
+/** Configured minimum Favor Factor (module setting `vendorFavorFactorMin`, default 1). */
+export const getFavorFactorMin = () => gs("vendorFavorFactorMin", FAVOR_FACTOR_MIN);
+/** Configured maximum Favor Factor (module setting `vendorFavorFactorMax`, default 20). */
+export const getFavorFactorMax = () => gs("vendorFavorFactorMax", FAVOR_FACTOR_MAX);
+/** Configured default Favor Factor (module setting `vendorFavorFactorDefault`, default 4). */
+export const getFavorFactorDefault = () => gs("vendorFavorFactorDefault", FAVOR_FACTOR_DEFAULT);
+
+/** A vendor's Favor, clamped to the configured [favorMin, favorMax]; absent / non-numeric → 0. */
+export function getVendorFavor(vendor) {
+  const raw = Number(vendor?.getFlag?.("pick-up-stix", "favor"));
+  if ( !Number.isFinite(raw) ) return 0;
+  return Math.max(getFavorMin(), Math.min(getFavorMax(), Math.round(raw)));
+}
+
+/** A vendor's Favor factor (% per point), clamped to [favorFactorMin, favorFactorMax]; absent → favorFactorDefault. */
+export function getVendorFavorFactor(vendor) {
+  const raw = Number(vendor?.getFlag?.("pick-up-stix", "favorFactor"));
+  if ( !Number.isFinite(raw) ) return getFavorFactorDefault();
+  return Math.max(getFavorFactorMin(), Math.min(getFavorFactorMax(), Math.round(raw)));
+}
+
+/**
+ * Cost multiplier for a Favor value: `1 - (favor * factor) / 100`.
+ * e.g. favor +5, factor 4 → 0.80 (20% off); favor -5, factor 4 → 1.20 (20% surcharge).
+ */
+export function favorMultiplier(favor, factor = getFavorFactorDefault()) {
+  return 1 - (favor * factor) / 100;
+}
+
+/** Convenience: the cost multiplier for a vendor actor (reads + clamps both flags). */
+export function vendorPriceMultiplier(vendor) {
+  const favor = getVendorFavor(vendor);
+  const factor = getVendorFavorFactor(vendor);
+  const m = favorMultiplier(favor, factor);
+  dbg("vendorPricing:multiplier", { vendor: vendor?.id, favor, factor, multiplier: m });
+  return m;
+}

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -930,3 +930,54 @@
   color: inherit;
   font-size: inherit;
 }
+
+/* Vendor Price column: Favor-adjusted sell price differs from the item's base value.
+   Up = costs more (red), down = costs less (green). */
+.vendor-sheet .shop-cell.pus-price-up { color: var(--dnd5e-color-maroon, #b9412f); }
+.vendor-sheet .shop-cell.pus-price-down { color: var(--dnd5e-color-green, #4b7d3a); }
+
+/* Favor card: occupies the abilities card's slot on the Shop tab. */
+.vendor-sheet .sheet-header .pus-vendor-favor {
+  align-items: center;
+  justify-content: flex-start;
+  padding: 6px 14px;
+  background: none;
+  box-shadow: none;
+  border: none;
+  width: 100%;
+}
+.vendor-sheet .pus-favor-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+.vendor-sheet .pus-favor-control {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  max-width: 200px;
+}
+.vendor-sheet .pus-favor-label {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: var(--font-size-12, 12px);
+}
+.vendor-sheet .pus-favor-slider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
+.vendor-sheet .pus-favor-range {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  box-shadow: none;
+}
+.vendor-sheet .pus-favor-value {
+  min-width: 2.5ch;
+  text-align: center;
+  font-weight: bold;
+}


### PR DESCRIPTION
Adds per-vendor Favor and Favor Factor controls to the dnd5e vendor sheet. Favor adjusts sell prices up or down; both bounds and the factor default are configurable via module settings.