### PR TITLE
Condense README and add per-feature docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,57 @@
 # Pick-Up-Stix
 
-A Foundry VTT v13+ module that lets GMs place interactive objects on the canvas for players to discover, inspect, and interact with. Objects use the active game system's native item and container sheets for a seamless experience.
+A Foundry VTT v13+ module that lets GMs place interactive objects on the canvas
+for players to discover, inspect, and interact with — using the active game
+system's own item and container sheets for a seamless experience.
 
-> Behavior may differ slightly between supported game systems where the underlying system handles a feature differently (most notably around identification and how a system displays container contents). The module follows each system's own conventions rather than imposing its own UI.
+> Behavior may differ slightly between supported game systems where the
+> underlying system handles a feature differently (most notably identification
+> and how container contents are displayed). The module follows each system's own
+> conventions rather than imposing its own UI.
 
 ## Features
 
-### One Actor, Two Modes
+- **[Interactive items](docs/interactive-items.md)** — Place items and containers
+  on the canvas as tokens. A single object adapts into either an inspectable,
+  pickup-able item or an open/close, lockable container, with unidentified
+  states, proximity-based visibility, quantity splitting, and full GM controls.
+- **[Vendors](docs/vendor.md)** — Shopkeeper actors players can buy from. GMs
+  stock wares and set prices with an adjustable Favor discount/surcharge; players
+  browse a storefront and check out, served one at a time through a shopping
+  queue. *(dnd5e only.)*
+- **[Light-emitting items](docs/lighting.md)** — Give any interactive item a
+  light source that follows it on the canvas, in a player's pack, or inside an
+  open container, layered on top of the carrier's own light.
 
-A single interactive object actor type adapts its behavior to whatever Item is dropped onto it:
-
-- **Item mode** -- When the embedded item is any non-container (weapon, potion, quest item, etc.). Players inspect via the system's native item sheet and pick the object up, removing the token from the canvas. Supports an unidentified state with a separate name, image, and description.
-- **Container mode** -- When the embedded item is a container. Opens the system's native container sheet with full inventory display. Supports open/close and lock/unlock states with the token image swapping between closed and open art.
-
-### Native System Sheet Integration
-
-Interactive objects display through the active system's own item and container sheets so players see a familiar interface. Identification leverages each system's built-in identification model, with the actor and embedded item kept in sync; toggling identification preserves both the identified and unidentified presentations across cycles.
-
-### Player Interaction
-
-- **Token HUD** -- Players interact through buttons on the Token HUD: inspect contents, pick up items, and open/close containers.
-- **Two proximity ranges** -- Each object has a configurable **inspection range** (to see the nameplate and open the sheet) and a tighter **interaction range** (to pick up, open/close, lock, or view container contents). Beyond inspection range, players see a **limited-view dialog** with a generic name and description; when they move into inspection range, the dialog is promoted in place to the real sheet. Sheets update live as a player moves through the ranges.
-- **Limited name / description** -- GMs can set a `Limited Name` and `Limited Description` shown to distant observers. When blank, a sensible fallback is used ("A chest of some sort" / "You are too far away to discern any details."). Containers append an "it appears open/closed" line automatically.
-- **Hidden container contents** -- When a player opens a container while it is closed, locked, or they are outside interaction range, the inventory listing is replaced with a placeholder message instead of revealing what's inside.
-- **Drop items** -- Players can drop items from their inventory onto the canvas via drag-and-drop or a "Drop Item" right-click context menu where the system supports it. Items are placed at the player's token position. By default no modifier key is required; GMs can optionally require Ctrl via the "Require Ctrl for drag actions" Module Setting.
-- **Deposit items** -- Players can drag items from their inventory into an open container to deposit them.
-- **Unidentified item privacy** -- When an interactive object item is in a player's inventory, the player sees only the generic name, image, and description until a GM reveals it.
-
-### GM Tools
-
-- **GM configuration dialog** -- Each interactive object has a dedicated config dialog for module-specific properties (interaction range, inspection range, identified/open/limited images, limited name/description, locked message). Accessible from the Token HUD (gear icon), the system sheet header (gear icon), or by clicking the base actor in the sidebar.
-- **Drag-and-drop placement** -- Drag any item from an inventory or the Items sidebar onto the canvas to create an interactive object, or drag an interactive actor from the sidebar to place one of its tokens. GMs can place anywhere; players drop at their own token.
-- **Template vs ephemeral actors** -- When placing a world item, GMs can choose to create a persistent template actor (reusable) or an ephemeral one-off placement that auto-cleans when the token is removed.
-- **Drop actors into containers** -- Drag an item-mode interactive object actor from the sidebar onto any container sheet to add it. The container preserves the actor's identification state and round-trip flags. Container-mode actors cannot be nested.
-- **Scene control button** -- A toolbar button to create empty interactive objects from scratch.
-- **GM actor picker** -- When a GM picks up an item with no unambiguous target (no single controlled NPC/PC token), a searchable dialog lists all non-interactive actors on the current scene so the GM can choose who receives the item. When multiple non-interactive tokens are already controlled, the picker is scoped to just those candidates.
-- **Lock and identify controls** -- Available from the config dialog, Token HUD, and the system's native sheet header. Locking an open container also closes it.
-- **Open/close toggle on container sheet** -- GMs see an open/close button in the container sheet header that toggles the container state and updates both the sheet image and token image.
-- **Per-item pickup and management in containers** -- GMs see lock, identify, and delete controls per row inside a container's contents listing. Where the system displays its own row controls, those are reused; otherwise the module renders its own.
-- **Drag items from container contents** -- Items in a container's contents listing can be dragged out to the canvas (placed as an interactive token) or onto another character/container sheet (transfers ownership).
-- **Configurable defaults** -- Module settings for default container images (open and closed), default interaction and inspection ranges, actor folder organization, and folder color.
-
-### Light-emitting Items
-
-- **Per-item light configuration** -- Configure dim/bright radius, color, animation, and advanced lighting options for any interactive item via a lightbulb button in the sheet header (matches Foundry's standard Token Light tab).
-- **Carry-on-pickup** -- When a player picks up a lit item (torch, lantern, etc.), the carrier token emits the item's light additively to its own token-light; the carrier's own light is never overwritten. Movement updates the light position smoothly.
-- **Container gating** -- Items inside an interactive container emit light only while the container is open; closing suppresses the emission.
-- **On/off toggle** -- A lightbulb HUD button on canvas tokens (GM) and a row icon in inventories / container contents (GM or item owner) toggle emission without losing the configured radii.
-
-### Architecture Highlights
-
-- **System adapter** -- All system-specific surfaces are isolated behind a `SystemAdapter` contract; one concrete adapter per supported system. Core code never branches on `game.system.id`, which keeps adding a new system to a single module under `scripts/adapter/`.
-- **Unlinked tokens** -- Each placed token is independent from the base actor template. Picking up an item from one token doesn't affect other tokens created from the same actor.
-- **Socket-based security** -- All player mutations (pickup, deposit, open/close, placement) route through sockets to the active GM client for processing.
-- **Round-trip placement** -- Items picked up from the canvas remember their source actor and token state. Dropping them back restores the original token appearance and reuses the original base actor.
-
-## Generic-system mode
-
-Pick-Up-Stix ships dedicated adapters for **dnd5e** (≥ 4.0.0) and **pf2e**
-(≥ 8.0.0). On any other system it falls back to a **generic adapter**
-that uses entirely module-owned data and UI. In generic mode:
-
-- All canvas placement, pickup, drop, and proximity flows work normally.
-- Interactive-object data is stored in module flags rather than the
-  system's actor / item types, so the module is independent of how the
-  active system structures its data.
-- Custom item-view, container-view, and config sheets are rendered
-  directly by the module — the system's own item sheets are not used.
-- **Item identification is disabled** — items are treated as permanently
-  identified and the identify UI is hidden.
-- On first launch the module auto-detects a "pickup item type" from
-  the system's declared item types, or prompts the GM to pick one via
-  dialog if no obvious match is found. You can change it later in
-  module settings.
+Across all of these, objects render through each system's **native sheets**,
+player actions route through **sockets** to the GM for security, and all
+system-specific behavior is isolated behind a system adapter. Pick-Up-Stix ships
+full support for **dnd5e** and **pf2e**, with a **generic fallback** for other
+systems.
 
 ## Requirements
 
 - Foundry VTT v13+
-- A supported game system (dnd5e 4.0.0+ or pf2e 8.0.0+ with full support; any other system with generic-mode fallback)
+- A supported game system (dnd5e 4.0.0+ or pf2e 8.0.0+ with full support; any
+  other system with generic-mode fallback)
 - [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper) module
 
 ## Installation
 
-Install via the Foundry module browser by searching for "Pick-Up-Stix", or paste the manifest URL into the Install Module dialog.
+Install via the Foundry module browser by searching for "Pick-Up-Stix", or paste
+the manifest URL into the Install Module dialog.
 
 ## AI Usage
 
-AI has been used for CSS styling and for researching the Foundry VTT APIs to ensure proper usage, most especially for determining the differences between the various versions of Foundry supported by the module.
+AI has been used for CSS styling and for researching the Foundry VTT APIs to
+ensure proper usage, most especially for determining the differences between the
+various versions of Foundry supported by the module.
 
 ## Tutorials
 
-You can find a playlist of videos quickly explaining some of the functionality on the [Pick-Up-Stix](https://www.youtube.com/playlist?list=PLNzm8yjPdznaPpEjILB0y66kDnE-gR_St) YouTube playlist.
+You can find a playlist of videos quickly explaining some of the functionality on
+the [Pick-Up-Stix](https://www.youtube.com/playlist?list=PLNzm8yjPdznaPpEjILB0y66kDnE-gR_St)
+YouTube playlist.
 
 ---
 

--- a/docs/interactive-items.md
+++ b/docs/interactive-items.md
@@ -1,0 +1,117 @@
+# Interactive Items
+
+Interactive items are the core of Pick-Up-Stix: objects a GM places on the
+canvas for players to discover, inspect, and interact with. Each one is a token
+backed by a single embedded item, presented through the active game system's own
+item and container sheets.
+
+## One actor, two modes
+
+A single actor type adapts to whatever item is dropped onto it:
+
+- **Item mode** — for any non-container item (weapon, potion, quest item, etc.).
+  Players inspect it through the system's native item sheet and can pick it up,
+  removing the token from the canvas. Supports an **unidentified** state with a
+  separate name, image, and description.
+- **Container mode** — for a container item. Opens the system's native container
+  sheet with full inventory. Supports **open/close** and **lock/unlock**, with
+  the token art swapping between closed and open images.
+
+## Placing objects
+
+- **Drag-and-drop** — Drag any item from an inventory, the Items sidebar, or a
+  compendium onto the canvas to create an interactive object. Dragging an
+  existing interactive actor from the sidebar places one of its tokens.
+- **Scene control button** — Create an empty interactive object from scratch.
+- **Who can place** — GMs place freely anywhere; players place at their own
+  token.
+- **Template vs ephemeral** — When placing a world item, GMs choose a persistent
+  **template** actor (reusable) or an **ephemeral** one-off that auto-cleans when
+  its token is removed.
+- **Source cleanup** — Placing an item from an inventory removes it from that
+  inventory.
+
+Each placed token is **independent** of the base actor it came from — picking up
+or changing one token never affects others made from the same actor.
+
+## Identification
+
+Interactive objects use the active system's built-in identification model, kept
+in sync between the actor and the embedded item. Toggling identification
+preserves both the identified and unidentified presentations across cycles. Only
+a GM can reveal or hide an object, via the system's native identify control, the
+config dialog, the Token HUD, or system-specific inventory controls. While an
+unidentified object sits in a player's inventory, that player sees only the
+generic name, image, and description until a GM reveals it.
+
+## Player interaction
+
+- **Token HUD** — Players inspect contents, pick up items, and open/close
+  containers from buttons on the Token HUD.
+- **Two proximity ranges** — Each object has an **inspection range** (see the
+  nameplate, open the real sheet) and a tighter **interaction range** (pick up,
+  open/close, lock, view container contents). Beyond inspection range a player
+  sees a **limited-view dialog** with a generic name and description; moving
+  closer promotes it in place to the real sheet. Sheets update live as players
+  move.
+- **Limited name / description** — GMs can set what distant observers see; a
+  sensible fallback is used when left blank, and containers append an "appears
+  open/closed" line automatically.
+- **Hidden container contents** — A container's inventory is replaced with a
+  placeholder while it is closed, locked, or the player is out of interaction
+  range.
+
+## Pick up, drop, and deposit
+
+- **Drop items** — Players drop items from their inventory onto the canvas by
+  drag-and-drop (or a right-click "Drop Item" menu where supported). A GM can
+  optionally require Ctrl to be held via the "Require Ctrl for drag actions"
+  setting.
+- **Deposit** — Drag items into an open container to deposit them. Drops are
+  gated by lock/open/proximity for players. Containers cannot be nested.
+- **Round-trip** — Items picked up from the canvas remember their source actor
+  and token state; dropping them back restores the original appearance and base
+  actor.
+
+## Quantity handling
+
+Stackable items are split-aware throughout:
+
+- **Quantity badge** — Non-container tokens with more than one in the stack show
+  a count in the corner.
+- **Split prompts** — Moving a stack across actors (canvas drop, deposit, give to
+  a nearby PC, HUD pickup, delete-key) opens a small dialog to choose how many to
+  move. Multi-token deletes are batched into one dialog.
+- **Split HUD button** — GMs can split a stacked token into a new adjacent token.
+
+Containers, world items, and stacks of one skip every prompt.
+
+## GM tools
+
+- **Config dialog** — A dedicated dialog for module-specific properties
+  (interaction/inspection ranges, identified/open/limited images, limited
+  name/description, locked message). Opened from the Token HUD gear, the system
+  sheet header gear, or by clicking the base actor in the sidebar.
+- **Lock and identify** — Available from the config dialog, Token HUD, and the
+  system sheet header. Locking an open container also closes it.
+- **Open/close toggle** — A button in the container sheet header toggles state
+  and updates both the sheet and token images.
+- **Per-item controls in containers** — Lock, identify, and delete controls per
+  row inside a container's contents. Items can be dragged back out to the canvas
+  or onto another sheet.
+- **Drop actors into containers** — Drag an item-mode interactive actor onto any
+  container sheet to add it, preserving its identification and round-trip state.
+- **GM actor picker** — When a GM picks up an item with no clear recipient, a
+  searchable dialog lists candidate actors on the scene.
+- **Configurable defaults** — Default container images, interaction/inspection
+  ranges, and actor folder organization are set in module settings.
+
+## System support
+
+Pick-Up-Stix ships full adapters for **dnd5e** and **pf2e**, which use those
+systems' native item and container sheets. On any other system it falls back to a
+**generic mode** that stores object data in module flags and renders its own
+item, container, and config sheets. In generic mode all placement, pickup, drop,
+and proximity flows work normally, but identification is disabled (items are
+always treated as identified). On first launch the module detects or prompts for
+which item type counts as a "pickup item"; this can be changed later in settings.

--- a/docs/lighting.md
+++ b/docs/lighting.md
@@ -1,0 +1,25 @@
+# Light-emitting Items
+
+Any interactive item can emit light — a torch, lantern, glowing relic, or a chest
+full of luminous loot. The light follows the item wherever it goes: lying on the
+canvas, carried in a player's pack, or stored inside a container.
+
+## Configuring light
+
+A **lightbulb** button in the item sheet header opens a light editor that matches
+Foundry's standard Token Light tab — dim and bright radius, color, animation, and
+the advanced options. Changes apply live.
+
+## How carried light behaves
+
+- **Carry on pickup** — When a player picks up a lit item, their token emits that
+  item's light **in addition to** its own. The carrier's own token light is never
+  overwritten, and the carried light tracks the token smoothly as it moves.
+- **Container gating** — An item inside an interactive container emits light only
+  while the container is **open**. Closing the container suppresses it.
+- **On/off toggle** — A lightbulb control (a HUD button on canvas tokens for the
+  GM, and a row icon in inventories and container contents for the GM or item
+  owner) turns emission on or off without losing the configured radii.
+
+Each placed token keeps its own light snapshot, so toggling or moving one lit
+item never affects another.

--- a/docs/vendor.md
+++ b/docs/vendor.md
@@ -1,0 +1,59 @@
+# Vendors
+
+A vendor is a shopkeeper actor that players can buy from in-world. The GM stocks
+it with wares, sets its prices, and places it on the canvas; players open it to
+browse a storefront and purchase items into their own inventory.
+
+> **System support:** Vendors are currently a **dnd5e-only** feature. On pf2e and
+> in generic mode the vendor sheet is not available.
+
+## Creating and stocking a vendor
+
+A vendor is its own actor sub-type, created like any other actor. Stock it by
+dragging items onto the vendor sheet's **Inventory** tab. Dragging from another
+actor's inventory **moves** the item (the source loses it); drops from a
+compendium or the sidebar add a copy. Coins players spend are added straight to
+the vendor's currency.
+
+Each item has a **show / hide in shop** toggle so the GM can keep stock in
+inventory without listing it on the storefront, plus an "All" toggle to add or
+remove everything at once.
+
+## The shop
+
+The vendor sheet adds a **Shop** tab. GMs see it alongside the full set of normal
+actor tabs (features, inventory, spells, etc.); players see a focused
+storefront-only view. The storefront shows the vendor's public description, the
+list of for-sale items with rarity, stock, and price, and a shopping queue.
+
+## Buying
+
+Players buy items either one at a time with a **Buy** button or by adding items
+to a **cart** and checking out in a single transaction. Quantities are capped by
+stock. The buyer must have a selected token or assigned character, and must be
+able to afford the total — the system makes change automatically. As stock sells
+out, items are removed from the vendor.
+
+## Favor pricing
+
+Each vendor has a **Favor** rating that shifts its prices for the party: positive
+Favor is a discount, negative is a surcharge. A per-vendor **Favor Factor** sets
+how much each point of Favor is worth (a percentage). The GM adjusts both with
+sliders on the Shop tab, and all displayed prices and affordability checks update
+to match. World-wide bounds for Favor and Favor Factor are configured in the
+module's Vendor Settings.
+
+For the underlying flags, formula, and helper API, see
+[Vendor Actor Flags](vendor-flags.md).
+
+## Shopping queue
+
+A vendor serves **one shopper at a time**. When a player opens a vendor they join
+its queue; only the actor at the front can actively buy, while everyone else can
+browse but not purchase. Controls enable automatically as a player reaches the
+front.
+
+Each player can be in only one vendor's queue at a time — opening a second vendor
+prompts to switch, leaving the first queue. Closing a vendor sheet leaves its
+queue and clears any in-progress cart. The Shop tab shows the queue with who is
+shopping now and who is waiting.


### PR DESCRIPTION
Slims the README to an overview and moves the detail into per-feature docs (interactive items, vendors, lighting), linked from the README. Adds the new vendor behavior to the docs.