### PR TITLE
feat(vendor): move portrait/token toggle into header name column

### DIFF
--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -177,6 +177,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     this.#injectPortraitClip();                 // wrap the portrait so the figure masks at the frame
     this.#repositionEditToggle();               // move dnd5e's edit toggle next to the XP badge
     this.#repositionInitiativeDie();            // move initiative d20 above the vendor name (GM only)
+    this.#repositionPortraitToggle();           // move portrait/token toggle above the initiative die (GM only, edit mode)
     this.#applyShopHeaderVisibility();   // keep NPC abilities card + legendary row hidden on the Shop tab
     await this.#injectGmShopBio();          // mirror the player storefront bio under the name (Shop tab)
     this.#wireFavorControls();              // wire favor sliders in the Shop tab (GM only)
@@ -238,15 +239,35 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     crXp.before(slider);
   }
 
+  /**
+   * Move dnd5e's portrait/token image toggle (`flags.dnd5e.showTokenPortrait`) from the
+   * portrait column to sit just above the relocated initiative die in the name container,
+   * left-aligned with it. GM only. The toggle is only rendered in edit mode (the template
+   * wraps it in `{{#if editable}}`), so a missing-toggle bail naturally scopes this to edit
+   * mode. Idempotent and re-checked each render since dnd5e re-renders the header part.
+   * Runs AFTER #repositionInitiativeDie so the initiative wrapper is already in the name
+   * container to anchor against. (Foundry v13 + v14, dnd5e NPC header.)
+   */
+  #repositionPortraitToggle() {
+    if ( !this.actor.isOwner ) return;
+    const input = this.element.querySelector('.sheet-header input[name="flags.dnd5e.showTokenPortrait"]');
+    const toggle = input?.closest("label.slide-toggle");
+    if ( !toggle ) return;
+    const wrapper = this.element.querySelector(".sheet-header .right.stats .top .left .initiative-wrapper");
+    if ( !wrapper ) return;
+    if ( wrapper.previousElementSibling === toggle ) return;
+    dbg("vendorSheet:repositionPortraitToggle", "moving portrait toggle above initiative die");
+    wrapper.before(toggle);
+  }
+
   /** Move dnd5e's initiative d20 from its portrait overlay to above the vendor name (GM only). */
   #repositionInitiativeDie() {
     if ( !this.actor.isOwner ) return;
-    // Name lives in .sheet-header .right.stats > .top > .left (in edit mode it's an input).
     const nameContainer = this.element.querySelector(".sheet-header .right.stats .top .left");
     if ( !nameContainer ) return;
     const name = nameContainer.querySelector(".document-name");
     if ( !name ) return;
-    if ( name.previousElementSibling?.classList.contains("initiative-wrapper") ) return; // already moved
+    if ( name.previousElementSibling?.classList.contains("initiative-wrapper") ) return;
     const wrapper = this.element.querySelector(".sheet-header .portrait .initiative-wrapper");
     if ( !wrapper ) return;
     dbg("vendorSheet:repositionInitiativeDie", "moving initiative die above vendor name");

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -954,6 +954,17 @@
   font-size: inherit;
 }
 
+/* GM NPC edit mode: the portrait/token toggle is moved by JS (#repositionPortraitToggle) from the
+   portrait column to .right.stats > .top > .left, just above the relocated initiative die. dnd5e
+   stretches it full-width (width:100%) with an 8px bottom margin; constrain + left-align it so it
+   sits as a compact control above the d20, with the column's own 4px gap handling spacing. */
+.vendor-sheet.dnd5e2.sheet.actor.npc .sheet-header .right.stats .top .left label.slide-toggle.header-interactable {
+  width: fit-content;
+  align-self: flex-start;
+  margin-bottom: 0;
+  gap: 36px;
+}
+
 /* Vendor Price column: Favor-adjusted sell price differs from the item's base value.
    Up = costs more (red), down = costs less (green). */
 .vendor-sheet .shop-cell.pus-price-up { color: var(--dnd5e-color-maroon, #b9412f); }


### PR DESCRIPTION
Relocates dnd5e's portrait/token image toggle from the portrait column into the name column, just above the initiative die, when the GM is in edit mode on the vendor sheet.