### PR TITLE
feat(vendor): global price factor

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -321,6 +321,10 @@
         "Type": "Type",
         "Rarity": "Rarity"
       },
+      "GlobalFactor": {
+        "Label": "Global Factor",
+        "Tooltip": "Applies to all items. Compounds with other factors."
+      },
       "Factor": {
         "Items": "items",
         "Hint": "Price factor — max is",

--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -1,6 +1,6 @@
 import { getAdapter } from "../index.mjs";
 import { dbg } from "../../utils/debugLog.mjs";
-import { vendorPriceMultiplier, groupingFactorMultiplier } from "../../utils/vendorPricing.mjs";
+import { vendorPriceMultiplier, groupingFactorMultiplier, globalFactorMultiplier } from "../../utils/vendorPricing.mjs";
 
 /* ---------- dnd5e display helpers (system-specific; kept in the dnd5e adapter) ---------- */
 
@@ -21,10 +21,11 @@ export function vendorItemMultiplier(item) {
   const vendor = item?.parent;
   if ( !vendor ) return 1;
   const favorM  = vendorPriceMultiplier(vendor);
+  const globalM = globalFactorMultiplier(vendor);
   const typeM   = groupingFactorMultiplier(vendor, "type", groupType(item));
   const rarityM = groupingFactorMultiplier(vendor, "rarity", rarityOf(item).key);
-  const m = favorM * typeM * rarityM;
-  dbg("shopGrouping:vendorItemMultiplier", { item: item.id, favorM, typeM, rarityM, m });
+  const m = favorM * globalM * typeM * rarityM;
+  dbg("shopGrouping:vendorItemMultiplier", { item: item.id, favorM, globalM, typeM, rarityM, m });
   return m;
 }
 

--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -7,7 +7,7 @@ import { buildShop, DEFAULT_GROUPING, buildSettingsGroups } from "./shopGrouping
 import { createRowControl } from "../../utils/domButtons.mjs";
 import { emitSocketEvent } from "../../socket/SocketHandler.mjs";
 import { getVendorQueue, findUserVendorQueues, promptVendorQueueSwitch } from "../../utils/vendorQueue.mjs";
-import { getVendorFavor, getVendorFavorFactor, getFavorMin, getFavorMax, getFavorFactorMin, getFavorFactorMax, getFavorFactorDefault, getVendorGroupingFactor, getMaxPriceFactor } from "../../utils/vendorPricing.mjs";
+import { getVendorFavor, getVendorFavorFactor, getFavorMin, getFavorMax, getFavorFactorMin, getFavorFactorMax, getFavorFactorDefault, getVendorGroupingFactor, getVendorGlobalFactor, getMaxPriceFactor } from "../../utils/vendorPricing.mjs";
 import { saveDefaultInventory, computeRestockDiff, applyRestock, promptRestockRemoval }
   from "../../utils/vendorInventory.mjs";
 
@@ -263,15 +263,21 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     if ( !game.user.isGM ) return;
     const rawFavor = Number(this.actor.getFlag("pick-up-stix", "favor"));
     const rawFactor = Number(this.actor.getFlag("pick-up-stix", "favorFactor"));
+    const rawGlobal = Number(this.actor.getFlag("pick-up-stix", "globalPriceFactor"));
+    const max = getMaxPriceFactor();
     const clampedFavor = Number.isFinite(rawFavor)
       ? Math.max(getFavorMin(), Math.min(getFavorMax(), Math.round(rawFavor)))
       : null;
     const clampedFactor = Number.isFinite(rawFactor)
       ? Math.max(getFavorFactorMin(), Math.min(getFavorFactorMax(), Math.round(rawFactor)))
       : null;
+    const clampedGlobal = Number.isFinite(rawGlobal)
+      ? Math.max(0, Math.min(max, Math.round(rawGlobal)))
+      : null;
     const updates = {};
     if ( clampedFavor !== null && clampedFavor !== rawFavor ) updates["flags.pick-up-stix.favor"] = clampedFavor;
     if ( clampedFactor !== null && clampedFactor !== rawFactor ) updates["flags.pick-up-stix.favorFactor"] = clampedFactor;
+    if ( clampedGlobal !== null && clampedGlobal !== rawGlobal ) updates["flags.pick-up-stix.globalPriceFactor"] = clampedGlobal;
     if ( !foundry.utils.isEmpty(updates) ) {
       dbg("vendorSheet:clampFavorFlags", { vendor: this.actor.id, updates });
       await this.actor.update(updates);
@@ -345,7 +351,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     }
   }
 
-  /** Wire the grouping-factor sliders + editable numeric inputs in the settings panel (GM only). */
+  /** Wire the global price factor slider and per-grouping sliders in the settings panel (GM only). */
   #wireSettingsControls() {
     if ( !game.user.isGM ) return;
     const list = this.element.querySelector(".pus-factor-list");
@@ -353,6 +359,23 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     list.dataset.pusWired = "1";
     const max = getMaxPriceFactor();
     const clamp = (v) => Math.max(0, Math.min(max, Math.round(Number(v) || 0)));
+
+    // Global price factor: range + number input above the settings-by toggle.
+    const globalRoot = list.closest(".pus-favor-content-inner");
+    const globalRange = globalRoot?.querySelector(".pus-global-factor-range");
+    const globalNum   = globalRoot?.querySelector(".pus-global-factor-num");
+    if ( globalRange ) {
+      globalRange.addEventListener("input", () => { if ( globalNum ) globalNum.value = String(clamp(globalRange.value)); });
+      if ( globalNum ) globalNum.addEventListener("input", () => { globalRange.value = String(clamp(globalNum.value)); });
+      const commitGlobal = async (el) => {
+        const v = clamp(el.value);
+        dbg("vendorSheet:globalFactorChange", { vendor: this.actor.id, value: v });
+        await this.actor.setFlag("pick-up-stix", "globalPriceFactor", v);
+      };
+      globalRange.addEventListener("change", () => commitGlobal(globalRange));
+      if ( globalNum ) globalNum.addEventListener("change", () => commitGlobal(globalNum));
+    }
+
     for ( const row of list.querySelectorAll(".pus-factor-row") ) {
       const range = row.querySelector(".pus-factor-range");
       const num   = row.querySelector(".pus-factor-num");
@@ -848,6 +871,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     const physical = this.actor.items.filter(i => getAdapter().isPhysicalItem(i));
     const groups = buildSettingsGroups(physical, this.#settingsBy);
     const maxFactor = getMaxPriceFactor();
+    const globalFactor = getVendorGlobalFactor(this.actor);
     return {
       by: this.#settingsBy,
       dimensions: [
@@ -855,6 +879,8 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
         { key: "rarity", label: "INTERACTIVE_ITEMS.Vendor.SettingsBy.Rarity", active: this.#settingsBy === "rarity" }
       ],
       maxFactor,
+      globalFactor,
+      globalFactorDisplay: (globalFactor / 100).toFixed(2),
       rows: groups.map(g => {
         const factor = getVendorGroupingFactor(this.actor, this.#settingsBy, g.key);
         return {

--- a/scripts/utils/vendorPricing.mjs
+++ b/scripts/utils/vendorPricing.mjs
@@ -30,6 +30,18 @@ export const getFavorFactorDefault = () => 1;
 /** Configured maximum per-grouping price factor (module setting `vendorMaxPriceFactor`, default 500). */
 export const getMaxPriceFactor = () => gs("vendorMaxPriceFactor", PRICE_FACTOR_MAX);
 
+/** A vendor's stored global price factor (percent), clamped to [0, maxPriceFactor]; absent → 100. */
+export function getVendorGlobalFactor(vendor) {
+  const raw = Number(vendor?.getFlag?.("pick-up-stix", "globalPriceFactor"));
+  if ( !Number.isFinite(raw) ) return PRICE_FACTOR_DEFAULT;
+  return Math.max(0, Math.min(getMaxPriceFactor(), Math.round(raw)));
+}
+
+/** Cost multiplier for the global factor: factor% / 100 (default → 1.0). */
+export function globalFactorMultiplier(vendor) {
+  return getVendorGlobalFactor(vendor) / 100;
+}
+
 /** A vendor's Favor, clamped to the configured [favorMin, favorMax]; absent / non-numeric → 0. */
 export function getVendorFavor(vendor) {
   const raw = Number(vendor?.getFlag?.("pick-up-stix", "favor"));

--- a/templates/vendor/shop.hbs
+++ b/templates/vendor/shop.hbs
@@ -36,6 +36,19 @@
       </div>
       <hr class="pus-settings-divider" />
 
+      <div class="pus-favor-control">
+        <label class="pus-favor-label" data-tooltip="{{ localize "INTERACTIVE_ITEMS.Vendor.GlobalFactor.Tooltip" }}">
+          {{ localize "INTERACTIVE_ITEMS.Vendor.GlobalFactor.Label" }}
+        </label>
+        <div class="pus-factor-slider-row">
+          <input type="range" class="pus-factor-range pus-global-factor-range" min="0" max="{{ settings.maxFactor }}"
+                 step="1" value="{{ settings.globalFactor }}" />
+          <input type="number" class="pus-factor-num pus-global-factor-num" min="0" max="{{ settings.maxFactor }}"
+                 step="1" value="{{ settings.globalFactor }}" />
+        </div>
+        <p class="hint pus-factor-hint">{{ localize "INTERACTIVE_ITEMS.Vendor.Factor.Hint" }} {{ settings.maxFactor }}%</p>
+      </div>
+
       <div class="pus-settings-by">
         <span class="pus-settings-by-label">{{ localize "INTERACTIVE_ITEMS.Vendor.SettingsBy.Label" }}</span>
         <div class="pus-settings-by-toggle">


### PR DESCRIPTION
Adds a global price factor slider to the vendor settings panel that applies to all items and compounds with favor, type, and rarity multipliers. Stored per-vendor as a flag; clamped on sheet open.