### PR TITLE
feat(vendor): per-grouping price factors by type and rarity

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -45,8 +45,12 @@
         "Hint": "Absolute Favor ceiling. Vendors can be set from −Max to +Max (e.g. 5 allows −5 to +5)."
       },
       "VendorFavorFactorMax": {
-        "Name": "Max Factor",
+        "Name": "Max Favor Factor",
         "Hint": "Highest Favor Factor (% per Favor point) a vendor can be set to. Minimum is always 1."
+      },
+      "VendorMaxPriceFactor": {
+        "Name": "Max Price Factor",
+        "Hint": "Highest per-grouping price factor (percent) a vendor can set, e.g. 500 allows up to ×5.00. Minimum is always 0."
       },
       "InteractiveItemSettingsMenu": {
         "Name": "Interactive Item Settings",
@@ -307,6 +311,16 @@
       "FavorFactorTooltip": "The percentage applied per Favor point. Default 4 means each Favor point shifts the price by 4%.",
       "Settings": "Vendor Settings",
       "SettingsToggle": "Show / hide vendor settings",
+      "SettingsBy": {
+        "Label": "Settings by",
+        "Type": "Type",
+        "Rarity": "Rarity"
+      },
+      "Factor": {
+        "Items": "items",
+        "Hint": "Price factor — max is",
+        "Empty": "No items in inventory to configure."
+      },
       "Queue": {
         "SwitchTitle": "Switch shops?",
         "SwitchPrompt": "You're already in line at {from}. Joining {to} will leave {from}'s queue.",

--- a/scripts/adapter/dnd5e/purchase.mjs
+++ b/scripts/adapter/dnd5e/purchase.mjs
@@ -1,5 +1,5 @@
 import { dbg } from "../../utils/debugLog.mjs";
-import { vendorPriceMultiplier } from "../../utils/vendorPricing.mjs";
+import { vendorItemMultiplier } from "./shopGrouping.mjs";
 
 /**
  * Given an exact copper-piece total, return the coarsest whole-coin denomination that
@@ -69,7 +69,7 @@ export const Dnd5ePurchase = {
   },
 
   canAfford(buyer, item, quantity = 1) {
-    const mult = vendorPriceMultiplier(item?.parent);
+    const mult = vendorItemMultiplier(item);
     const { amount, denomination } = chargeAmount(this.getItemPrice(item), quantity, mult);
     if (amount <= 0) return true;                     // free
     if (!buyer) return false;
@@ -81,7 +81,7 @@ export const Dnd5ePurchase = {
   },
 
   getItemChargeCp(item, quantity = 1) {
-    return chargeAmount(this.getItemPrice(item), quantity, vendorPriceMultiplier(item?.parent)).cp;
+    return chargeAmount(this.getItemPrice(item), quantity, vendorItemMultiplier(item)).cp;
   },
 
   getActorWealthCp(actor) {

--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -1,16 +1,31 @@
 import { getAdapter } from "../index.mjs";
 import { dbg } from "../../utils/debugLog.mjs";
-import { getVendorFavor, getVendorFavorFactor, favorMultiplier } from "../../utils/vendorPricing.mjs";
+import { vendorPriceMultiplier, groupingFactorMultiplier } from "../../utils/vendorPricing.mjs";
 
 /* ---------- dnd5e display helpers (system-specific; kept in the dnd5e adapter) ---------- */
 
-/** Price as { display: ceil(gp), exact: gp, denomination }, Favor-adjusted. */
-export function priceInGP(item, favor = 0, factor = 4) {
+/** Price as { display: ceil(gp), exact: gp, denomination }, scaled by `multiplier`. */
+export function priceInGP(item, multiplier = 1) {
   const { value, denomination } = item.system?.price ?? {};
   const conv = CONFIG.DND5E.currencies?.[denomination]?.conversion;
   if (!value || !conv) return { display: 0, exact: 0, denomination: denomination ?? "gp" };
-  const exact = (value / conv) * favorMultiplier(favor, factor);   // gp, Favor-adjusted
+  const exact = (value / conv) * multiplier;
   return { display: Math.ceil(exact), exact, denomination };
+}
+
+/**
+ * Full per-item cost multiplier: Favor × type-factor × rarity-factor, all compounded.
+ * Returns 1 when the item has no vendor parent. Absent factors default to 100% → ×1.0.
+ */
+export function vendorItemMultiplier(item) {
+  const vendor = item?.parent;
+  if ( !vendor ) return 1;
+  const favorM  = vendorPriceMultiplier(vendor);
+  const typeM   = groupingFactorMultiplier(vendor, "type", groupType(item));
+  const rarityM = groupingFactorMultiplier(vendor, "rarity", rarityOf(item).key);
+  const m = favorM * typeM * rarityM;
+  dbg("shopGrouping:vendorItemMultiplier", { item: item.id, favorM, typeM, rarityM, m });
+  return m;
 }
 
 /** Localized rarity label + raw key. Mundane / unset items are treated as "common". */
@@ -77,19 +92,16 @@ const COLUMNS = {
   price: {
     id: "price", header: "INTERACTIVE_ITEMS.Vendor.Col.Price", align: "end",
     cell(item) {
-      const favor = getVendorFavor(item.parent);
-      const factor = getVendorFavorFactor(item.parent);
-      const base = priceInGP(item, 0, factor);        // unmodified item value
-      const sell = priceInGP(item, favor, factor);    // what the buyer pays (Favor-adjusted)
+      const base = priceInGP(item, 1);
+      const sell = priceInGP(item, vendorItemMultiplier(item));
       const gp = game.i18n.localize("DND5E.CurrencyAbbrGP");
       const isNegative = sell.exact < 0;
       const displayValue = Math.max(0, sell.display);
       const fractional = !isNegative && sell.exact !== Math.trunc(sell.exact);
-      // Negative (clamped) prices shown purple for GM; else tint by Favor direction.
       let classes = "pus-price";
-      if (isNegative && game.user.isGM) classes += " pus-price-negative";
-      else if (base.display > 0 && favor > 0) classes += " pus-price-down";
-      else if (base.display > 0 && favor < 0) classes += " pus-price-up";
+      if ( isNegative && game.user.isGM ) classes += " pus-price-negative";
+      else if ( base.exact > 0 && sell.exact < base.exact ) classes += " pus-price-down";
+      else if ( base.exact > 0 && sell.exact > base.exact ) classes += " pus-price-up";
       return {
         text: `${displayValue} ${gp}`,
         tooltip: fractional ? `${Number(sell.exact.toFixed(2))} ${gp}` : null,
@@ -121,6 +133,51 @@ export const SHOP_GROUPINGS = {
 };
 
 export const DEFAULT_GROUPING = "type";
+
+/* -------------------- Settings-panel dimension registry -------------------- */
+
+/** Ordered rarity keys (dnd5e ladder), unknowns last. */
+function rarityOrder() {
+  return Object.keys(CONFIG.DND5E.itemRarity ?? {});
+}
+
+/** Settings-panel grouping dimensions: how to bucket + label + order items for the factor list. */
+export const SETTINGS_DIMENSIONS = {
+  type: {
+    keyOf: (item) => groupType(item),
+    labelOf: (key) => game.i18n.localize(CONFIG.Item.typeLabels?.[key] ?? key),
+    order: () => inventoryTypeOrder()
+  },
+  rarity: {
+    keyOf: (item) => rarityOf(item).key,
+    labelOf: (key) => game.i18n.localize(CONFIG.DND5E.itemRarity?.[key] ?? key),
+    order: () => rarityOrder()
+  }
+};
+
+/**
+ * Buckets `items` by the given settings dimension, returning only buckets that have
+ * at least one item, ordered by the dimension's canonical order (unknowns alpha-last).
+ * @returns {Array<{ key, label, count }>}
+ */
+export function buildSettingsGroups(items, dimension) {
+  const dim = SETTINGS_DIMENSIONS[dimension] ?? SETTINGS_DIMENSIONS.type;
+  const counts = new Map();
+  for ( const item of items ) {
+    const key = dim.keyOf(item);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const order = dim.order();
+  return [...counts.entries()]
+    .map(([key, count]) => ({ key, label: dim.labelOf(key), count }))
+    .sort((a, b) => {
+      const ai = order.indexOf(a.key), bi = order.indexOf(b.key);
+      if ( ai !== -1 && bi !== -1 ) return ai - bi;
+      if ( ai !== -1 ) return -1;
+      if ( bi !== -1 ) return 1;
+      return a.label.localeCompare(b.label);
+    });
+}
 
 /* ------------------------ Build the grouped structure ------------------------ */
 

--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -3,11 +3,11 @@ import { getPlayerCandidateTokens, purchaseItem, purchaseCart } from "../../tran
 import { dispatchGM } from "../../utils/gmDispatch.mjs";
 import { notifyPurchase } from "../../utils/notify.mjs";
 import { dbg } from "../../utils/debugLog.mjs";
-import { buildShop, DEFAULT_GROUPING } from "./shopGrouping.mjs";
+import { buildShop, DEFAULT_GROUPING, buildSettingsGroups } from "./shopGrouping.mjs";
 import { createRowControl } from "../../utils/domButtons.mjs";
 import { emitSocketEvent } from "../../socket/SocketHandler.mjs";
 import { getVendorQueue, findUserVendorQueues, promptVendorQueueSwitch } from "../../utils/vendorQueue.mjs";
-import { getVendorFavor, getVendorFavorFactor, getFavorMin, getFavorMax, getFavorFactorMin, getFavorFactorMax, getFavorFactorDefault } from "../../utils/vendorPricing.mjs";
+import { getVendorFavor, getVendorFavorFactor, getFavorMin, getFavorMax, getFavorFactorMin, getFavorFactorMax, getFavorFactorDefault, getVendorGroupingFactor, getMaxPriceFactor } from "../../utils/vendorPricing.mjs";
 import { saveDefaultInventory, computeRestockDiff, applyRestock, promptRestockRemoval }
   from "../../utils/vendorInventory.mjs";
 
@@ -34,6 +34,9 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
   #updateItemHookId = null;
   #queueHookId = null;
   #groupingId = DEFAULT_GROUPING;
+  #settingsBy = "type";                 // "type" | "rarity" — which dimension the factor list edits
+  #expandedFactorRows = new Set();      // `${dimension}:${key}` rows currently expanded (survives re-render)
+  #favorCollapsed = true;               // vendor-settings panel — always starts collapsed on open; toggled live
   #cart = new Map();   // itemId -> quantity to buy
   #renderTimer = null;
 
@@ -55,6 +58,8 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
       stepCartQty: Dnd5eVendorSheet.#onStepCartQty,
       toggleShopVisible: Dnd5eVendorSheet.#onToggleShopVisible,
       toggleFavor: Dnd5eVendorSheet.#onToggleFavor,
+      settingsBy: Dnd5eVendorSheet.#onSettingsBy,
+      toggleFactorRow: Dnd5eVendorSheet.#onToggleFactorRow,
       toggleQueue: Dnd5eVendorSheet.#onToggleQueue
     }
   };
@@ -172,9 +177,10 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     this.#injectPortraitClip();                 // wrap the portrait so the figure masks at the frame
     this.#repositionEditToggle();               // move dnd5e's edit toggle next to the XP badge
     this.#repositionInitiativeDie();            // move initiative d20 above the vendor name (GM only)
-    this.#applyAbilitiesTabVisibility();   // keep NPC abilities card hidden on the Shop tab
+    this.#applyShopHeaderVisibility();   // keep NPC abilities card + legendary row hidden on the Shop tab
     await this.#injectGmShopBio();          // mirror the player storefront bio under the name (Shop tab)
     this.#wireFavorControls();              // wire favor sliders in the Shop tab (GM only)
+    this.#wireSettingsControls();           // wire grouping-factor controls in the Shop tab (GM only)
     // Re-evaluate cart state and buy-button gating after core _toggleDisabled has run.
     // #refreshCart owns the disabled state for both basket toggles and buy buttons.
     this.#refreshCart();
@@ -272,12 +278,15 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     }
   }
 
-  /** Hide the inherited NPC abilities card on the Shop tab (it has no place in the storefront);
-   *  show it on every other tab. No-op if the card isn't present (player storefront header). */
-  #applyAbilitiesTabVisibility() {
-    const abilities = this.element.querySelector(".sheet-header .ability-scores");
-    if ( !abilities ) return;
-    abilities.style.display = this.tabGroups.primary === "shop" ? "none" : "";
+  /** Hide inherited NPC header chrome that has no place in the storefront — the abilities card and
+   *  the legendary/lair (.bottom) row — on the Shop tab; restore them on every other tab. No-op for
+   *  any section not present (e.g. the player storefront header). */
+  #applyShopHeaderVisibility() {
+    const onShop = this.tabGroups.primary === "shop";
+    for ( const sel of [".sheet-header .ability-scores", ".sheet-header .right.stats .bottom"] ) {
+      const el = this.element.querySelector(sel);
+      if ( el ) el.style.display = onShop ? "none" : "";
+    }
   }
 
   /**
@@ -336,6 +345,39 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     }
   }
 
+  /** Wire the grouping-factor sliders + editable numeric inputs in the settings panel (GM only). */
+  #wireSettingsControls() {
+    if ( !game.user.isGM ) return;
+    const list = this.element.querySelector(".pus-factor-list");
+    if ( !list || list.dataset.pusWired === "1" ) return;
+    list.dataset.pusWired = "1";
+    const max = getMaxPriceFactor();
+    const clamp = (v) => Math.max(0, Math.min(max, Math.round(Number(v) || 0)));
+    for ( const row of list.querySelectorAll(".pus-factor-row") ) {
+      const range = row.querySelector(".pus-factor-range");
+      const num   = row.querySelector(".pus-factor-num");
+      const mult  = row.querySelector(".pus-factor-mult");
+      if ( !range || !num ) continue;
+      const flagKey = `groupingFactors.${row.dataset.dimension}.${row.dataset.key}`;
+      const syncLive = (v) => {
+        num.value = String(v);
+        if ( mult ) mult.textContent = `×${(v / 100).toFixed(2)}`;
+      };
+      range.addEventListener("input", () => syncLive(clamp(range.value)));
+      num.addEventListener("input", () => {
+        range.value = String(clamp(num.value));
+        if ( mult ) mult.textContent = `×${(clamp(num.value) / 100).toFixed(2)}`;
+      });
+      const commit = async (el) => {
+        const v = clamp(el.value);
+        dbg("vendorSheet:factorChange", { vendor: this.actor.id, flagKey, value: v });
+        await this.actor.setFlag("pick-up-stix", flagKey, v);
+      };
+      range.addEventListener("change", () => commit(range));
+      num.addEventListener("change", () => commit(num));
+    }
+  }
+
   /**
    * Re-evaluate subtitle truncation when a tab is shown. The GM's Shop tab is hidden
    * at first render (they land on an NPC tab), so the `_onRender` pass sees a zero-size
@@ -344,7 +386,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
   changeTab(tab, group, options) {
     super.changeTab(tab, group, options);
     if ( tab === "shop" ) this.#refreshSubtitleTooltips();
-    this.#applyAbilitiesTabVisibility();   // swap abilities visibility with the active tab
+    this.#applyShopHeaderVisibility();   // swap abilities + legendary visibility with the active tab
     this.#injectGmShopBio();               // show/hide the header bio with the active tab
   }
 
@@ -627,6 +669,9 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
   _onClose(options) {
     super._onClose(options);
     this.#leaveQueue();
+    // The sheet instance is cached per-actor and reused on reopen, so reset the vendor-settings
+    // panel to collapsed here — otherwise it reopens in whatever state it was last left in.
+    this.#favorCollapsed = true;
   }
 
   async close(options = {}) {
@@ -692,25 +737,17 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     }, []);
   }
 
-  /** Per-user, per-vendor favor-panel collapse state (defaults to collapsed). */
+  /** Vendor-settings panel collapse state — instance-only, so it always starts collapsed on open. */
   #isFavorCollapsed() {
-    const map = game.user.getFlag("pick-up-stix", "favorCollapsed") ?? {};
-    return map[this.actor.id] ?? true;
-  }
-
-  /** Persist the favor-panel collapse state for this user + vendor (no actor re-render). */
-  async #setFavorCollapsed(collapsed) {
-    const map = { ...(game.user.getFlag("pick-up-stix", "favorCollapsed") ?? {}) };
-    map[this.actor.id] = collapsed;
-    dbg("vendorSheet:setFavorCollapsed", { vendor: this.actor.id, collapsed });
-    await game.user.setFlag("pick-up-stix", "favorCollapsed", map);
+    return this.#favorCollapsed;
   }
 
   /**
-   * Toggle the favor panel open/closed. Persisted to a per-user user flag, so this does NOT
-   * re-render the sheet — the CSS height transition animates on the live DOM (mirrors dnd5e's
-   * sidebar collapse). On the next full render, `#prepareFavorContext().collapsed` re-applies the
-   * class from the flag. GM-only in practice (players never render the panel).
+   * Toggle the favor panel open/closed. Tracked in an instance field (not persisted) so it always
+   * starts collapsed on open, while a live toggle survives re-renders within the session. This does
+   * NOT re-render — the CSS height transition animates on the live DOM (mirrors dnd5e's sidebar
+   * collapse); the next full render re-applies the class from the field via `#prepareFavorContext`.
+   * GM-only in practice (players never render the panel).
    */
   static #onToggleFavor(event, target) {
     const panel = target.closest(".pus-favor-panel");
@@ -718,7 +755,35 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     const collapsed = panel.classList.toggle("collapsed");
     target.setAttribute("aria-expanded", String(!collapsed));
     dbg("vendorSheet:onToggleFavor", { vendor: this.actor.id, collapsed });
-    this.#setFavorCollapsed(collapsed);
+    this.#favorCollapsed = collapsed;
+  }
+
+  /** Switch the factor list between the Type and Rarity dimensions (GM only). Re-renders the shop part. */
+  static #onSettingsBy(event, target) {
+    const dim = target.dataset.dimension;
+    if ( dim !== "type" && dim !== "rarity" ) return;
+    if ( this.#settingsBy === dim ) return;
+    dbg("vendorSheet:onSettingsBy", { vendor: this.actor.id, dim });
+    this.#settingsBy = dim;
+    this.render();
+  }
+
+  /**
+   * Expand/collapse one grouping-factor row. DOM-only so the transition is instant; the instance
+   * Set records the state so a later re-render (after a flag write) re-applies it via context.
+   * Clicks originating inside `.pus-factor-body` (slider / number input) are ignored so editing
+   * doesn't collapse the row.
+   */
+  static #onToggleFactorRow(event, target) {
+    if ( event.target.closest(".pus-factor-body") ) return;
+    const row = target.closest(".pus-factor-row");
+    if ( !row ) return;
+    const id = `${row.dataset.dimension}:${row.dataset.key}`;
+    const expanded = row.classList.toggle("expanded");
+    target.setAttribute("aria-expanded", String(expanded));
+    if ( expanded ) this.#expandedFactorRows.add(id);
+    else this.#expandedFactorRows.delete(id);
+    dbg("vendorSheet:onToggleFactorRow", { vendor: this.actor.id, id, expanded });
   }
 
   /** Per-user, per-vendor queue-panel collapse state (defaults to expanded). */
@@ -770,6 +835,35 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     };
   }
 
+  /** GM-only context for the "Settings by" toggle + the factor list of inventory-present buckets. */
+  #prepareSettingsContext() {
+    const physical = this.actor.items.filter(i => getAdapter().isPhysicalItem(i));
+    const groups = buildSettingsGroups(physical, this.#settingsBy);
+    const maxFactor = getMaxPriceFactor();
+    return {
+      by: this.#settingsBy,
+      dimensions: [
+        { key: "type",   label: "INTERACTIVE_ITEMS.Vendor.SettingsBy.Type",   active: this.#settingsBy === "type" },
+        { key: "rarity", label: "INTERACTIVE_ITEMS.Vendor.SettingsBy.Rarity", active: this.#settingsBy === "rarity" }
+      ],
+      maxFactor,
+      rows: groups.map(g => {
+        const factor = getVendorGroupingFactor(this.actor, this.#settingsBy, g.key);
+        return {
+          dimension: this.#settingsBy,
+          key: g.key,
+          label: g.label,
+          count: g.count,
+          factor,
+          factorDisplay: (factor / 100).toFixed(2),
+          // Reuse the ware-row rarity palette to tint the group name when grouped by rarity.
+          colorClass: this.#settingsBy === "rarity" ? `pus-rarity-${g.key}` : "",
+          expanded: this.#expandedFactorRows.has(`${this.#settingsBy}:${g.key}`)
+        };
+      })
+    };
+  }
+
   async _preparePartContext(partId, context, options) {
     context = await super._preparePartContext(partId, context, options);
     if ( partId === "shop" ) {
@@ -778,6 +872,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
       context.queue = this.#prepareQueue();
       context.canShop = this.#canShop();
       if ( context.isGM ) context.favor = this.#prepareFavorContext();
+      if ( context.isGM ) context.settings = this.#prepareSettingsContext();
       if ( context.isGM ) context.queueCollapsed = this.#isQueueCollapsed();
     }
     if ( partId === "header" ) {

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -211,6 +211,13 @@ Hooks.once("init", async () => {
     default: 20
   });
 
+  game.settings.register(MODULE_ID, "vendorMaxPriceFactor", {
+    scope: "world",
+    config: false,
+    type: Number,
+    default: 500
+  });
+
   // Hidden world setting that persists the install-tracker state (sent flag,
   // version, attempt count, last error). Managed entirely by installTracker.mjs.
   registerInstallTrackerSetting();

--- a/scripts/settings/VendorSettingsApp.mjs
+++ b/scripts/settings/VendorSettingsApp.mjs
@@ -32,6 +32,7 @@ export default class VendorSettingsApp extends HandlebarsApplicationMixin(Applic
     return {
       vendorFavorMax: gs("vendorFavorMax"),
       vendorFavorFactorMax: gs("vendorFavorFactorMax"),
+      vendorMaxPriceFactor: gs("vendorMaxPriceFactor"),
       buttons: [{ type: "submit", icon: "fa-solid fa-save", label: "Save Settings" }]
     };
   }
@@ -43,5 +44,6 @@ export default class VendorSettingsApp extends HandlebarsApplicationMixin(Applic
 
     await ss("vendorFavorMax", Number(d.vendorFavorMax ?? 5));
     await ss("vendorFavorFactorMax", Number(d.vendorFavorFactorMax ?? 20));
+    await ss("vendorMaxPriceFactor", Math.max(0, Number(d.vendorMaxPriceFactor ?? 500)));
   }
 }

--- a/scripts/utils/vendorPricing.mjs
+++ b/scripts/utils/vendorPricing.mjs
@@ -9,6 +9,10 @@ import { dbg } from "./debugLog.mjs";
 /** Hard-coded fallback for max Favor — used before `init` and as setting default. */
 export const FAVOR_MAX = 5;
 export const FAVOR_FACTOR_MAX = 20;
+/** Hard-coded fallback for the max per-grouping price factor (percent). */
+export const PRICE_FACTOR_MAX = 500;
+/** Default per-grouping price factor (percent); 100 = ×1.00 = no change. */
+export const PRICE_FACTOR_DEFAULT = 100;
 
 // Runtime setting reader — falls back to the constant when settings aren't available yet.
 const gs = (key, fallback) => { try { return game.settings.get("pick-up-stix", key); } catch { return fallback; } };
@@ -23,6 +27,8 @@ export const getFavorFactorMin = () => 1;
 export const getFavorFactorMax = () => gs("vendorFavorFactorMax", FAVOR_FACTOR_MAX);
 /** Default Favor Factor when a vendor has none set — always 1. */
 export const getFavorFactorDefault = () => 1;
+/** Configured maximum per-grouping price factor (module setting `vendorMaxPriceFactor`, default 500). */
+export const getMaxPriceFactor = () => gs("vendorMaxPriceFactor", PRICE_FACTOR_MAX);
 
 /** A vendor's Favor, clamped to the configured [favorMin, favorMax]; absent / non-numeric → 0. */
 export function getVendorFavor(vendor) {
@@ -53,4 +59,22 @@ export function vendorPriceMultiplier(vendor) {
   const m = favorMultiplier(favor, factor);
   dbg("vendorPricing:multiplier", { vendor: vendor?.id, favor, factor, multiplier: m });
   return m;
+}
+
+/**
+ * A vendor's stored price factor (percent) for one grouping bucket, clamped to
+ * [0, maxPriceFactor]; absent / non-numeric → PRICE_FACTOR_DEFAULT (100).
+ * @param {Actor} vendor
+ * @param {"type"|"rarity"} dimension
+ * @param {string} key  grouping bucket key (e.g. "weapon", "rare")
+ */
+export function getVendorGroupingFactor(vendor, dimension, key) {
+  const raw = Number(vendor?.getFlag?.("pick-up-stix", `groupingFactors.${dimension}.${key}`));
+  if ( !Number.isFinite(raw) ) return PRICE_FACTOR_DEFAULT;
+  return Math.max(0, Math.min(getMaxPriceFactor(), Math.round(raw)));
+}
+
+/** Cost multiplier for one grouping bucket: factor% / 100 (default → 1.0). */
+export function groupingFactorMultiplier(vendor, dimension, key) {
+  return getVendorGroupingFactor(vendor, dimension, key) / 100;
 }

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -986,7 +986,8 @@
 
 /* Expanding content: an absolute overlay below the bar. Inset left/right to match the bar width
    (the 12px mirrors the panel's horizontal padding). Fades + slides in; `visibility` keeps it
-   fully hidden — and non-interactive — when collapsed. */
+   fully hidden — and non-interactive — when collapsed. The inner wrapper owns the scroll so the
+   overlay never grows the outer sheet — tall content (many expanded rows) scrolls in place. */
 .vendor-sheet .pus-favor-content {
   position: absolute; top: 100%; left: 12px; right: 12px; z-index: 20;
   transition: opacity 0.2s ease, transform 0.2s ease, visibility 0s;
@@ -995,7 +996,8 @@
   opacity: 0; transform: translateY(-8px); visibility: hidden; pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease, visibility 0s 0.2s;
 }
-.vendor-sheet .pus-favor-content > .pus-favor-controls {
+.vendor-sheet .pus-favor-content-inner {
+  max-height: 360px; overflow-y: auto;
   padding: 8px 12px;
   background: color-mix(in srgb, var(--dnd5e-color-maroon, #741b2b) 14%, #161013);
   border: 1px solid var(--color-border-light-1, rgba(255, 255, 255, 0.25));
@@ -1015,7 +1017,7 @@
 }
 .vendor-sheet .pus-favor-controls {
   display: flex;
-  flex-direction: column;
+  flex-flow: row wrap;
   gap: 8px;
   width: 100%;
 }
@@ -1024,7 +1026,14 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 4px;
-  max-width: 200px;
+  flex: 1 1 calc(50% - 8px);
+  max-width: 50%;
+  box-sizing: border-box;
+}
+.vendor-sheet .pus-settings-divider {
+  margin: 10px 0;
+  border: none;
+  border-top: 1px solid var(--color-border-light-1, rgba(255, 255, 255, 0.25));
 }
 .vendor-sheet .pus-favor-label {
   font-weight: bold;
@@ -1047,6 +1056,64 @@
   min-width: 2.5ch;
   text-align: center;
   font-weight: bold;
+}
+
+/* "Settings by" segmented toggle */
+.vendor-sheet .pus-settings-by {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 8px;
+}
+.vendor-sheet .pus-settings-by-label {
+  font-size: var(--font-size-12, 12px); text-transform: uppercase; font-weight: bold;
+}
+.vendor-sheet .pus-settings-by-toggle {
+  display: inline-flex;
+  border: 1px solid var(--color-border-light-1, rgba(255,255,255,.25));
+  border-radius: 4px; overflow: hidden;
+}
+.vendor-sheet .pus-settings-by-btn {
+  background: none; border: none; padding: 2px 10px; cursor: pointer;
+  color: var(--color-text-secondary, #999); font-size: var(--font-size-12, 12px);
+}
+.vendor-sheet .pus-settings-by-btn.active {
+  background: color-mix(in srgb, var(--dnd5e-color-gold, #c9ad6a) 28%, transparent);
+  color: var(--color-text-primary, #ddd);
+}
+
+/* Grouping-factor row list */
+.vendor-sheet .pus-factor-list { display: flex; flex-direction: column; gap: 4px; }
+.vendor-sheet .pus-factor-row {
+  border: 1px solid var(--color-border-light-1, rgba(255,255,255,.2)); border-radius: 4px;
+}
+.vendor-sheet .pus-factor-head {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  background: none; border: none; cursor: pointer; padding: 6px 8px;
+  color: var(--color-text-primary, #ddd); font-size: var(--font-size-13, 13px);
+}
+.vendor-sheet .pus-factor-name { font-weight: bold; color: var(--pus-rarity-color, var(--color-text-primary, #ddd)); }
+.vendor-sheet .pus-factor-count {
+  color: var(--color-text-secondary, #999); font-size: var(--font-size-11, 11px);
+}
+.vendor-sheet .pus-factor-mult { margin-left: auto; font-weight: bold; }
+.vendor-sheet .pus-factor-caret { transition: transform 0.2s ease; }
+.vendor-sheet .pus-factor-row.expanded .pus-factor-caret { transform: rotate(180deg); }
+
+/* Collapsible body — grid 0fr→1fr, clips the strip flush */
+.vendor-sheet .pus-factor-body {
+  display: grid; grid-template-rows: 0fr;
+  transition: grid-template-rows 0.2s ease;
+}
+.vendor-sheet .pus-factor-row.expanded .pus-factor-body { grid-template-rows: 1fr; }
+.vendor-sheet .pus-factor-body-inner { min-height: 0; overflow: hidden; }
+
+/* Slider + editable number input side by side */
+.vendor-sheet .pus-factor-slider-row {
+  display: flex; align-items: center; gap: 10px; padding: 6px 8px;
+}
+.vendor-sheet .pus-factor-range { flex: 1; min-width: 0; background: none; box-shadow: none; }
+.vendor-sheet .pus-factor-num { width: 5ch; text-align: center; }
+.vendor-sheet .pus-factor-hint { margin: 0 8px 6px; }
+.vendor-sheet .pus-factor-empty {
+  color: var(--color-text-secondary, #999); font-size: var(--font-size-12, 12px); padding: 4px 8px;
 }
 
 /* Vendor price tint — clamped-to-zero negative price (GM only) */

--- a/templates/settings/vendor-settings.hbs
+++ b/templates/settings/vendor-settings.hbs
@@ -21,5 +21,13 @@
       </div>
       <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorFavorFactorMax.Hint"}}</p>
     </div>
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Settings.VendorMaxPriceFactor.Name"}}</label>
+      <div class="form-fields">
+        <input type="number" name="vendorMaxPriceFactor" value="{{vendorMaxPriceFactor}}" min="0" step="1">
+      </div>
+      <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorMaxPriceFactor.Hint"}}</p>
+    </div>
   </fieldset>
 </div>

--- a/templates/vendor/shop.hbs
+++ b/templates/vendor/shop.hbs
@@ -11,6 +11,7 @@
       <i class="fa-solid fa-chevron-down pus-collapse-caret"></i>
     </button>
     <div class="pus-favor-content">
+      <div class="pus-favor-content-inner">
       <div class="pus-favor-controls">
         <div class="pus-favor-control">
           <label class="pus-favor-label" data-tooltip="{{ localize "INTERACTIVE_ITEMS.Vendor.FavorTooltip" }}">
@@ -32,6 +33,49 @@
             <span class="pus-favor-value">{{ favor.factorDisplay }}</span>
           </div>
         </div>
+      </div>
+      <hr class="pus-settings-divider" />
+
+      <div class="pus-settings-by">
+        <span class="pus-settings-by-label">{{ localize "INTERACTIVE_ITEMS.Vendor.SettingsBy.Label" }}</span>
+        <div class="pus-settings-by-toggle">
+          {{#each settings.dimensions}}
+          <button type="button" class="pus-settings-by-btn {{#if this.active}}active{{/if}}"
+                  data-action="settingsBy" data-dimension="{{ this.key }}"
+                  aria-pressed="{{#if this.active}}true{{else}}false{{/if}}">
+            {{ localize this.label }}
+          </button>
+          {{/each}}
+        </div>
+      </div>
+
+      <div class="pus-factor-list">
+        {{#each settings.rows}}
+        <div class="pus-factor-row {{#if this.expanded}}expanded{{/if}}"
+             data-dimension="{{ this.dimension }}" data-key="{{ this.key }}">
+          <button type="button" class="pus-factor-head" data-action="toggleFactorRow"
+                  aria-expanded="{{#if this.expanded}}true{{else}}false{{/if}}">
+            <span class="pus-factor-name {{ this.colorClass }}">{{ this.label }}</span>
+            <span class="pus-factor-count">{{ this.count }} {{ localize "INTERACTIVE_ITEMS.Vendor.Factor.Items" }}</span>
+            <span class="pus-factor-mult">&times;{{ this.factorDisplay }}</span>
+            <i class="fa-solid fa-chevron-down pus-factor-caret"></i>
+          </button>
+          <div class="pus-factor-body">
+            <div class="pus-factor-body-inner">
+              <div class="pus-factor-slider-row">
+                <input type="range" class="pus-factor-range" min="0" max="{{ ../settings.maxFactor }}"
+                       step="1" value="{{ this.factor }}" />
+                <input type="number" class="pus-factor-num" min="0" max="{{ ../settings.maxFactor }}"
+                       step="1" value="{{ this.factor }}" />
+              </div>
+              <p class="hint pus-factor-hint">{{ localize "INTERACTIVE_ITEMS.Vendor.Factor.Hint" }} {{ ../settings.maxFactor }}%</p>
+            </div>
+          </div>
+        </div>
+        {{else}}
+        <p class="pus-factor-empty">{{ localize "INTERACTIVE_ITEMS.Vendor.Factor.Empty" }}</p>
+        {{/each}}
+      </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Adds GM-configurable per-type and per-rarity price factors to the vendor settings panel, compounded with Favor across displayed prices, affordability, and currency transferred on purchase. Includes a "Max Price Factor" world setting and a "Settings by" Type/Rarity toggle with expandable per-grouping controls.