### PR TITLE
fix(vendor): player cart clear disabled; real multi-denomination prices with icons

### DIFF
--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -93,19 +93,38 @@ const COLUMNS = {
   price: {
     id: "price", header: "INTERACTIVE_ITEMS.Vendor.Col.Price", align: "end",
     cell(item) {
-      const base = priceInGP(item, 1);
-      const sell = priceInGP(item, vendorItemMultiplier(item));
-      const gp = game.i18n.localize("DND5E.CurrencyAbbrGP");
-      const isNegative = sell.exact < 0;
-      const displayValue = Math.max(0, sell.display);
-      const fractional = !isNegative && sell.exact !== Math.trunc(sell.exact);
+      const conv = getAdapter().currency;
+      const { value, denomination } = item.system?.price ?? {};
+      if ( !value || !conv ) return { text: `0 ${conv?.defaultDenom ?? "gp"}`, classes: "pus-price" };
+
+      const basePrice = conv.toBase(value, denomination ?? conv.defaultDenom);
+      const mult = vendorItemMultiplier(item);
+      // Exact cp after factors, then float-safe ceil: kills noise (237.0000000001 → 237)
+      // and rounds any genuine sub-cp fraction up — only the smallest denomination is bumped,
+      // never a larger one. Matches getItemChargeCp so display === what the player pays.
+      const exactCp = basePrice * mult;
+      const sellBase = Math.max(0, Math.ceil(Math.round(exactCp * 1e4) / 1e4));
+
       let classes = "pus-price";
-      if ( isNegative && game.user.isGM ) classes += " pus-price-negative";
-      else if ( base.exact > 0 && sell.exact < base.exact ) classes += " pus-price-down";
-      else if ( base.exact > 0 && sell.exact > base.exact ) classes += " pus-price-up";
+      if ( exactCp < 0 && game.user.isGM ) classes += " pus-price-negative";
+      else if ( basePrice > 0 && sellBase < basePrice ) classes += " pus-price-down";
+      else if ( basePrice > 0 && sellBase > basePrice ) classes += " pus-price-up";
+
+      // decompose into whole coins; sellBase is already integer so remainder is always 0.
+      const { coins } = conv.decompose(sellBase);
+      const coinEntries = conv.changeDenoms.filter(d => coins[d]).map(d => ({
+        amount: coins[d], denom: d,
+        label: CONFIG.DND5E?.currencies?.[d]?.label ?? d
+      }));
+
+      if ( !coinEntries.length ) {
+        const d = conv.defaultDenom;
+        coinEntries.push({ amount: 0, denom: d, label: CONFIG.DND5E?.currencies?.[d]?.label ?? d });
+      }
+      // Always use the coins array so the template renders denomination icons for every price.
       return {
-        text: `${displayValue} ${gp}`,
-        tooltip: fractional ? `${Number(sell.exact.toFixed(2))} ${gp}` : null,
+        text: coinEntries.map(c => `${c.amount} ${c.denom}`).join(" "),
+        coins: coinEntries,
         classes
       };
     }

--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -1112,6 +1112,8 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
       if ( countEl ) countEl.textContent = String(cartUnits);
       const checkout = footer.querySelector(".cart-checkout");
       if ( checkout ) checkout.disabled = !(hasCart && buyer && cartCp <= wealthCp);
+      const clear = footer.querySelector(".cart-clear");
+      if ( clear ) clear.disabled = !hasCart;   // re-enable for non-owners (_toggleDisabled disabled it)
     }
   }
 

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -970,6 +970,22 @@
 .vendor-sheet .shop-cell.pus-price-up { color: var(--dnd5e-color-maroon, #b9412f); }
 .vendor-sheet .shop-cell.pus-price-down { color: var(--dnd5e-color-green, #4b7d3a); }
 
+/* Multi-denomination prices stack vertically, right-aligned within the cell.
+   Single-denomination prices use the plain text path and are unaffected. */
+.vendor-sheet .pus-coin-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  line-height: 1.2;
+}
+.vendor-sheet .pus-coin-row {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  white-space: nowrap;
+}
+
 /* Shop-tab sibling sections (settings panel, queue, inventory list, cart footer) share one inset. */
 .vendor-sheet .pus-favor-panel,
 .vendor-sheet .pus-queue-panel,

--- a/templates/vendor/shop.hbs
+++ b/templates/vendor/shop.hbs
@@ -142,7 +142,7 @@
         </div>
         {{#each this.cells}}
         <span class="shop-cell shop-align-{{ this.align }} {{ this.classes }}"
-              {{#if this.tooltip}}data-tooltip="{{ this.tooltip }}"{{/if}}>{{ this.text }}</span>
+              {{#if this.tooltip}}data-tooltip="{{ this.tooltip }}"{{/if}}>{{#if this.coins}}<span class="pus-coin-stack">{{#each this.coins}}<span class="pus-coin-row">{{this.amount}}<i class="currency {{this.denom}}" data-tooltip="{{this.label}}"></i></span>{{/each}}</span>{{else}}{{ this.text }}{{/if}}</span>
         {{/each}}
         {{#if @root.isGM}}
         <a class="ii-row-control shop-toggle {{#if this.shopVisible}}active{{/if}}"


### PR DESCRIPTION
Fixes the player cart trash/clear button being permanently disabled due to a missing `_toggleDisabled` override in `#refreshCart`. Also replaces the rounded-GP price display with real denomination breakdown using the CurrencyConverter, rendering each coin with its dnd5e inventory icon and a hover tooltip.