### PR TITLE
feat: vendor Set Inventory and Restock

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -315,7 +315,19 @@
         "Waiting": "Waiting in line",
         "Title": "Shopping Queue",
         "Toggle": "Show / hide the shopping queue"
-      }
+      },
+      "SetInventory": "Set default inventory",
+      "SetInventoryDone": "Saved {count} item(s) as this vendor's default inventory.",
+      "Restock": "Restock to default",
+      "RestockNoDefault": "No default inventory saved yet — use Set Inventory first.",
+      "RestockNothing": "Inventory already matches the saved default.",
+      "RestockDone": "Restock complete — {created} added, {increased} restocked, {removed} removed.",
+      "RestockConfirmTitle": "Remove extra stock?",
+      "RestockConfirmPrompt": "Missing items and quantities will be restored. These exceed the saved default and can be removed:",
+      "RestockExtraQtyRow": "{name}: remove {remove} extra",
+      "RestockExtraItemRow": "{name} (×{qty}): not in the default",
+      "RestockRemove": "Remove extras",
+      "RestockKeep": "Keep extras"
     }
   },
   "TYPES": {

--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -8,6 +8,8 @@ import { createRowControl } from "../../utils/domButtons.mjs";
 import { emitSocketEvent } from "../../socket/SocketHandler.mjs";
 import { getVendorQueue, findUserVendorQueues, promptVendorQueueSwitch } from "../../utils/vendorQueue.mjs";
 import { getVendorFavor, getVendorFavorFactor, getFavorMin, getFavorMax, getFavorFactorMin, getFavorFactorMax, getFavorFactorDefault } from "../../utils/vendorPricing.mjs";
+import { saveDefaultInventory, computeRestockDiff, applyRestock, promptRestockRemoval }
+  from "../../utils/vendorInventory.mjs";
 
 const NPCActorSheet = dnd5e.applications.actor.NPCActorSheet;
 
@@ -442,8 +444,50 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
         if ( updates.length ) await this.actor.updateEmbeddedDocuments("Item", updates);
       }
     }));
-    row.append(label, cell);
+    const actions = document.createElement("div");
+    actions.className = "pus-shop-all-actions";
+    actions.appendChild(createRowControl({
+      iconClass: "fa-solid fa-floppy-disk",
+      titleKey: "INTERACTIVE_ITEMS.Vendor.SetInventory",
+      extraClass: "pus-shop-action",
+      onClick: () => this.#onSetInventory()
+    }));
+    actions.appendChild(createRowControl({
+      iconClass: "fa-solid fa-truck-ramp-box",
+      titleKey: "INTERACTIVE_ITEMS.Vendor.Restock",
+      extraClass: "pus-shop-action",
+      onClick: () => this.#onRestock()
+    }));
+    row.append(actions, label, cell);   // actions sit left (margin-right:auto), All label+toggle stay right
     list.parentElement.insertBefore(row, list);
+  }
+
+  /** Save the current physical inventory as this vendor's default (overwrites any prior). GM-only. */
+  async #onSetInventory() {
+    dbg("vendorSheet:onSetInventory", { vendor: this.actor.id });
+    const count = await saveDefaultInventory(this.actor);
+    ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Vendor.SetInventoryDone", { count }));
+  }
+
+  /** Restock to the saved default: always add missing items/quantities; confirm before removing extras. */
+  async #onRestock() {
+    const diff = computeRestockDiff(this.actor);
+    if ( !diff ) {
+      dbg("vendorSheet:onRestock", "no default saved, bail", { vendor: this.actor.id });
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockNoDefault"));
+      return;
+    }
+    const hasExtras = diff.extraQty.length > 0 || diff.extraItems.length > 0;
+    const hasAdds = diff.toCreate.length > 0 || diff.toIncrease.length > 0;
+    if ( !hasExtras && !hasAdds ) {
+      dbg("vendorSheet:onRestock", "already matches default", { vendor: this.actor.id });
+      ui.notifications.info(game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockNothing"));
+      return;
+    }
+    const removeExtras = hasExtras ? await promptRestockRemoval(diff) : false;
+    dbg("vendorSheet:onRestock", "applying", { vendor: this.actor.id, removeExtras, hasAdds, hasExtras });
+    const summary = await applyRestock(this.actor, diff, { removeExtras });
+    ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Vendor.RestockDone", summary));
   }
 
   /**

--- a/scripts/utils/vendorInventory.mjs
+++ b/scripts/utils/vendorInventory.mjs
@@ -1,0 +1,126 @@
+import { getAdapter } from "../adapter/index.mjs";
+import { dbg } from "./debugLog.mjs";
+
+const DEFAULT_INVENTORY_FLAG = "defaultInventory";
+
+/** Saved default-inventory snapshot (array of item source objects), or null when none saved. */
+export function getDefaultInventory(vendor) {
+  const snap = vendor?.getFlag("pick-up-stix", DEFAULT_INVENTORY_FLAG);
+  return Array.isArray(snap) ? snap : null;
+}
+
+/** True when this vendor has a saved default inventory. */
+export function hasDefaultInventory(vendor) {
+  return getDefaultInventory(vendor) !== null;
+}
+
+/**
+ * Snapshot the vendor's current PHYSICAL items as its default inventory. Stores full item source
+ * (toObject, _id included) so a sold-out item can be recreated faithfully on restock. Overwrites
+ * any prior default. GM-side. Returns the number of items saved.
+ */
+export async function saveDefaultInventory(vendor) {
+  const adapter = getAdapter();
+  const snapshot = vendor.items.filter(i => adapter.isPhysicalItem(i)).map(i => i.toObject());
+  dbg("vendorInventory:save", { vendor: vendor.id, count: snapshot.length });
+  await vendor.setFlag("pick-up-stix", DEFAULT_INVENTORY_FLAG, snapshot);
+  return snapshot.length;
+}
+
+/**
+ * Diff the vendor's current physical inventory against its saved default, matched by item _id
+ * (stock decrements in place on sale, so a partly-sold item keeps its _id; a sold-out one is gone).
+ * Returns null when no default is saved.
+ *
+ * @returns {{toCreate: object[], toIncrease: {id:string,to:number}[],
+ *            extraQty: {id:string,name:string,from:number,to:number}[],
+ *            extraItems: {id:string,name:string,qty:number}[]} | null}
+ */
+export function computeRestockDiff(vendor) {
+  const snap = getDefaultInventory(vendor);
+  if ( !snap ) return null;
+  const adapter = getAdapter();
+  const qtyOf = (src) => Number(foundry.utils.getProperty(src, "system.quantity")) || 0;
+
+  const current = new Map(vendor.items.filter(i => adapter.isPhysicalItem(i)).map(i => [i.id, i]));
+  const defaultIds = new Set();
+  const toCreate = [], toIncrease = [], extraQty = [];
+
+  for ( const src of snap ) {
+    defaultIds.add(src._id);
+    const want = qtyOf(src);
+    const item = current.get(src._id);
+    if ( !item ) { toCreate.push(src); continue; }              // sold out / deleted → recreate
+    const have = adapter.getItemQuantity(item);
+    if ( have < want ) toIncrease.push({ id: item.id, to: want });
+    else if ( have > want ) extraQty.push({ id: item.id, name: item.name, from: have, to: want });
+  }
+
+  const extraItems = [];
+  for ( const [id, item] of current ) {
+    if ( !defaultIds.has(id) ) extraItems.push({ id, name: item.name, qty: adapter.getItemQuantity(item) });
+  }
+
+  dbg("vendorInventory:diff", {
+    vendor: vendor.id, create: toCreate.length, increase: toIncrease.length,
+    extraQty: extraQty.length, extraItems: extraItems.length
+  });
+  return { toCreate, toIncrease, extraQty, extraItems };
+}
+
+/**
+ * Apply a restock. ALWAYS performs the additive part (recreate missing, top up low stacks). Removes
+ * extras (excess quantity + items absent from the default) only when removeExtras is true. GM-side.
+ */
+export async function applyRestock(vendor, diff, { removeExtras }) {
+  const { toCreate, toIncrease, extraQty, extraItems } = diff;
+
+  if ( toCreate.length )
+    await vendor.createEmbeddedDocuments("Item", toCreate, { keepId: true });
+  if ( toIncrease.length )
+    await vendor.updateEmbeddedDocuments("Item", toIncrease.map(u => ({ _id: u.id, "system.quantity": u.to })));
+
+  if ( removeExtras ) {
+    if ( extraQty.length )
+      await vendor.updateEmbeddedDocuments("Item", extraQty.map(u => ({ _id: u.id, "system.quantity": u.to })));
+    if ( extraItems.length )
+      await vendor.deleteEmbeddedDocuments("Item", extraItems.map(e => e.id));
+  }
+
+  dbg("vendorInventory:applyRestock", { vendor: vendor.id, removeExtras,
+    created: toCreate.length, increased: toIncrease.length,
+    extraQty: extraQty.length, extraItems: extraItems.length });
+  return {
+    created: toCreate.length, increased: toIncrease.length,
+    removed: removeExtras ? (extraQty.length + extraItems.length) : 0
+  };
+}
+
+/**
+ * Confirm removing the listed extras. "Remove extras" + "Keep extras" buttons; the X dismiss
+ * resolves false (keep). Mirrors promptVendorQueueSwitch's DialogV2.wait convention.
+ *
+ * @returns {Promise<boolean>} true only when "Remove extras" is pressed.
+ */
+export async function promptRestockRemoval({ extraQty, extraItems }) {
+  const rows = [
+    ...extraQty.map(e => game.i18n.format("INTERACTIVE_ITEMS.Vendor.RestockExtraQtyRow",
+      { name: e.name, remove: e.from - e.to })),
+    ...extraItems.map(e => game.i18n.format("INTERACTIVE_ITEMS.Vendor.RestockExtraItemRow",
+      { name: e.name, qty: e.qty }))
+  ];
+  const result = await foundry.applications.api.DialogV2.wait({
+    window: { title: game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockConfirmTitle") },
+    content: `<p>${game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockConfirmPrompt")}</p>`
+      + `<ul>${rows.map(r => `<li>${r}</li>`).join("")}</ul>`,
+    buttons: [
+      { action: "remove", default: true, icon: "fa-solid fa-trash",
+        label: game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockRemove") },
+      { action: "keep", icon: "fa-solid fa-box",
+        label: game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockKeep") }
+    ],
+    rejectClose: false
+  });
+  dbg("vendorInventory:promptRestockRemoval", { result });
+  return result === "remove";
+}

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -136,6 +136,12 @@
   justify-content: flex-end;
   padding-right: 8px;
 }
+.pus-shop-all-row .pus-shop-all-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: auto;        /* push the actions to the left; ALL label + toggle stay right */
+}
 
 /* ===== GM Identification Toggle (injected into dnd5e character sheets) ===== */
 
@@ -777,8 +783,8 @@
 .vendor-sheet.dnd5e2.sheet.actor.npc .sheet-header .portrait {
   position: relative;
   flex: 0 0 200px;
-  width: 200px;
-  height: 200px;
+  width: 150px;
+  height: 150px;
   border: 5px solid var(--dnd5e-color-gold);
   border-radius: 18px;
   box-shadow: 0 0 6px var(--dnd5e-color-black);


### PR DESCRIPTION
Adds two GM-only buttons to the vendor Inventory tab's "All in shop" row: **Set Inventory** snapshots the current physical inventory as the vendor's default, and **Restock** diffs against that default — always restoring missing items/quantities, and optionally removing extras after a confirmation dialog.