### PR TITLE
feat(settings): settings UI overhaul

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -59,6 +59,16 @@
       "VendorFavorFactorDefault": {
         "Name": "Vendor Favor Factor — Default",
         "Hint": "The Favor Factor applied when a vendor has no Factor set. Default: 4."
+      },
+      "InteractiveItemSettingsMenu": {
+        "Name": "Interactive Item Settings",
+        "Hint": "Configure GM overrides, folder organisation, container images, range defaults, and drag behaviour.",
+        "Label": "Open Settings"
+      },
+      "VendorSettingsMenu": {
+        "Name": "Vendor Settings",
+        "Hint": "Configure the Favor bounds and Favor Factor range applied to vendor pricing.",
+        "Label": "Open Settings"
       }
     },
     "FolderToggle": {

--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -82,13 +82,16 @@ const COLUMNS = {
       const base = priceInGP(item, 0, factor);        // unmodified item value
       const sell = priceInGP(item, favor, factor);    // what the buyer pays (Favor-adjusted)
       const gp = game.i18n.localize("DND5E.CurrencyAbbrGP");
-      const fractional = sell.exact !== Math.trunc(sell.exact);
-      // Tint only priced items whose cost Favor actually shifts: cheaper = green, pricier = red.
+      const isNegative = sell.exact < 0;
+      const displayValue = Math.max(0, sell.display);
+      const fractional = !isNegative && sell.exact !== Math.trunc(sell.exact);
+      // Negative (clamped) prices shown purple for GM; else tint by Favor direction.
       let classes = "pus-price";
-      if (base.display > 0 && favor > 0) classes += " pus-price-down";
+      if (isNegative && game.user.isGM) classes += " pus-price-negative";
+      else if (base.display > 0 && favor > 0) classes += " pus-price-down";
       else if (base.display > 0 && favor < 0) classes += " pus-price-up";
       return {
-        text: `${sell.display} ${gp}`,
+        text: `${displayValue} ${gp}`,
         tooltip: fractional ? `${Number(sell.exact.toFixed(2))} ${gp}` : null,
         classes
       };

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -1,4 +1,6 @@
 import { loadAdapter, getAdapter } from "./adapter/index.mjs";
+import InteractiveItemSettingsApp from "./settings/InteractiveItemSettingsApp.mjs";
+import VendorSettingsApp from "./settings/VendorSettingsApp.mjs";
 import InteractiveItemModel from "./models/InteractiveItemModel.mjs";
 import VendorModel from "./models/VendorModel.mjs";
 import InteractiveItemSheet from "./sheets/InteractiveItemSheet.mjs";
@@ -76,6 +78,24 @@ Hooks.once("init", async () => {
     "pick-up-stix.config-fields-v1": "modules/pick-up-stix/templates/partials/config-fields-v1.hbs"
   });
 
+  game.settings.registerMenu(MODULE_ID, "interactiveItemSettings", {
+    name: "INTERACTIVE_ITEMS.Settings.InteractiveItemSettingsMenu.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.InteractiveItemSettingsMenu.Hint",
+    label: "INTERACTIVE_ITEMS.Settings.InteractiveItemSettingsMenu.Label",
+    icon: "fa-solid fa-box-open",
+    type: InteractiveItemSettingsApp,
+    restricted: true
+  });
+
+  game.settings.registerMenu(MODULE_ID, "vendorSettings", {
+    name: "INTERACTIVE_ITEMS.Settings.VendorSettingsMenu.Name",
+    hint: "INTERACTIVE_ITEMS.Settings.VendorSettingsMenu.Hint",
+    label: "INTERACTIVE_ITEMS.Settings.VendorSettingsMenu.Label",
+    icon: "fa-solid fa-shop",
+    type: VendorSettingsApp,
+    restricted: true
+  });
+
   game.settings.register(MODULE_ID, "debugLogging", {
     name: "Debug Logging",
     hint: "Write detailed [PUS] debug logs to the browser console. Turn off for normal play.",
@@ -86,76 +106,60 @@ Hooks.once("init", async () => {
   });
 
   game.settings.register(MODULE_ID, "gmOverrideEnabled", {
-    name: "INTERACTIVE_ITEMS.Settings.GMOverrideEnabled.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.GMOverrideEnabled.Hint",
     scope: "client",
-    config: true,
+    config: false,
     type: Boolean,
     default: true,
     onChange: () => _onGMOverrideChanged()
   });
 
   game.settings.register(MODULE_ID, "actorFolder", {
-    name: "INTERACTIVE_ITEMS.Settings.ActorFolder.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.ActorFolder.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: String,
     default: "",
     onChange: value => _onActorFolderChanged(value)
   });
 
   game.settings.register(MODULE_ID, "folderColor", {
-    name: "INTERACTIVE_ITEMS.Settings.FolderColor.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.FolderColor.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: String,
     default: "",
     onChange: value => _onFolderColorChanged(value)
   });
 
   game.settings.register(MODULE_ID, "defaultContainerImage", {
-    name: "INTERACTIVE_ITEMS.Settings.DefaultContainerImage.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.DefaultContainerImage.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: String,
     default: CHEST_CLOSED
   });
 
   game.settings.register(MODULE_ID, "defaultContainerOpenImage", {
-    name: "INTERACTIVE_ITEMS.Settings.DefaultContainerOpenImage.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.DefaultContainerOpenImage.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: String,
     default: CHEST_OPEN
   });
 
   game.settings.register(MODULE_ID, "defaultInteractionRange", {
-    name: "INTERACTIVE_ITEMS.Settings.DefaultInteractionRange.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.DefaultInteractionRange.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Number,
     default: 1
   });
 
   game.settings.register(MODULE_ID, "defaultInspectionRange", {
-    name: "INTERACTIVE_ITEMS.Settings.DefaultInspectionRange.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.DefaultInspectionRange.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Number,
     default: 4
   });
 
   game.settings.register(MODULE_ID, "requireCtrlForDrag", {
-    name: "INTERACTIVE_ITEMS.Settings.RequireCtrlForDrag.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.RequireCtrlForDrag.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Boolean,
     default: false
   });
@@ -163,10 +167,8 @@ Hooks.once("init", async () => {
   // Item type used when creating a pickup stub in a player's inventory (generic
   // mode only). Populated automatically by heuristic or via dialog on first launch.
   game.settings.register(MODULE_ID, "genericPickupItemType", {
-    name: "INTERACTIVE_ITEMS.Settings.GenericPickupItemType.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.GenericPickupItemType.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: String,
     default: ""
   });
@@ -196,46 +198,36 @@ Hooks.once("init", async () => {
   });
 
   game.settings.register(MODULE_ID, "vendorFavorMin", {
-    name: "INTERACTIVE_ITEMS.Settings.VendorFavorMin.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorMin.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Number,
     default: -5
   });
 
   game.settings.register(MODULE_ID, "vendorFavorMax", {
-    name: "INTERACTIVE_ITEMS.Settings.VendorFavorMax.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorMax.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Number,
     default: 5
   });
 
   game.settings.register(MODULE_ID, "vendorFavorFactorMin", {
-    name: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMin.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMin.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Number,
     default: 1
   });
 
   game.settings.register(MODULE_ID, "vendorFavorFactorMax", {
-    name: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMax.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMax.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Number,
     default: 20
   });
 
   game.settings.register(MODULE_ID, "vendorFavorFactorDefault", {
-    name: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorDefault.Name",
-    hint: "INTERACTIVE_ITEMS.Settings.VendorFavorFactorDefault.Hint",
     scope: "world",
-    config: true,
+    config: false,
     type: Number,
     default: 4
   });
@@ -1816,83 +1808,6 @@ async function _handleContainerSheetGmDeposit({ destActor, droppedItem, destCont
     console.error("pick-up-stix | failed to deposit item on container sheet:", err);
   }
 }
-
-Hooks.on("renderSettingsConfig", (app, html) => {
-  const input = html.querySelector(`[name="${MODULE_ID}.actorFolder"]`);
-  if (!input) return;
-
-  const currentValue = input.value;
-  const currentFolder = currentValue ? game.folders.get(currentValue) : null;
-
-  const wrapper = document.createElement("div");
-  wrapper.classList.add("ii-settings-folder-picker");
-
-  const textInput = document.createElement("input");
-  textInput.type = "text";
-  textInput.placeholder = game.i18n.localize("INTERACTIVE_ITEMS.Settings.ActorFolder.Placeholder");
-  textInput.classList.add("ii-settings-folder-field");
-
-  const select = document.createElement("select");
-  select.classList.add("ii-settings-folder-field");
-
-  const emptyOpt = document.createElement("option");
-  emptyOpt.value = "";
-  emptyOpt.textContent = `\u2014 ${game.i18n.localize("INTERACTIVE_ITEMS.Settings.ActorFolder.Existing")} \u2014`;
-  select.appendChild(emptyOpt);
-
-  for (const folder of game.folders.filter(f => f.type === "Actor").sort((a, b) => a.name.localeCompare(b.name))) {
-    const opt = document.createElement("option");
-    opt.value = folder.id;
-    opt.textContent = folder.name;
-    if (folder.id === currentValue) opt.selected = true;
-    select.appendChild(opt);
-  }
-
-  const hidden = document.createElement("input");
-  hidden.type = "hidden";
-  hidden.name = input.name;
-  hidden.value = currentValue;
-
-  if (currentFolder) textInput.value = currentFolder.name;
-
-  select.addEventListener("change", () => {
-    if (select.value) {
-      const folder = game.folders.get(select.value);
-      textInput.value = folder?.name ?? "";
-      hidden.value = select.value;
-    }
-  });
-
-  textInput.addEventListener("input", () => {
-    select.value = "";
-    hidden.value = textInput.value;
-  });
-
-  wrapper.appendChild(textInput);
-  wrapper.appendChild(select);
-  input.replaceWith(wrapper);
-  wrapper.parentNode.insertBefore(hidden, wrapper.nextSibling);
-
-  for (const key of ["defaultContainerImage", "defaultContainerOpenImage"]) {
-    const imgInput = html.querySelector(`[name="${MODULE_ID}.${key}"]`);
-    if (!imgInput) continue;
-    const fp = document.createElement("file-picker");
-    fp.setAttribute("name", imgInput.name);
-    fp.setAttribute("type", "image");
-    fp.setAttribute("value", imgInput.value);
-    imgInput.replaceWith(fp);
-  }
-
-  const colorInput = html.querySelector(`[name="${MODULE_ID}.folderColor"]`);
-  if (colorInput) {
-    const picker = document.createElement("input");
-    picker.type = "color";
-    picker.name = colorInput.name;
-    picker.value = colorInput.value || "#000000";
-    picker.classList.add("ii-settings-color-picker");
-    colorInput.replaceWith(picker);
-  }
-});
 
 // Captures the source token's synthetic-actor state at paste time so
 // preCreateToken can rebuild the new token's delta from the source's

--- a/scripts/settings/InteractiveItemSettingsApp.mjs
+++ b/scripts/settings/InteractiveItemSettingsApp.mjs
@@ -1,0 +1,96 @@
+import { dbg } from "../utils/debugLog.mjs";
+
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+const MODULE_ID = "pick-up-stix";
+
+export default class InteractiveItemSettingsApp extends HandlebarsApplicationMixin(ApplicationV2) {
+  static DEFAULT_OPTIONS = {
+    id: "pick-up-stix-interactive-item-settings",
+    classes: ["pick-up-stix", "standard-form"],
+    position: { width: 900, height: 850 },
+    window: {
+      title: "INTERACTIVE_ITEMS.Settings.InteractiveItemSettingsMenu.Name",
+      icon: "fa-solid fa-box-open",
+      resizable: true
+    },
+    tag: "form",
+    form: {
+      handler: InteractiveItemSettingsApp.#onSubmit,
+      closeOnSubmit: true,
+      submitOnChange: false
+    }
+  };
+
+  static PARTS = {
+    form: { template: "modules/pick-up-stix/templates/settings/interactive-item-settings.hbs" },
+    footer: { template: "templates/generic/form-footer.hbs" }
+  };
+
+  async _prepareContext(options) {
+    dbg("InteractiveItemSettingsApp:_prepareContext", "preparing context");
+    const gs = (key) => game.settings.get(MODULE_ID, key);
+    const folderId = gs("actorFolder");
+    const currentFolder = folderId ? game.folders.get(folderId) : null;
+    const folders = game.folders
+      .filter(f => f.type === "Actor")
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(f => ({ id: f.id, name: f.name, selected: f.id === folderId }));
+
+    return {
+      gmOverrideEnabled: gs("gmOverrideEnabled"),
+      actorFolderValue: folderId,
+      actorFolderName: currentFolder?.name ?? "",
+      folders,
+      folderColor: gs("folderColor") || "#000000",
+      defaultContainerImage: gs("defaultContainerImage"),
+      defaultContainerOpenImage: gs("defaultContainerOpenImage"),
+      defaultInteractionRange: gs("defaultInteractionRange"),
+      defaultInspectionRange: gs("defaultInspectionRange"),
+      requireCtrlForDrag: gs("requireCtrlForDrag"),
+      genericPickupItemType: gs("genericPickupItemType"),
+      buttons: [{ type: "submit", icon: "fa-solid fa-save", label: "Save Settings" }]
+    };
+  }
+
+  _onRender(context, options) {
+    super._onRender(context, options);
+    this.#wireActorFolderPicker();
+  }
+
+  #wireActorFolderPicker() {
+    const form = this.element;
+    const hidden = form.querySelector('input[name="actorFolder"]');
+    const text = form.querySelector('.ii-folder-text');
+    const select = form.querySelector('.ii-folder-select');
+    if (!hidden || !text || !select) return;
+
+    select.addEventListener("change", () => {
+      if (select.value) {
+        const folder = game.folders.get(select.value);
+        text.value = folder?.name ?? "";
+        hidden.value = select.value;
+      }
+    });
+
+    text.addEventListener("input", () => {
+      select.value = "";
+      hidden.value = text.value;
+    });
+  }
+
+  static async #onSubmit(event, form, formData) {
+    dbg("InteractiveItemSettingsApp:submit", "saving settings");
+    const d = formData.object;
+    const ss = async (key, val) => game.settings.set(MODULE_ID, key, val);
+
+    await ss("gmOverrideEnabled", !!d.gmOverrideEnabled);
+    await ss("actorFolder", d.actorFolder ?? "");
+    await ss("folderColor", d.folderColor ?? "");
+    await ss("defaultContainerImage", d.defaultContainerImage ?? "");
+    await ss("defaultContainerOpenImage", d.defaultContainerOpenImage ?? "");
+    await ss("defaultInteractionRange", Number(d.defaultInteractionRange ?? 1));
+    await ss("defaultInspectionRange", Number(d.defaultInspectionRange ?? 4));
+    await ss("requireCtrlForDrag", !!d.requireCtrlForDrag);
+    await ss("genericPickupItemType", d.genericPickupItemType ?? "");
+  }
+}

--- a/scripts/settings/VendorSettingsApp.mjs
+++ b/scripts/settings/VendorSettingsApp.mjs
@@ -1,0 +1,53 @@
+import { dbg } from "../utils/debugLog.mjs";
+
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+const MODULE_ID = "pick-up-stix";
+
+export default class VendorSettingsApp extends HandlebarsApplicationMixin(ApplicationV2) {
+  static DEFAULT_OPTIONS = {
+    id: "pick-up-stix-vendor-settings",
+    classes: ["pick-up-stix", "standard-form"],
+    position: { width: 600, height: 500 },
+    window: {
+      title: "INTERACTIVE_ITEMS.Settings.VendorSettingsMenu.Name",
+      icon: "fa-solid fa-shop",
+      resizable: true
+    },
+    tag: "form",
+    form: {
+      handler: VendorSettingsApp.#onSubmit,
+      closeOnSubmit: true,
+      submitOnChange: false
+    }
+  };
+
+  static PARTS = {
+    form: { template: "modules/pick-up-stix/templates/settings/vendor-settings.hbs" },
+    footer: { template: "templates/generic/form-footer.hbs" }
+  };
+
+  async _prepareContext(options) {
+    dbg("VendorSettingsApp:_prepareContext", "preparing context");
+    const gs = (key) => game.settings.get(MODULE_ID, key);
+    return {
+      vendorFavorMin: gs("vendorFavorMin"),
+      vendorFavorMax: gs("vendorFavorMax"),
+      vendorFavorFactorMin: gs("vendorFavorFactorMin"),
+      vendorFavorFactorMax: gs("vendorFavorFactorMax"),
+      vendorFavorFactorDefault: gs("vendorFavorFactorDefault"),
+      buttons: [{ type: "submit", icon: "fa-solid fa-save", label: "Save Settings" }]
+    };
+  }
+
+  static async #onSubmit(event, form, formData) {
+    dbg("VendorSettingsApp:submit", "saving vendor settings");
+    const d = formData.object;
+    const ss = async (key, val) => game.settings.set(MODULE_ID, key, val);
+
+    await ss("vendorFavorMin", Number(d.vendorFavorMin ?? -5));
+    await ss("vendorFavorMax", Number(d.vendorFavorMax ?? 5));
+    await ss("vendorFavorFactorMin", Number(d.vendorFavorFactorMin ?? 1));
+    await ss("vendorFavorFactorMax", Number(d.vendorFavorFactorMax ?? 20));
+    await ss("vendorFavorFactorDefault", Number(d.vendorFavorFactorDefault ?? 4));
+  }
+}

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -981,3 +981,23 @@
   text-align: center;
   font-weight: bold;
 }
+
+/* Vendor price tint — clamped-to-zero negative price (GM only) */
+.pus-price-negative {
+  color: #c9a0dc !important;
+}
+
+/* Settings dialogs — scrollable body, sticky footer */
+#pick-up-stix-interactive-item-settings .window-content,
+#pick-up-stix-vendor-settings .window-content {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#pick-up-stix-interactive-item-settings .window-content > .standard-form,
+#pick-up-stix-vendor-settings .window-content > .standard-form {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}

--- a/templates/settings/interactive-item-settings.hbs
+++ b/templates/settings/interactive-item-settings.hbs
@@ -1,0 +1,83 @@
+<div class="standard-form">
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.GMOverrideEnabled.Name"}}</label>
+    <div class="form-fields">
+      <input type="checkbox" name="gmOverrideEnabled" {{checked gmOverrideEnabled}}>
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.GMOverrideEnabled.Hint"}}</p>
+  </div>
+
+  <div class="form-group stacked">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.ActorFolder.Name"}}</label>
+    <div class="form-fields">
+      <input type="text"
+             class="ii-folder-text"
+             placeholder="{{localize 'INTERACTIVE_ITEMS.Settings.ActorFolder.Placeholder'}}"
+             value="{{actorFolderName}}">
+      <select class="ii-folder-select">
+        <option value="">— {{localize "INTERACTIVE_ITEMS.Settings.ActorFolder.Existing"}} —</option>
+        {{#each folders}}
+          <option value="{{this.id}}" {{#if this.selected}}selected{{/if}}>{{this.name}}</option>
+        {{/each}}
+      </select>
+    </div>
+    <input type="hidden" name="actorFolder" value="{{actorFolderValue}}">
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.ActorFolder.Hint"}}</p>
+  </div>
+
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.FolderColor.Name"}}</label>
+    <div class="form-fields">
+      <input type="color" name="folderColor" value="{{folderColor}}">
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.FolderColor.Hint"}}</p>
+  </div>
+
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.DefaultContainerImage.Name"}}</label>
+    <div class="form-fields">
+      <file-picker name="defaultContainerImage" type="image" value="{{defaultContainerImage}}"></file-picker>
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.DefaultContainerImage.Hint"}}</p>
+  </div>
+
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.DefaultContainerOpenImage.Name"}}</label>
+    <div class="form-fields">
+      <file-picker name="defaultContainerOpenImage" type="image" value="{{defaultContainerOpenImage}}"></file-picker>
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.DefaultContainerOpenImage.Hint"}}</p>
+  </div>
+
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.DefaultInteractionRange.Name"}}</label>
+    <div class="form-fields">
+      <input type="number" name="defaultInteractionRange" value="{{defaultInteractionRange}}" min="0" step="1">
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.DefaultInteractionRange.Hint"}}</p>
+  </div>
+
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.DefaultInspectionRange.Name"}}</label>
+    <div class="form-fields">
+      <input type="number" name="defaultInspectionRange" value="{{defaultInspectionRange}}" min="0" step="1">
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.DefaultInspectionRange.Hint"}}</p>
+  </div>
+
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.RequireCtrlForDrag.Name"}}</label>
+    <div class="form-fields">
+      <input type="checkbox" name="requireCtrlForDrag" {{checked requireCtrlForDrag}}>
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.RequireCtrlForDrag.Hint"}}</p>
+  </div>
+
+  <div class="form-group">
+    <label>{{localize "INTERACTIVE_ITEMS.Settings.GenericPickupItemType.Name"}}</label>
+    <div class="form-fields">
+      <input type="text" name="genericPickupItemType" value="{{genericPickupItemType}}">
+    </div>
+    <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.GenericPickupItemType.Hint"}}</p>
+  </div>
+</div>

--- a/templates/settings/vendor-settings.hbs
+++ b/templates/settings/vendor-settings.hbs
@@ -1,0 +1,53 @@
+<div class="standard-form">
+  <div class="notification warning">
+    Some settings can result in a calculated price below zero. All prices are clamped to a minimum of 0 and will never be negative. GMs will see these items highlighted in purple.
+  </div>
+
+  <fieldset>
+    <legend>{{localize "INTERACTIVE_ITEMS.Vendor.Favor"}}</legend>
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorMin.Name"}}</label>
+      <div class="form-fields">
+        <input type="number" name="vendorFavorMin" value="{{vendorFavorMin}}" step="1">
+      </div>
+      <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorMin.Hint"}}</p>
+    </div>
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorMax.Name"}}</label>
+      <div class="form-fields">
+        <input type="number" name="vendorFavorMax" value="{{vendorFavorMax}}" step="1">
+      </div>
+      <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorMax.Hint"}}</p>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>{{localize "INTERACTIVE_ITEMS.Vendor.FavorFactor"}}</legend>
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMin.Name"}}</label>
+      <div class="form-fields">
+        <input type="number" name="vendorFavorFactorMin" value="{{vendorFavorFactorMin}}" min="1" step="1">
+      </div>
+      <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMin.Hint"}}</p>
+    </div>
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMax.Name"}}</label>
+      <div class="form-fields">
+        <input type="number" name="vendorFavorFactorMax" value="{{vendorFavorFactorMax}}" min="1" step="1">
+      </div>
+      <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMax.Hint"}}</p>
+    </div>
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorFactorDefault.Name"}}</label>
+      <div class="form-fields">
+        <input type="number" name="vendorFavorFactorDefault" value="{{vendorFavorFactorDefault}}" min="1" step="1">
+      </div>
+      <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorFactorDefault.Hint"}}</p>
+    </div>
+  </fieldset>
+</div>


### PR DESCRIPTION
Group module settings into two ApplicationV2 dialogs (Interactive Item Settings, Vendor Settings) opened via menu buttons. Negative vendor prices are clamped to 0 and highlighted purple for GMs.