### PR TITLE
feat(vendor): settings backdrop overlay

### DIFF
--- a/scripts/adapter/dnd5e/vendorSheet.mjs
+++ b/scripts/adapter/dnd5e/vendorSheet.mjs
@@ -39,6 +39,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
   #favorCollapsed = true;               // vendor-settings panel — always starts collapsed on open; toggled live
   #cart = new Map();   // itemId -> quantity to buy
   #renderTimer = null;
+  #backdropObserver = null;
 
   constructor(options) {
     super(options);
@@ -194,6 +195,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     await this.#injectGmShopBio();          // mirror the player storefront bio under the name (Shop tab)
     this.#wireFavorControls();              // wire favor sliders in the Shop tab (GM only)
     this.#wireSettingsControls();           // wire grouping-factor controls in the Shop tab (GM only)
+    this.#wireSettingsBackdrop();           // size the settings backdrop + observe for changes (GM only)
     // Re-evaluate cart state and buy-button gating after core _toggleDisabled has run.
     // #refreshCart owns the disabled state for both basket toggles and buy buttons.
     this.#refreshCart();
@@ -432,6 +434,48 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
       range.addEventListener("change", () => commit(range));
       num.addEventListener("change", () => commit(num));
     }
+  }
+
+  /**
+   * Size the settings backdrop to span from the bottom of the (variable-height) settings panel
+   * down to the bottom of the shop content. The gradient stops are static relative to the
+   * backdrop's own top (which top:100% pins to the panel bottom), so only the height is dynamic.
+   * Difference of two getBoundingClientRect bottoms — both elements scroll together, so the gap
+   * is scroll-invariant and needs no recompute on scroll. GM only. (Foundry v13 + v14, dnd5e.)
+   */
+  #sizeSettingsBackdrop() {
+    const content = this.element.querySelector(".pus-favor-content");
+    const backdrop = content?.querySelector(":scope > .pus-settings-backdrop");
+    if ( !content || !backdrop ) return;
+    const tab = content.closest(".tab");
+    if ( !tab ) return;
+    // Use tab.scrollHeight (full content height) not getBoundingClientRect (viewport-clipped) so the
+    // backdrop reaches the true bottom of the ware list even when the sheet content overflows the
+    // visible window. Convert content's viewport bottom to tab scroll-space by adding scrollTop.
+    const tabRect = tab.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    const contentBottomInScroll = (contentRect.bottom - tabRect.top) + tab.scrollTop;
+    const h = Math.max(0, tab.scrollHeight - contentBottomInScroll);
+    backdrop.style.height = `${h}px`;
+  }
+
+  /**
+   * Wire the settings backdrop: (re)observe the settings content and the shop tab so the backdrop
+   * height tracks factor-row expansion and sheet resizes, then size it once immediately. GM only;
+   * the backdrop only exists in the GM settings panel. Re-run each render (the elements are
+   * rebuilt); the observer is torn down in close().
+   */
+  #wireSettingsBackdrop() {
+    if ( !game.user.isGM ) return;
+    const content = this.element.querySelector(".pus-favor-content");
+    const tab = content?.closest(".tab");
+    if ( !content || !tab ) return;
+    if ( !this.#backdropObserver ) this.#backdropObserver = new ResizeObserver(() => this.#sizeSettingsBackdrop());
+    this.#backdropObserver.disconnect();
+    this.#backdropObserver.observe(content);
+    this.#backdropObserver.observe(tab);
+    dbg("vendorSheet:wireSettingsBackdrop", "observing settings + tab for backdrop sizing");
+    this.#sizeSettingsBackdrop();
   }
 
   /**
@@ -745,6 +789,7 @@ export default class Dnd5eVendorSheet extends NPCActorSheet {
     if (this.#updateItemHookId !== null) { Hooks.off("updateItem", this.#updateItemHookId); this.#updateItemHookId = null; }
     if (this.#queueHookId !== null) { Hooks.off("updateActor", this.#queueHookId); this.#queueHookId = null; }
     if (this.#renderTimer) { clearTimeout(this.#renderTimer); this.#renderTimer = null; }
+    if (this.#backdropObserver) { this.#backdropObserver.disconnect(); this.#backdropObserver = null; }
     return super.close(options);
   }
 

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -1023,12 +1023,35 @@
   opacity: 0; transform: translateY(-8px); visibility: hidden; pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease, visibility 0s 0.2s;
 }
+/* Shared opaque shade for the settings panel and its downward backdrop extension. */
+.vendor-sheet { --pus-settings-panel-bg: color-mix(in srgb, var(--dnd5e-color-maroon, #741b2b) 14%, #161013); }
+
 .vendor-sheet .pus-favor-content-inner {
   max-height: 360px; overflow-y: auto;
   padding: 8px 12px;
-  background: color-mix(in srgb, var(--dnd5e-color-maroon, #741b2b) 14%, #161013);
+  background: var(--pus-settings-panel-bg);
   border: 1px solid var(--color-border-light-1, rgba(255, 255, 255, 0.25));
   border-radius: 4px;
+}
+
+/* Backdrop that extends below the open settings panel over the queue + ware list.
+   Child of .pus-favor-content (z-index:20), so it paints above in-flow siblings but behind the
+   settings controls (which follow it in DOM order). top:100% pins it to the panel bottom edge.
+   Gradient: transparent at top, fades to 70% opaque black over 60px, stays 70% opaque.
+   Height set in JS (#sizeSettingsBackdrop). Hides with panel via inherited visibility.
+   Blocks mouse events so items beneath cannot be hovered or clicked while the panel is open. */
+.vendor-sheet .pus-settings-backdrop {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0,
+    rgba(0, 0, 0, 0.7) 60px,
+    rgba(0, 0, 0, 0.7) 100%
+  );
 }
 
 /* Queue panel content: in-flow (the height animation pushes the list down rather than overlaying).

--- a/templates/vendor/shop.hbs
+++ b/templates/vendor/shop.hbs
@@ -11,6 +11,7 @@
       <i class="fa-solid fa-chevron-down pus-collapse-caret"></i>
     </button>
     <div class="pus-favor-content">
+      <div class="pus-settings-backdrop" aria-hidden="true"></div>
       <div class="pus-favor-content-inner">
       <div class="pus-favor-controls">
         <div class="pus-favor-control">


### PR DESCRIPTION
Adds a gradient backdrop that appears below the Vendor Settings panel when it is open, visually separating the panel from the ware list and queue beneath it. The backdrop blocks mouse events on underlying items while the panel is open.