### PR TITLE
feat(vendor): rich item tooltip on shop wares

### DIFF
--- a/scripts/adapter/SystemAdapter.mjs
+++ b/scripts/adapter/SystemAdapter.mjs
@@ -776,6 +776,37 @@ export default class SystemAdapter {
    */
   async createItemsWithContents(items, options) { _abstract("createItemsWithContents"); }
 
+  // === Item tooltips =========================================================
+
+  /**
+   * Decorate `element` so hovering it shows a rich tooltip describing `item`.
+   *
+   * The base implementation builds a static fallback card (image, name,
+   * description) and sets it as Foundry's `data-tooltip-html`, which the core
+   * TooltipManager renders as HTML (sanitised via `foundry.utils.cleanHTML`)
+   * — behaviour confirmed identical on Foundry v13 and v14. Systems with a
+   * native rich item tooltip (dnd5e) override this to wire their own.
+   *
+   * Idempotent: safe to call on every render (it overwrites the attributes).
+   *
+   * @param {HTMLElement} element - The element that triggers the tooltip on hover.
+   * @param {Item} item - The item the tooltip describes.
+   */
+  applyItemTooltip(element, item) {
+    if ( !element || !item ) return;
+    const esc = foundry.utils.escapeHTML ?? (s => String(s ?? ""));
+    const img = item.img ? `<img src="${item.img}" alt="">` : "";
+    const descHtml = item.system?.description?.value;
+    const desc = descHtml ? `<div class="pus-tt-desc">${descHtml}</div>` : "";
+    element.dataset.tooltipHtml =
+      `<div class="pus-item-tooltip">`
+      + `<div class="pus-tt-header">${img}<span class="pus-tt-name">${esc(item.name)}</span></div>`
+      + desc
+      + `</div>`;
+    element.dataset.tooltipClass = "pus-item-tooltip";
+    element.dataset.tooltipDirection ??= "LEFT";
+  }
+
   // === CSS class constants ===================================================
 
   /**

--- a/scripts/adapter/dnd5e/index.mjs
+++ b/scripts/adapter/dnd5e/index.mjs
@@ -4,6 +4,7 @@ import { Dnd5eContainer } from "./container.mjs";
 import { Dnd5eSheets } from "./sheets.mjs";
 import { Dnd5eHooks } from "./hooks.mjs";
 import { Dnd5ePurchase } from "./purchase.mjs";
+import { Dnd5eTooltip } from "./tooltip.mjs";
 import Dnd5eVendorModel from "./vendorModel.mjs";
 import { buildDnd5eCurrencyConverter } from "./currency.mjs";
 
@@ -78,3 +79,4 @@ Object.assign(Dnd5eAdapter.prototype, Dnd5eContainer);
 Object.assign(Dnd5eAdapter.prototype, Dnd5eSheets);
 Object.assign(Dnd5eAdapter.prototype, Dnd5eHooks);
 Object.assign(Dnd5eAdapter.prototype, Dnd5ePurchase);
+Object.assign(Dnd5eAdapter.prototype, Dnd5eTooltip);

--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -43,7 +43,7 @@ export function typeSubtitle(item) {
 }
 
 /** Item description as full single-line plaintext ("" if none). CSS clamps the
- *  display; the sheet adds a hover tooltip when it's visually truncated. */
+ *  visible line; the full description now appears in the ware's hover item card. */
 export function descriptionSubtitle(item) {
   const html = item.system?.description?.value;                    // HTMLField, nullable
   if (!html) return "";

--- a/scripts/adapter/dnd5e/tooltip.mjs
+++ b/scripts/adapter/dnd5e/tooltip.mjs
@@ -1,0 +1,28 @@
+/**
+ * dnd5e item-tooltip concern. Mixed onto Dnd5eAdapter.prototype.
+ *
+ * Reproduces the native rich item tooltip (icon, name, type, description,
+ * property pills) on an arbitrary element by mirroring dnd5e's own wiring: a
+ * "loading" section keyed by the item UUID placed in Foundry's `data-tooltip`,
+ * plus the dnd5e tooltip classes. dnd5e's global `Tooltips5e` MutationObserver
+ * (`game.dnd5e.tooltips`) watches the shared `#tooltip` element, resolves the
+ * UUID via `fromUuid` on hover, calls `item.richTooltip()`, and swaps in the
+ * real card — so content is built lazily and stays identification-aware,
+ * exactly like the inventory rows. Works for embedded vendor items and
+ * synthetic-token items alike (both resolve via `fromUuid`).
+ */
+export const Dnd5eTooltip = {
+  applyItemTooltip(element, item) {
+    if ( !element || !item?.uuid ) return;
+    // Native lazy trigger: Tooltips5e replaces this loading section on hover.
+    element.dataset.tooltip =
+      `<section class="loading" data-uuid="${item.uuid}">`
+      + `<i class="fas fa-spinner fa-spin-pulse"></i></section>`;
+    // Version-gated class list (dnd5e): 4.0.0 = "dnd5e2 dnd5e-tooltip item-tooltip";
+    // 5.x adds "themed theme-light". The extra theme tokens are inert on 4.0.0,
+    // so this superset is safe on both; "item-tooltip" is the load-bearing token
+    // dnd5e's _positionItemTooltip keys on.
+    element.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip themed theme-light";
+    element.dataset.tooltipDirection ??= "LEFT";
+  }
+};

--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -184,7 +184,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     // Re-evaluate cart state and buy-button gating after core _toggleDisabled has run.
     // #refreshCart owns the disabled state for both basket toggles and buy buttons.
     this.#refreshCart();
-    this.#refreshSubtitleTooltips();
+    this.#applyWareTooltips();
     this.#injectInventoryShopToggles();
     this.#injectInventoryShopAllToggle();
     this.#fixListControlsPrefs();
@@ -385,21 +385,29 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
    */
   changeTab(tab, group, options) {
     super.changeTab(tab, group, options);
-    if ( tab === "shop" ) this.#refreshSubtitleTooltips();
     this.#applyShopHeaderVisibility();   // swap abilities + legendary visibility with the active tab
-    this.#injectGmShopBio();               // show/hide the header bio with the active tab
+    this.#injectGmShopBio();             // show/hide the header bio with the active tab
   }
 
   /**
-   * Tooltip the full subtitle on any `.shop-ware-sub` that's visually clipped. Needs the
-   * shop content visible (a hidden tab has no layout box → scrollWidth/clientWidth are 0),
-   * so it's called from `_onRender` (player / re-render while on Shop) and `changeTab`.
+   * Decorate each shop ware's identity block (icon + name + subtitle) with a
+   * rich item tooltip via the adapter — the native dnd5e item card on dnd5e, a
+   * formatted fallback elsewhere. Replaces the old subtitle-clip tooltip; the
+   * card supersedes it (it carries the full description). Pure attribute setting
+   * (no layout reads), so it works even while the Shop tab is hidden at first
+   * render — no changeTab re-run needed.
    */
-  #refreshSubtitleTooltips() {
-    for ( const sub of this.element.querySelectorAll(".shop-ware-sub") ) {
-      if ( sub.scrollWidth > sub.clientWidth ) sub.dataset.tooltip = sub.textContent;
-      else delete sub.dataset.tooltip;
+  #applyWareTooltips() {
+    const adapter = getAdapter();
+    let wares = 0;
+    for ( const row of this.element.querySelectorAll(".shop-ware[data-item-id]") ) {
+      const item = this.actor.items.get(row.dataset.itemId);
+      const main = row.querySelector(".shop-ware-main");
+      if ( !item || !main ) continue;
+      adapter.applyItemTooltip(main, item);
+      wares++;
     }
+    dbg("vendorSheet:applyWareTooltips", { wares });
   }
 
   /**


### PR DESCRIPTION
Hovering a shop ware's icon, name, or subtitle now shows the native dnd5e rich item card (icon, name, type, description, property pills) instead of a plain text clip. Adds an `applyItemTooltip` contract method to `SystemAdapter` with a system-agnostic fallback for future systems.