### PR TITLE
feat(vendor): CurrencyConverter provider + real-economy settlement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -52,6 +52,10 @@
         "Name": "Max Price Factor",
         "Hint": "Highest per-grouping price factor (percent) a vendor can set, e.g. 500 allows up to ×5.00. Minimum is always 0."
       },
+      "UseOnlyAvailableCurrency": {
+        "Name": "Use only available currency",
+        "Hint": "When on, purchases use only coins the buyer and vendor actually hold — if exact change can't be made, the item can't be bought. When off, change is created as needed."
+      },
       "InteractiveItemSettingsMenu": {
         "Name": "Interactive Item Settings",
         "Hint": "Configure GM overrides, folder organisation, container images, range defaults, and drag behaviour.",
@@ -146,6 +150,7 @@
       "PurchasedQty": "You purchased {name} ×{quantity} from {vendor}.",
       "PurchasedQtyByPlayer": "{player} purchased {name} ×{quantity} from {vendor}.",
       "NotEnoughCoin": "You can't afford {name}.",
+      "NoChange": "This purchase can't be settled with available coins.",
       "NoBuyer": "Select a token or assign a character to make a purchase.",
       "TransferError": "Failed to transfer item.",
       "NoCharacter": "No character assigned. Set your character in User Configuration.",

--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -164,32 +164,45 @@ export default class SystemAdapter {
   getActorWealthCp(_actor) { return Infinity; }
 
   /**
-   * Debit an exact copper-piece total from the buyer, applied WITHOUT a re-render (so a
-   * batch checkout doesn't flicker the open shop). Used by `purchaseCart` as both the
-   * payment and the affordability gate. GM-side only.
-   *
-   * Default: no-op success (systems without a currency model transfer for free).
+   * Compute (without mutating) how a `cp` transfer from buyer→vendor would settle.
+   * Returns an opaque plan object passed to applyBuyerSettlement/applyVendorSettlement,
+   * or null when the purchase cannot be paid or changed.
+   * Default: returns a noop plan (systems without a currency model are always free).
    *
    * @param {Actor} _buyer
-   * @param {number} _cp - Total charge in copper pieces.
-   * @returns {Promise<boolean>} false if the buyer could not pay (no items should move).
+   * @param {Actor} _vendor
+   * @param {number} _cp
+   * @returns {{ mode: string }|null}
    */
-  async debitBuyerCp(_buyer, _cp) {
-    return true;
-  }
+  planSettlement(_buyer, _vendor, _cp) { return { mode: "noop" }; }
 
   /**
-   * Credit an exact copper-piece total to the vendor. Intended as the LAST write of a
-   * batch checkout, rendering normally so every client re-renders exactly once with the
-   * final stock + currency. GM-side only.
+   * Apply the buyer side of a settlement plan (render-suppressed — fires before items move).
+   * Default: no-op.
    *
-   * Default: no-op (systems without a currency model).
-   *
-   * @param {Actor} _vendor
-   * @param {number} _cp - Total credit in copper pieces.
+   * @param {Actor} _buyer
+   * @param {{ mode: string }} _plan
    * @returns {Promise<void>}
    */
-  async creditVendorCp(_vendor, _cp) {}
+  async applyBuyerSettlement(_buyer, _plan) {}
+
+  /**
+   * Apply the vendor side of a settlement plan (renders — the single final write).
+   * Default: no-op.
+   *
+   * @param {Actor} _vendor
+   * @param {{ mode: string }} _plan
+   * @returns {Promise<void>}
+   */
+  async applyVendorSettlement(_vendor, _plan) {}
+
+  /**
+   * The system's currency converter, or null when the system has no currency model
+   * (affordability is then always free — see getActorWealthCp/getItemChargeCp defaults).
+   * Subclasses return a cached CurrencyConverter.
+   * @returns {import("../utils/CurrencyConverter.mjs").CurrencyConverter|null}
+   */
+  get currency() { return null; }
 
   // === Container parent reference ============================================
 

--- a/scripts/adapter/dnd5e/currency.mjs
+++ b/scripts/adapter/dnd5e/currency.mjs
@@ -1,0 +1,28 @@
+import { CurrencyConverter } from "../../utils/CurrencyConverter.mjs";
+
+/** Canonical dnd5e ratios (cp base) used when CONFIG is unavailable: 1pp=10gp=20ep=100sp=1000cp. */
+const FALLBACK = { pp: 1000, gp: 100, ep: 50, sp: 10, cp: 1 };
+
+/**
+ * Build the dnd5e currency converter from CONFIG.DND5E.currencies (respecting any
+ * homebrew edits), falling back to the canonical table. cp-per-coin = 100 / conversion.
+ * Change generation stays gp/sp/cp to preserve today's tidy change.
+ */
+export function buildDnd5eCurrencyConverter() {
+  const cfg = CONFIG.DND5E?.currencies;
+  let denominations = null;
+  if ( cfg ) {
+    denominations = {};
+    for ( const [denom, data] of Object.entries(cfg) ) {
+      const conv = Number(data?.conversion);
+      if ( conv > 0 ) denominations[denom] = 100 / conv;
+    }
+  }
+  if ( !denominations || !denominations.cp ) denominations = { ...FALLBACK };
+  return new CurrencyConverter({
+    denominations,
+    baseDenom: "cp",
+    defaultDenom: CONFIG.DND5E?.defaultCurrency || "gp",
+    changeDenoms: ["gp", "sp", "cp"]
+  });
+}

--- a/scripts/adapter/dnd5e/index.mjs
+++ b/scripts/adapter/dnd5e/index.mjs
@@ -5,6 +5,7 @@ import { Dnd5eSheets } from "./sheets.mjs";
 import { Dnd5eHooks } from "./hooks.mjs";
 import { Dnd5ePurchase } from "./purchase.mjs";
 import Dnd5eVendorModel from "./vendorModel.mjs";
+import { buildDnd5eCurrencyConverter } from "./currency.mjs";
 
 /**
  * Concrete SystemAdapter implementation for the dnd5e game system.
@@ -24,6 +25,13 @@ export default class Dnd5eAdapter extends SystemAdapter {
 
   /** @type {string} */
   static SYSTEM_ID = "dnd5e";
+
+  #currency = null;
+
+  /** dnd5e currency converter (cp base), built lazily from CONFIG and cached. */
+  get currency() {
+    return (this.#currency ??= buildDnd5eCurrencyConverter());
+  }
 
   constructor() {
     super();

--- a/scripts/adapter/dnd5e/purchase.mjs
+++ b/scripts/adapter/dnd5e/purchase.mjs
@@ -2,56 +2,24 @@ import { dbg } from "../../utils/debugLog.mjs";
 import { vendorItemMultiplier } from "./shopGrouping.mjs";
 
 /**
- * Given an exact copper-piece total, return the coarsest whole-coin denomination that
- * represents it precisely. Picking the coarsest denomination makes change come back
- * tidy — e.g. 1020 cp → "102 sp" so a gp-only buyer gets 8 sp change (not 80 cp).
- *
- * @param {number} cp - Exact value in copper pieces (must be a non-negative integer).
- * @returns {{ amount: number, denomination: string }}
+ * Exact charge in base units (cp): price × qty × multiplier, sub-unit rounded UP (vendor's favour).
+ * Inner round to 1e-4 kills float noise so a whole-cp value (e.g. 10.2 gp = 1020 cp)
+ * doesn't get ceil'd up by a 1e-13 artifact.
  */
-function denomFromCp(cp) {
-  if (cp % 100 === 0) return { amount: cp / 100, denomination: "gp" };  // whole gp
-  if (cp % 10 === 0) return { amount: cp / 10, denomination: "sp" };    // whole sp → silver change
-  return { amount: cp, denomination: "cp" };                            // sub-sp → copper
+function chargeCp(converter, price, quantity, multiplier = 1) {
+  if ( !converter || !price.value ) return 0;
+  const raw = converter.toBase(price.value * quantity, price.denomination) * multiplier;
+  const cp = Math.ceil(Math.round(raw * 1e4) / 1e4);
+  return cp > 0 ? cp : 0;
 }
 
-/**
- * The EXACT charge for a purchase, expressed as a whole-coin amount in the COARSEST
- * denomination that represents it precisely (gp if whole, else sp, else cp). Charging in
- * a whole coin lets dnd5e's change-making pay a sub-unit remainder from a coarser purse,
- * and picking the coarsest denomination makes the change come back tidy — e.g. 10.2 gp →
- * 102 sp, so a gp-only buyer gets 8 sp change (not 80 cp). Also returns the value in copper
- * for crediting the vendor a consolidated coin payload. The buyer pays the exact value,
- * except any sub-copper fraction is rounded UP (always in the vendor's favour); the Price
- * column separately rounds up to whole gp for display.
- *
- * @param {{ value:number, denomination:string }} price
- * @param {number} quantity
- * @returns {{ amount:number, denomination:string, cp:number }}
- */
-function chargeAmount(price, quantity, multiplier = 1) {
-  const conv = CONFIG.DND5E.currencies?.[price.denomination]?.conversion;
-  if (!price.value || !conv) return { amount: 0, denomination: "gp", cp: 0 };
-  // Exact value in copper, Favor-adjusted, rounding any sub-copper fraction UP.
-  // Inner round to 1e-4 first kills float noise so a whole-cp value (e.g. 10.2 gp = 1020 cp)
-  // doesn't get ceil'd up by a 1e-13 artifact.
-  const rawCp = (price.value * quantity / conv) * 100 * multiplier;
-  const cp = Math.ceil(Math.round(rawCp * 1e4) / 1e4);
-  if (cp <= 0) return { amount: 0, denomination: "gp", cp: 0 };
-  const { amount, denomination } = denomFromCp(cp);
-  return { amount, denomination, cp };
-}
+const useOnlyAvailable = () => { try { return !!game.settings.get("pick-up-stix", "useOnlyAvailableCurrency"); } catch { return false; } };
 
-/** Decompose a copper amount into a tidy { gp, sp, cp } payload for crediting the vendor. */
-function coinsFromCp(cp) {
-  const out = {};
-  const gp = Math.floor(cp / 100);
-  const sp = Math.floor((cp % 100) / 10);
-  const c = cp % 10;
-  if (gp) out.gp = gp;
-  if (sp) out.sp = sp;
-  if (c) out.cp = c;
-  return out;
+/** Clone actor currency and apply a signed {denom:count} delta. */
+function withDelta(actor, delta) {
+  const c = foundry.utils.deepClone(actor.system?.currency ?? {});
+  for ( const [d, n] of Object.entries(delta) ) c[d] = (c[d] ?? 0) + n;
+  return c;
 }
 
 /**
@@ -64,51 +32,71 @@ export const Dnd5ePurchase = {
     const price = item?.system?.price ?? {};
     return {
       value: Number(price.value) || 0,
-      denomination: price.denomination || CONFIG.DND5E.defaultCurrency || "gp"
+      denomination: price.denomination || this.currency?.defaultDenom || "gp"
     };
   },
 
   canAfford(buyer, item, quantity = 1) {
-    const mult = vendorItemMultiplier(item);
-    const { amount, denomination } = chargeAmount(this.getItemPrice(item), quantity, mult);
-    if (amount <= 0) return true;                     // free
-    if (!buyer) return false;
-    const { CurrencyManager } = game.dnd5e.applications;
-    const { remainder } = CurrencyManager.getActorCurrencyUpdates(
-      buyer, amount, denomination, { priority: "high" }   // coarsest whole coin → tidy change
-    );
-    return !remainder;
+    const cp = chargeCp(this.currency, this.getItemPrice(item), quantity, vendorItemMultiplier(item));
+    if ( cp <= 0 ) return true;
+    return this.getActorWealthCp(buyer) >= cp;
   },
 
   getItemChargeCp(item, quantity = 1) {
-    return chargeAmount(this.getItemPrice(item), quantity, vendorItemMultiplier(item)).cp;
+    return chargeCp(this.currency, this.getItemPrice(item), quantity, vendorItemMultiplier(item));
   },
 
   getActorWealthCp(actor) {
-    const currency = actor?.system?.currency ?? {};
-    let cp = 0;
-    for ( const [denom, { conversion }] of Object.entries(CONFIG.DND5E.currencies) ) {
-      cp += (currency[denom] ?? 0) * (100 / conversion);   // cp-per-coin = 100 / coins-per-gp
-    }
-    return cp;
+    return this.currency ? this.currency.bundleToBase(actor?.system?.currency ?? {}) : Infinity;
   },
 
-  async debitBuyerCp(buyer, cp) {
-    if ( cp <= 0 ) return true;
-    const { amount, denomination } = denomFromCp(cp);
-    const { CurrencyManager } = game.dnd5e.applications;
-    // Non-mutating change-making (mirrors CurrencyManager.deductActorCurrency, which applies
-    // `updates` = { system: { currency } }); we apply it ourselves with render suppressed and a
-    // marker the vendor sheet's currency hook skips, so the deduction doesn't flicker the shop.
-    // eslint-disable-next-line no-unused-vars
-    const { item, remainder, ...updates } = CurrencyManager.getActorCurrencyUpdates(buyer, amount, denomination, { priority: "high" });
-    if ( remainder ) {
-      dbg("dnd5e-purchase:debitBuyerCp", "buyer cannot afford", { buyer: buyer?.id, amount, denomination, cp });
-      return false;
+  /**
+   * Compute (without mutating) how a `cp` transfer from buyer→vendor would settle.
+   * Returns an opaque plan object, or null when the purchase can't be paid/changed.
+   *   magic mode: buyer pays via CurrencyManager (change conjured as needed).
+   *   real mode:  converter.settle over both real purses — no coins created.
+   */
+  planSettlement(buyer, vendor, cp) {
+    if ( cp <= 0 ) return { mode: "noop" };
+    if ( useOnlyAvailable() ) {
+      const plan = this.currency.settle(cp, buyer?.system?.currency ?? {}, vendor?.system?.currency ?? {});
+      dbg("dnd5e-purchase:planSettlement", "real mode", { cp, feasible: !!plan });
+      return plan ? { mode: "real", ...plan } : null;
     }
-    dbg("dnd5e-purchase:debitBuyerCp", "debit buyer (no render)", { buyer: buyer?.id, amount, denomination, cp });
-    await buyer.update(updates, { render: false, pickUpStix: { suppressVendorRender: true } });
-    return true;
+    if ( !buyer ) return null;
+    const { amount, denomination } = this.currency.coarsestCoin(cp);
+    const { CurrencyManager } = game.dnd5e.applications;
+    // eslint-disable-next-line no-unused-vars
+    const { item, remainder, ...buyerUpdates } = CurrencyManager.getActorCurrencyUpdates(buyer, amount, denomination, { priority: "high" });
+    if ( remainder ) { dbg("dnd5e-purchase:planSettlement", "magic mode: buyer cannot afford", { cp }); return null; }
+    dbg("dnd5e-purchase:planSettlement", "magic mode", { cp, amount, denomination });
+    return { mode: "magic", buyerUpdates, vendorCoins: this.currency.decompose(cp).coins };
+  },
+
+  /** Apply the buyer side of a plan (render-suppressed — fires before items move). */
+  async applyBuyerSettlement(buyer, plan) {
+    if ( !plan || plan.mode === "noop" ) return;
+    const opts = { render: false, pickUpStix: { suppressVendorRender: true } };
+    if ( plan.mode === "magic" ) {
+      dbg("dnd5e-purchase:applyBuyerSettlement", "magic debit", { buyer: buyer?.id });
+      await buyer.update(plan.buyerUpdates, opts);
+      return;
+    }
+    dbg("dnd5e-purchase:applyBuyerSettlement", "real debit", { buyer: buyer?.id, delta: plan.buyerDelta });
+    await buyer.update({ "system.currency": withDelta(buyer, plan.buyerDelta) }, opts);
+  },
+
+  /** Apply the vendor side of a plan (renders — the single final write of a transaction). */
+  async applyVendorSettlement(vendor, plan) {
+    if ( !plan || plan.mode === "noop" ) return;
+    const currency = foundry.utils.deepClone(vendor.system?.currency ?? {});
+    if ( plan.mode === "magic" ) {
+      for ( const [d, n] of Object.entries(plan.vendorCoins) ) currency[d] = (currency[d] ?? 0) + n;
+    } else {
+      for ( const [d, n] of Object.entries(plan.vendorDelta) ) currency[d] = (currency[d] ?? 0) + n;
+    }
+    dbg("dnd5e-purchase:applyVendorSettlement", "credit vendor (renders once)", { vendor: vendor?.id, mode: plan.mode });
+    await vendor.update({ "system.currency": currency }, { diff: false });
   },
 
   /**
@@ -121,14 +109,5 @@ export const Dnd5ePurchase = {
    */
   stacksOnPurchase(item) {
     return item?.type === "consumable";
-  },
-
-  async creditVendorCp(vendor, cp) {
-    const currency = foundry.utils.deepClone(vendor.system?.currency ?? {});
-    for ( const [denom, n] of Object.entries(coinsFromCp(cp)) ) currency[denom] = (currency[denom] ?? 0) + n;
-    // The last write of the checkout — render normally (diff:false so a zero-coin cart still
-    // forces the one re-render) so every client updates exactly once with the final state.
-    dbg("dnd5e-purchase:creditVendorCp", "credit vendor (renders once)", { vendor: vendor?.id, cp });
-    await vendor.update({ "system.currency": currency }, { diff: false });
   }
 };

--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -7,9 +7,9 @@ import { vendorPriceMultiplier, groupingFactorMultiplier } from "../../utils/ven
 /** Price as { display: ceil(gp), exact: gp, denomination }, scaled by `multiplier`. */
 export function priceInGP(item, multiplier = 1) {
   const { value, denomination } = item.system?.price ?? {};
-  const conv = CONFIG.DND5E.currencies?.[denomination]?.conversion;
-  if (!value || !conv) return { display: 0, exact: 0, denomination: denomination ?? "gp" };
-  const exact = (value / conv) * multiplier;
+  const conv = getAdapter().currency;
+  if ( !value || !conv ) return { display: 0, exact: 0, denomination: denomination ?? "gp" };
+  const exact = conv.convert(value, denomination, "gp") * multiplier;
   return { display: Math.ceil(exact), exact, denomination };
 }
 

--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -937,6 +937,20 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
       ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoBuyer"));
       return;
     }
+
+    // Pre-flight: total the cart and check buyer wealth before dispatching.
+    // Settlement feasibility (change availability) is the GM-side authoritative gate in purchaseCart.
+    const adapter = getAdapter();
+    const totalCp = cartItems.reduce((sum, [id, qty]) => {
+      const item = this.actor.items.get(id);
+      return sum + (item ? adapter.getItemChargeCp(item, qty) : 0);
+    }, 0);
+    if ( totalCp > 0 && adapter.getActorWealthCp(buyer) < totalCp ) {
+      dbg("vendorSheet:onCheckoutCart", "buyer lacks wealth, bail", { totalCp, buyer: buyer.id });
+      ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotEnoughCoin"));
+      return;
+    }
+
     // Resolve names NOW — the GM mutates vendor stock during the purchase, so the rows may be gone
     // by the time the self-notify fires. Drop entries whose item vanished (GM notify is authoritative).
     const lines = cartItems.reduce((acc, [id, qty]) => {
@@ -1083,8 +1097,11 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
 
   /** Format a copper amount as a short coin string, e.g. 3060 → "30 gp 6 sp". */
   #formatCp(cp) {
-    const gp = Math.floor(cp / 100), sp = Math.floor((cp % 100) / 10), c = cp % 10;
-    return [gp && `${gp} gp`, sp && `${sp} sp`, c && `${c} cp`].filter(Boolean).join(" ") || "0 gp";
+    const conv = getAdapter().currency;
+    if ( !conv ) return `${cp}`;
+    const { coins } = conv.decompose(cp);
+    const parts = conv.changeDenoms.filter(d => coins[d]).map(d => `${coins[d]} ${d}`);
+    return parts.join(" ") || `0 ${conv.defaultDenom}`;
   }
 
   static async #onBuyWare(event, target) {
@@ -1108,6 +1125,12 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     if ( !adapter.canAfford(buyer, item, qty) ) {
       dbg("vendorSheet:onBuyWare", "buyer cannot afford qty, bail", { item: item.id, buyer: buyer.id, qty });
       ui.notifications.warn(game.i18n.format("INTERACTIVE_ITEMS.Notify.NotEnoughCoin", { name: item.name }));
+      return;
+    }
+    const chargeCp = adapter.getItemChargeCp(item, qty);
+    if ( chargeCp > 0 && !adapter.planSettlement(buyer, item.parent, chargeCp) ) {
+      dbg("vendorSheet:onBuyWare", "no change available, bail", { item: item.id, buyer: buyer.id, qty });
+      ui.notifications.warn(game.i18n.format("INTERACTIVE_ITEMS.Notify.NoChange", { name: item.name }));
       return;
     }
 

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -218,6 +218,13 @@ Hooks.once("init", async () => {
     default: 500
   });
 
+  game.settings.register(MODULE_ID, "useOnlyAvailableCurrency", {
+    scope: "world",
+    config: false,
+    type: Boolean,
+    default: false
+  });
+
   // Hidden world setting that persists the install-tracker state (sent flag,
   // version, attempt count, last error). Managed entirely by installTracker.mjs.
   registerInstallTrackerSetting();

--- a/scripts/settings/VendorSettingsApp.mjs
+++ b/scripts/settings/VendorSettingsApp.mjs
@@ -33,6 +33,7 @@ export default class VendorSettingsApp extends HandlebarsApplicationMixin(Applic
       vendorFavorMax: gs("vendorFavorMax"),
       vendorFavorFactorMax: gs("vendorFavorFactorMax"),
       vendorMaxPriceFactor: gs("vendorMaxPriceFactor"),
+      useOnlyAvailableCurrency: gs("useOnlyAvailableCurrency"),
       buttons: [{ type: "submit", icon: "fa-solid fa-save", label: "Save Settings" }]
     };
   }
@@ -45,5 +46,6 @@ export default class VendorSettingsApp extends HandlebarsApplicationMixin(Applic
     await ss("vendorFavorMax", Number(d.vendorFavorMax ?? 5));
     await ss("vendorFavorFactorMax", Number(d.vendorFavorFactorMax ?? 20));
     await ss("vendorMaxPriceFactor", Math.max(0, Number(d.vendorMaxPriceFactor ?? 500)));
+    await ss("useOnlyAvailableCurrency", !!d.useOnlyAvailableCurrency);
   }
 }

--- a/scripts/transfer/ItemTransfer.mjs
+++ b/scripts/transfer/ItemTransfer.mjs
@@ -638,20 +638,18 @@ export async function purchaseItem(vendorActorId, itemId, buyerActorId, quantity
 
   const qty = Math.max(1, Number(quantity) || 1);
 
-  // Re-validate affordability GM-side (defends against a stale client / race).
-  if (!adapter.canAfford(buyer, item, qty)) {
-    dbg("xfer:purchaseItem", "GM-side affordability failed, bail", { itemId, buyer: buyer.id });
-    return false;
-  }
-
   const totalCp = adapter.getItemChargeCp(item, qty);
 
-  // Debit the buyer first (also the affordability gate). No re-render — the single vendor
-  // credit at the end is the one write that renders, so the shop updates once (no flicker).
-  if (!(await adapter.debitBuyerCp(buyer, totalCp))) {
-    dbg("xfer:purchaseItem", "debit failed, no item moved", { itemId, buyer: buyer.id });
+  // Compute the settlement plan (validates affordability + change feasibility for both modes).
+  // Re-validates GM-side, defending against stale client state / race.
+  const plan = adapter.planSettlement(buyer, vendor, totalCp);
+  if ( !plan ) {
+    dbg("xfer:purchaseItem", "cannot settle, bail", { itemId, buyer: buyer.id });
     return false;
   }
+
+  // Debit the buyer first (render suppressed) — the single vendor credit at the end renders.
+  await adapter.applyBuyerSettlement(buyer, plan);
 
   // Add the purchased item(s) to the buyer. Consumables land as one stack of `qty`; other types
   // split into `qty` qty-1 documents. This create renders the buyer's OWN sheet once.
@@ -661,7 +659,7 @@ export async function purchaseItem(vendorActorId, itemId, buyerActorId, quantity
   await decrementOrDeleteItem(item, qty, { render: false });
 
   // Credit the vendor LAST and let it render → exactly one re-render on every client.
-  await adapter.creditVendorCp(vendor, totalCp);
+  await adapter.applyVendorSettlement(vendor, plan);
 
   notifyPurchase(item.name, vendor.name, qty);
   return true;
@@ -708,18 +706,20 @@ export async function purchaseCart(vendorActorId, cartItems, buyerActorId) {
   const totalUnits = resolved.reduce((sum, { qty }) => sum + qty, 0);
   dbg("xfer:purchaseCart", "cart totalled", { totalCp, items: resolved.length, units: totalUnits });
 
-  // GM-side wealth re-check (defends against stale client state / race).
-  if ( adapter.getActorWealthCp(buyer) < totalCp ) {
-    dbg("xfer:purchaseCart", "buyer cannot afford cart total, bail", { totalCp, buyer: buyer.id });
+  // Compute the settlement plan (validates affordability + change feasibility for both modes).
+  // Re-validates GM-side, defending against stale client state / race.
+  const plan = adapter.planSettlement(buyer, vendor, totalCp);
+  if ( !plan ) {
+    dbg("xfer:purchaseCart", "cannot settle, bail", { totalCp, buyer: buyer.id });
+    const noChangeKey = adapter.getActorWealthCp(buyer) >= totalCp
+      ? "INTERACTIVE_ITEMS.Notify.NoChange"
+      : "INTERACTIVE_ITEMS.Notify.NotEnoughCoin";
+    ui.notifications.warn(game.i18n.localize(noChangeKey));
     return false;
   }
 
-  // Debit the buyer first (also the affordability gate). No re-render here — the single
-  // vendor-credit write at the very end is the one that renders, so the shop updates once.
-  if ( !(await adapter.debitBuyerCp(buyer, totalCp)) ) {
-    dbg("xfer:purchaseCart", "debit failed, no items moved");
-    return false;
-  }
+  // Debit the buyer first (render suppressed) — the single vendor credit at the end renders.
+  await adapter.applyBuyerSettlement(buyer, plan);
 
   // Build one batched set of moves. The buyer create renders the buyer's OWN sheet once
   // (reflecting the already-debited gold + new items); the vendor stock update/delete are
@@ -745,7 +745,7 @@ export async function purchaseCart(vendorActorId, cartItems, buyerActorId) {
   if ( toDelete.length ) await vendor.deleteEmbeddedDocuments("Item", toDelete, { deleteContents: true, render: false });
 
   // Credit the vendor LAST and let it render → exactly one re-render on every client.
-  await adapter.creditVendorCp(vendor, totalCp);
+  await adapter.applyVendorSettlement(vendor, plan);
 
   for ( const { item, qty } of resolved ) notifyPurchase(item.name, vendor.name, qty);
   dbg("xfer:purchaseCart", "cart purchase complete", { units: totalUnits });

--- a/scripts/utils/CurrencyConverter.mjs
+++ b/scripts/utils/CurrencyConverter.mjs
@@ -1,0 +1,142 @@
+import { dbg } from "./debugLog.mjs";
+
+/**
+ * System-agnostic currency converter. Parameterised by a denomination table that
+ * maps each denomination key to its value in the system's base (smallest) unit.
+ * dnd5e: base is copper, table { pp:1000, gp:100, ep:50, sp:10, cp:1 }.
+ *
+ * The converter never reads a system CONFIG itself — each adapter builds the table
+ * and hands it in, so the math here stays generic and unit-testable.
+ */
+export class CurrencyConverter {
+  /**
+   * @param {object} opts
+   * @param {Record<string, number>} opts.denominations  denom -> value in base units (must include the base = 1)
+   * @param {string} opts.baseDenom        smallest denomination key
+   * @param {string} [opts.defaultDenom]   denomination assumed when a price omits one
+   * @param {string[]} [opts.changeDenoms] denominations used when generating change (defaults to all)
+   */
+  constructor({ denominations, baseDenom, defaultDenom, changeDenoms } = {}) {
+    this.denominations = denominations ?? {};
+    this.baseDenom = baseDenom;
+    this.defaultDenom = defaultDenom ?? baseDenom;
+    // Coarse → fine (largest base value first), for greedy decomposition.
+    this.ordered = Object.keys(this.denominations).sort((a, b) => this.denominations[b] - this.denominations[a]);
+    this.changeDenoms = changeDenoms ?? this.ordered;
+  }
+
+  /** Base-unit value of one coin of `denom` (0 if unknown). */
+  unit(denom) { return this.denominations[denom] ?? 0; }
+
+  /** `amount` coins of `denom` → base units. */
+  toBase(amount, denom) { return (Number(amount) || 0) * this.unit(denom); }
+
+  /** `amount` of `from` → equivalent (possibly fractional) count of `to`. */
+  convert(amount, from, to) {
+    const u = this.unit(to);
+    return u ? this.toBase(amount, from) / u : 0;
+  }
+
+  /** Sum a `{denom: count}` bundle into base units. */
+  bundleToBase(coins = {}) {
+    let total = 0;
+    for ( const [denom, n] of Object.entries(coins) ) total += this.toBase(n, denom);
+    return total;
+  }
+
+  /** Signed base-unit difference between two bundles (a − b). */
+  difference(a = {}, b = {}) { return this.bundleToBase(a) - this.bundleToBase(b); }
+
+  /**
+   * Greedy largest-first decomposition of a base amount into whole coins over `denoms`.
+   * Returns `{ coins, remainder }`; remainder is 0 when `denoms` includes the base denom.
+   */
+  decompose(baseAmount, denoms = this.changeDenoms) {
+    let rest = Math.max(0, Math.round(baseAmount));
+    const coins = {};
+    for ( const denom of denoms.slice().sort((a, b) => this.unit(b) - this.unit(a)) ) {
+      const u = this.unit(denom);
+      if ( u <= 0 ) continue;
+      const n = Math.floor(rest / u);
+      if ( n > 0 ) { coins[denom] = n; rest -= n * u; }
+    }
+    return { coins, remainder: rest };
+  }
+
+  /**
+   * Coarsest single whole-coin representation of a base amount (largest denom that
+   * divides it exactly). e.g. 1020 cp → { amount:102, denomination:"sp" }.
+   */
+  coarsestCoin(baseAmount) {
+    const v = Math.max(0, Math.round(baseAmount));
+    for ( const denom of this.ordered ) {
+      const u = this.unit(denom);
+      if ( u > 0 && v % u === 0 ) return { amount: v / u, denomination: denom };
+    }
+    return { amount: v, denomination: this.baseDenom };
+  }
+
+  /**
+   * Settlement using ONLY coins each party holds (no creation). Find a buyer payment
+   * (subset of `buyerCoins`) and vendor change (subset of `vendorCoins`) with
+   * payment − change === priceBase. Returns signed {denom:count} deltas, or null.
+   *
+   * The buyer overpays by at most one coin's worth, so vendor change is bounded by the
+   * largest denomination value; we search that change window for a feasible pairing.
+   * (A solution needing change larger than the biggest single coin — pathological purses —
+   * is reported as "no change possible".)
+   */
+  settle(priceBase, buyerCoins = {}, vendorCoins = {}) {
+    const P = Math.max(0, Math.round(priceBase));
+    if ( P === 0 ) return { buyerDelta: {}, vendorDelta: {} };
+    if ( this.bundleToBase(buyerCoins) < P ) return null;
+
+    const cap = Math.max(0, ...this.ordered.map(d => this.unit(d)));
+    const buyerSums = this.#reachableSums(buyerCoins, P + cap);
+    const vendorSums = this.#reachableSums(vendorCoins, cap);
+
+    for ( let C = 0; C <= cap; C++ ) {
+      if ( !vendorSums.has(C) || !buyerSums.has(P + C) ) continue;
+      const payment = this.#coinsForSum(buyerCoins, P + C);
+      const change  = this.#coinsForSum(vendorCoins, C);
+      if ( payment && change ) {
+        const buyerDelta = {}, vendorDelta = {};
+        for ( const d of this.ordered ) {
+          const net = (change[d] ?? 0) - (payment[d] ?? 0);
+          if ( net ) buyerDelta[d] = net;
+          if ( net ) vendorDelta[d] = -net;
+        }
+        dbg("CurrencyConverter:settle", "settled", { P, C, payment, change });
+        return { buyerDelta, vendorDelta };
+      }
+    }
+    dbg("CurrencyConverter:settle", "no feasible settlement", { P, buyerCoins, vendorCoins });
+    return null;
+  }
+
+  /** Set of subset-sum base values in [0, max] reachable from a coin bundle (bounded knapsack DP). */
+  #reachableSums(coins, max) {
+    const reach = new Uint8Array(max + 1); reach[0] = 1;
+    for ( const [denom, count] of Object.entries(coins) ) {
+      const u = this.unit(denom);
+      if ( u <= 0 ) continue;
+      for ( let k = 0; k < count; k++ )
+        for ( let s = max; s >= u; s-- ) if ( reach[s - u] ) reach[s] = 1;
+    }
+    const set = new Set();
+    for ( let s = 0; s <= max; s++ ) if ( reach[s] ) set.add(s);
+    return set;
+  }
+
+  /** A concrete {denom:count} subset of `coins` summing exactly to `target`, or null. Greedy largest-first. */
+  #coinsForSum(coins, target) {
+    let rest = target; const out = {};
+    for ( const denom of this.ordered ) {
+      const u = this.unit(denom), have = coins[denom] ?? 0;
+      if ( u <= 0 || have <= 0 ) continue;
+      const n = Math.min(have, Math.floor(rest / u));
+      if ( n > 0 ) { out[denom] = n; rest -= n * u; }
+    }
+    return rest === 0 ? out : null;
+  }
+}

--- a/templates/settings/vendor-settings.hbs
+++ b/templates/settings/vendor-settings.hbs
@@ -29,5 +29,13 @@
       </div>
       <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.VendorMaxPriceFactor.Hint"}}</p>
     </div>
+
+    <div class="form-group">
+      <label>{{localize "INTERACTIVE_ITEMS.Settings.UseOnlyAvailableCurrency.Name"}}</label>
+      <div class="form-fields">
+        <input type="checkbox" name="useOnlyAvailableCurrency" {{checked useOnlyAvailableCurrency}}>
+      </div>
+      <p class="hint">{{localize "INTERACTIVE_ITEMS.Settings.UseOnlyAvailableCurrency.Hint"}}</p>
+    </div>
   </fieldset>
 </div>


### PR DESCRIPTION
Introduces a system-agnostic `CurrencyConverter` class and routes all dnd5e vendor currency math through it. Adds an optional world setting to restrict purchases to coins the buyer and vendor actually hold (exact-change mode via a bounded knapsack solver), with clear failure notifications when change can't be made.