### PR TITLE
Add pf2e vendor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ system's own item and container sheets for a seamless experience.
 - **[Vendors](docs/vendor.md)** — Shopkeeper actors players can buy from. GMs
   stock wares and set prices with an adjustable Favor discount/surcharge; players
   browse a storefront and check out, served one at a time through a shopping
-  queue. *(dnd5e only.)*
+  queue.
 - **[Light-emitting items](docs/lighting.md)** — Give any interactive item a
   light source that follows it on the canvas, in a player's pack, or inside an
   open container, layered on top of the carrier's own light.

--- a/docs/vendor.md
+++ b/docs/vendor.md
@@ -4,8 +4,9 @@ A vendor is a shopkeeper actor that players can buy from in-world. The GM stocks
 it with wares, sets its prices, and places it on the canvas; players open it to
 browse a storefront and purchase items into their own inventory.
 
-> **System support:** Vendors are currently a **dnd5e-only** feature. On pf2e and
-> in generic mode the vendor sheet is not available.
+> **System support:** Vendors are available on **dnd5e** and **pf2e**, each
+> following its own sheet conventions. In generic mode the vendor sheet is not
+> available.
 
 ## Creating and stocking a vendor
 
@@ -21,10 +22,10 @@ remove everything at once.
 
 ## The shop
 
-The vendor sheet adds a **Shop** tab. GMs see it alongside the full set of normal
-actor tabs (features, inventory, spells, etc.); players see a focused
-storefront-only view. The storefront shows the vendor's public description, the
-list of for-sale items with rarity, stock, and price, and a shopping queue.
+The vendor sheet adds a **Shop** tab alongside the system's normal inventory
+view. GMs use the inventory view to stock and manage the vendor; players see a
+focused storefront-only view. The storefront shows the list of for-sale items
+with rarity, stock, and price, and a shopping queue.
 
 ## Buying
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -300,6 +300,8 @@
       "Buy": "Buy",
       "Empty": "This vendor has nothing for sale.",
       "ShopTab": "Shop",
+      "Delete": "Delete",
+      "StockHint": "Drag items here to stock the vendor. Adjust quantity or remove with the controls on each row.",
       "Col": { "Rarity": "Rarity", "Stock": "Stock", "Price": "Price" },
       "Group": { "Type": "Type" },
       "Filter": {
@@ -311,6 +313,7 @@
         "NoneAffordable": "Nothing here is affordable right now."
       },
       "ToggleShopVisible": "Show / hide in shop",
+      "ViewDetails": "Press to view details",
       "AddToCart": "Add to / remove from cart",
       "ClearCart": "Clear cart",
       "CartTotal": "Cart total",

--- a/scripts/adapter/dnd5e/shopGrouping.mjs
+++ b/scripts/adapter/dnd5e/shopGrouping.mjs
@@ -95,7 +95,7 @@ const COLUMNS = {
     cell(item) {
       const conv = getAdapter().currency;
       const { value, denomination } = item.system?.price ?? {};
-      if ( !value || !conv ) return { text: `0 ${conv?.defaultDenom ?? "gp"}`, classes: "pus-price" };
+      if ( !value || !conv ) return { text: "0", classes: "pus-price" };
 
       const basePrice = conv.toBase(value, denomination ?? conv.defaultDenom);
       const mult = vendorItemMultiplier(item);
@@ -110,18 +110,15 @@ const COLUMNS = {
       else if ( basePrice > 0 && sellBase < basePrice ) classes += " pus-price-down";
       else if ( basePrice > 0 && sellBase > basePrice ) classes += " pus-price-up";
 
+      // A free ware shows a bare "0" — no denomination/coin appended.
+      if ( sellBase <= 0 ) return { text: "0", classes };
+
       // decompose into whole coins; sellBase is already integer so remainder is always 0.
       const { coins } = conv.decompose(sellBase);
       const coinEntries = conv.changeDenoms.filter(d => coins[d]).map(d => ({
         amount: coins[d], denom: d,
         label: CONFIG.DND5E?.currencies?.[d]?.label ?? d
       }));
-
-      if ( !coinEntries.length ) {
-        const d = conv.defaultDenom;
-        coinEntries.push({ amount: 0, denom: d, label: CONFIG.DND5E?.currencies?.[d]?.label ?? d });
-      }
-      // Always use the coins array so the template renders denomination icons for every price.
       return {
         text: coinEntries.map(c => `${c.amount} ${c.denom}`).join(" "),
         coins: coinEntries,

--- a/scripts/adapter/pf2e/currency.mjs
+++ b/scripts/adapter/pf2e/currency.mjs
@@ -1,0 +1,19 @@
+import { CurrencyConverter } from "../../utils/CurrencyConverter.mjs";
+
+/** pf2e coin ratios (cp base): 1pp=10gp, 1gp=10sp, 1sp=10cp. No electrum. */
+const PF2E_DENOMINATIONS = { pp: 1000, gp: 100, sp: 10, cp: 1 };
+
+/**
+ * Build the pf2e currency converter. pf2e denominations are fixed (pp/gp/sp/cp),
+ * so the ratios are hard-coded (unlike dnd5e, which reads CONFIG.DND5E.currencies).
+ * cp is the base unit; change is generated in pp/gp/sp/cp (pf2e prices routinely
+ * run into platinum).
+ */
+export function buildPf2eCurrencyConverter() {
+  return new CurrencyConverter({
+    denominations: { ...PF2E_DENOMINATIONS },
+    baseDenom: "cp",
+    defaultDenom: "gp",
+    changeDenoms: ["pp", "gp", "sp", "cp"]
+  });
+}

--- a/scripts/adapter/pf2e/index.mjs
+++ b/scripts/adapter/pf2e/index.mjs
@@ -4,6 +4,9 @@ import { Pf2eIdentification } from "./identification.mjs";
 import { Pf2eContainer } from "./container.mjs";
 import { Pf2eSheets } from "./sheets.mjs";
 import { Pf2eHooks } from "./hooks.mjs";
+import Pf2eVendorModel from "./vendorModel.mjs";
+import { buildPf2eCurrencyConverter } from "./currency.mjs";
+import { Pf2ePurchase } from "./purchase.mjs";
 
 /**
  * Concrete SystemAdapter implementation for the pf2e game system.
@@ -28,6 +31,13 @@ export default class Pf2eAdapter extends SystemAdapter {
   /** @type {string} */
   static SYSTEM_ID = "pf2e";
 
+  #currency = null;
+
+  /** pf2e currency converter (cp base), built lazily from fixed ratios and cached. */
+  get currency() {
+    return (this.#currency ??= buildPf2eCurrencyConverter());
+  }
+
   constructor() {
     super();
     // Register the pf2e-aware data model so that pf2e's prepareBaseData chain
@@ -48,12 +58,68 @@ export default class Pf2eAdapter extends SystemAdapter {
     const LootPF2e = CONFIG.PF2E?.Actor?.documentClasses?.loot;
     if (LootPF2e) {
       CONFIG.PF2E.Actor.documentClasses["pick-up-stix.interactiveItem"] = LootPF2e;
+      // Vendor reuses the same LootPF2e base (allowedItemTypes: physical,
+      // canAct: false) so the closed ActorProxyPF2e registry accepts it.
+      CONFIG.PF2E.Actor.documentClasses["pick-up-stix.vendor"] = LootPF2e;
+      // Vendor system data is our pf2e-aware model, overriding the base
+      // VendorModel registered in core init moments earlier.
+      CONFIG.Actor.dataModels["pick-up-stix.vendor"] = Pf2eVendorModel;
+      // pf2e's ActorPF2e.createDialog strips module sub-types from the Create
+      // Actor dialog; re-inject the vendor type so GMs can create one from the UI.
+      this.#patchActorCreateDialogForVendor(LootPF2e);
     } else {
       console.warn(
         "pick-up-stix | pf2e: LootPF2e not found in CONFIG.PF2E.Actor.documentClasses — " +
         "actor creation will fail. This likely indicates a pf2e version mismatch (target: 8.x)."
       );
     }
+  }
+
+  /**
+   * pf2e's ActorPF2e.createDialog (pf2e.mjs ~:36813) hard-replaces the Create
+   * Actor dialog's type list with its own ACTOR_TYPES, hiding every module
+   * sub-type — so "Vendor" never appears (unlike dnd5e, which does not filter).
+   * It only falls back to ACTOR_TYPES when `options.types` is absent, so we wrap
+   * it to inject the vendor type (NOT interactiveItem — those are created via the
+   * Token HUD / item drops, never this dialog).
+   *
+   * Patched directly on ActorPF2e (LootPF2e's direct superclass — pf2e does not
+   * export ActorPF2e) with the original preserved and `this` forwarded, so the
+   * ActorProxyPF2e construct trap still selects LootPF2e for our sub-type.
+   * Mirrors the direct-patch approach used for `_handleDroppedItem` in hooks.mjs.
+   * Idempotency-guarded against re-init.
+   *
+   * @param {Function} LootPF2e - The resolved LootPF2e class (extends ActorPF2e).
+   */
+  #patchActorCreateDialogForVendor(LootPF2e) {
+    let ActorPF2e = LootPF2e ?? null;
+    while (ActorPF2e && ActorPF2e.name !== "ActorPF2e") ActorPF2e = Object.getPrototypeOf(ActorPF2e);
+    if (!ActorPF2e || ActorPF2e.name !== "ActorPF2e" || typeof ActorPF2e.createDialog !== "function") {
+      console.warn(
+        "pick-up-stix | pf2e: ActorPF2e.createDialog not found; the 'Vendor' type will be " +
+        "absent from the Create Actor dialog. Create vendors via macro/console instead."
+      );
+      return;
+    }
+    if (ActorPF2e.createDialog.pickUpStixVendorPatched) return;
+
+    const VENDOR_TYPE = "pick-up-stix.vendor";
+    const _original = ActorPF2e.createDialog;
+    const patched = function (data = {}, createOptions = {}, options = {}) {
+      // Only build a type list when the caller didn't pass one (the sidebar
+      // "Create Actor" button passes none → pf2e would force ACTOR_TYPES and
+      // drop our sub-type). Exclude interactiveItem (dotted module sub-types).
+      if (!options.types) {
+        const pf2eTypes = Object.keys(CONFIG.PF2E?.Actor?.documentClasses ?? {})
+          .filter((t) => !t.includes("."));
+        options.types = [...pf2eTypes, VENDOR_TYPE];
+      } else if (!options.types.includes(VENDOR_TYPE)) {
+        options.types = [...options.types, VENDOR_TYPE];
+      }
+      return _original.call(this, data, createOptions, options);
+    };
+    patched.pickUpStixVendorPatched = true;
+    ActorPF2e.createDialog = patched;
   }
 
   capabilities = {
@@ -100,3 +166,4 @@ Object.assign(Pf2eAdapter.prototype, Pf2eIdentification);
 Object.assign(Pf2eAdapter.prototype, Pf2eContainer);
 Object.assign(Pf2eAdapter.prototype, Pf2eSheets);
 Object.assign(Pf2eAdapter.prototype, Pf2eHooks);
+Object.assign(Pf2eAdapter.prototype, Pf2ePurchase);

--- a/scripts/adapter/pf2e/purchase.mjs
+++ b/scripts/adapter/pf2e/purchase.mjs
@@ -1,0 +1,106 @@
+import { dbg } from "../../utils/debugLog.mjs";
+import { vendorItemMultiplier, basePriceCp } from "./shopGrouping.mjs";
+
+/**
+ * Exact charge in copper: per-unit price × qty × multiplier, sub-unit rounded UP
+ * (vendor's favour). The inner round to 1e-4 kills float noise so a whole-cp value
+ * doesn't get ceil'd up by a 1e-13 artifact.
+ *
+ * @param {Item} item
+ * @param {number} quantity
+ * @param {number} multiplier
+ * @returns {number}
+ */
+function chargeCp(item, quantity, multiplier = 1) {
+  const raw = basePriceCp(item) * quantity * multiplier;
+  const cp = Math.ceil(Math.round(raw * 1e4) / 1e4);
+  return cp > 0 ? cp : 0;
+}
+
+/**
+ * pf2e vendor purchase / currency concern. Mixed onto Pf2eAdapter.prototype.
+ *
+ * pf2e money is treasure-Item documents (not a number): wealth is
+ * `actor.inventory.coins` (a Coins; `.copperValue` is the number), and
+ * `inventory.removeCoins`/`addCoins` are async and only ever move REAL coins
+ * (never conjured). removeCoins returns `false` on insufficient funds and makes
+ * change automatically from the buyer's own purse — so there is a single
+ * settlement mode (dnd5e's magic-vs-real split collapses here). Both
+ * removeCoins/addCoins accept a plain `{pp,gp,sp,cp}` object, so the shared
+ * CurrencyConverter.decompose output passes straight through.
+ */
+export const Pf2ePurchase = {
+
+  /**
+   * Normalised price. pf2e's native price is a Coins object with no single
+   * value+denomination, so we express it as copper (cp). Not consumed by the
+   * shared flow today, but kept contract-correct.
+   */
+  getItemPrice(item) {
+    const cp = this.currency ? this.currency.bundleToBase(item?.system?.price?.value ?? {}) : 0;
+    return { value: cp, denomination: this.currency?.baseDenom ?? "cp" };
+  },
+
+  getItemChargeCp(item, quantity = 1) {
+    return chargeCp(item, quantity, vendorItemMultiplier(item));
+  },
+
+  getActorWealthCp(actor) {
+    // actor.inventory.coins is a Coins; .copperValue is the number. Infinity when
+    // the actor has no inventory (so affordability never spuriously blocks).
+    return actor?.inventory?.coins?.copperValue ?? Infinity;
+  },
+
+  canAfford(buyer, item, quantity = 1) {
+    const cp = this.getItemChargeCp(item, quantity);
+    if (cp <= 0) return true;
+    return this.getActorWealthCp(buyer) >= cp;
+  },
+
+  /**
+   * Compute (no mutation) the coin bundle for a `cp` charge. Returns null when
+   * the buyer can't afford it. The plan is opaque; we store the decomposed coins.
+   */
+  planSettlement(buyer, vendor, cp) {
+    if (cp <= 0) return { mode: "noop" };
+    if (buyer && this.getActorWealthCp(buyer) < cp) {
+      dbg("pf2e-purchase:planSettlement", "buyer cannot afford", { cp });
+      return null;
+    }
+    const { coins } = this.currency.decompose(cp);   // tidy {pp,gp,sp,cp}
+    dbg("pf2e-purchase:planSettlement", "ok", { cp, coins });
+    return { mode: "coins", cp, coins };
+  },
+
+  /** Debit the buyer (GM-side). removeCoins makes change from real coins; returns false if short. */
+  async applyBuyerSettlement(buyer, plan) {
+    if (!plan || plan.mode === "noop") return;
+    dbg("pf2e-purchase:applyBuyerSettlement", "debit", { buyer: buyer?.id, cp: plan.cp });
+    const ok = await buyer.inventory.removeCoins(plan.coins, { byValue: true });
+    if (ok === false) {
+      // planSettlement pre-checked affordability; reaching here implies a race
+      // (the buyer spent between plan and apply). Surface rather than silently
+      // crediting the vendor for coins that never left the buyer.
+      dbg("pf2e-purchase:applyBuyerSettlement", "removeCoins returned false (race)", { buyer: buyer?.id });
+      throw new Error("pick-up-stix | pf2e: buyer had insufficient funds at settlement time");
+    }
+  },
+
+  /** Credit the vendor (GM-side) — tidy denominations via addCoins. */
+  async applyVendorSettlement(vendor, plan) {
+    if (!plan || plan.mode === "noop") return;
+    dbg("pf2e-purchase:applyVendorSettlement", "credit", { vendor: vendor?.id, coins: plan.coins });
+    await vendor.inventory.addCoins(plan.coins);
+  },
+
+  /**
+   * pf2e physical items stack by quantity; bulk purchase keeps one stack.
+   * (The base contract default is already `true`; declared here for locality.)
+   *
+   * @param {Item} _item
+   * @returns {boolean}
+   */
+  stacksOnPurchase(_item) {
+    return true;
+  }
+};

--- a/scripts/adapter/pf2e/sheets.mjs
+++ b/scripts/adapter/pf2e/sheets.mjs
@@ -87,5 +87,66 @@ export const Pf2eSheets = {
     const sheet = Pf2eInteractiveItemConfigSheet.forActor(actor);
     sheet.render(true, options);
     return sheet;
+  },
+
+  /**
+   * Register the pf2e vendor sheet for the `pick-up-stix.vendor` sub-type.
+   *
+   * pf2e does not export ActorSheetPF2e, so we resolve it at runtime as the
+   * direct superclass of the registered LootSheetPF2e (LootSheetPF2e extends
+   * ActorSheetPF2e), then hand it to the factory (the class must `extends` a
+   * runtime value). pf2e registers its sheets during init; if the registry
+   * isn't populated yet when this runs, defer to `setup`.
+   */
+  async registerVendorSheet() {
+    const resolveBase = () => {
+      const lootEntry = Object.values(CONFIG.Actor.sheetClasses?.loot ?? {})
+        .find(s => s?.cls?.name === "LootSheetPF2e");
+      const base = lootEntry?.cls ? Object.getPrototypeOf(lootEntry.cls) : null;
+      return (base && base.name === "ActorSheetPF2e") ? base : null;
+    };
+
+    const tryRegister = async () => {
+      const ActorSheetPF2e = resolveBase();
+      if (!ActorSheetPF2e) return false;
+      const { definePf2eVendorSheet } = await import("./vendorSheet.mjs");
+      const Pf2eVendorSheet = definePf2eVendorSheet(ActorSheetPF2e);
+      dbg("pf2e-sheets:registerVendorSheet", "registering Pf2eVendorSheet for pick-up-stix.vendor");
+      foundry.documents.collections.Actors.registerSheet("pick-up-stix", Pf2eVendorSheet, {
+        types: ["pick-up-stix.vendor"],
+        makeDefault: true,
+        label: "Vendor Sheet"
+      });
+      // The vendor sheet reuses pf2e's native inventory partials. pf2e preloads
+      // them, but register explicitly so our template's `{{> (resolvePath ...)}}`
+      // can never race an unloaded partial.
+      try {
+        await foundry.applications.handlebars.loadTemplates([
+          "systems/pf2e/templates/actors/partials/coinage.hbs",
+          "systems/pf2e/templates/actors/partials/inventory-header.hbs",
+          "systems/pf2e/templates/actors/partials/inventory.hbs",
+          "systems/pf2e/templates/actors/partials/encumbrance.hbs",
+          "systems/pf2e/templates/actors/partials/item-line.hbs"
+        ]);
+      } catch (err) {
+        console.warn("pick-up-stix | pf2e: failed preloading inventory partials", err);
+      }
+      return true;
+    };
+
+    // pf2e registers LootSheetPF2e in Hooks.once("setup"), but sheet
+    // registrations made before `game.ready` are queued to a pending list and
+    // only flushed into CONFIG.Actor.sheetClasses afterward — so LootSheetPF2e
+    // (and thus ActorSheetPF2e, its superclass) isn't resolvable until `ready`.
+    // Try eagerly, then fall back to `ready` where the registry is populated.
+    if (await tryRegister()) return;
+    Hooks.once("ready", async () => {
+      if (!(await tryRegister())) {
+        console.warn(
+          "pick-up-stix | pf2e: ActorSheetPF2e not resolvable at ready — the vendor falls " +
+          "back to Foundry's default sheet. (pf2e version mismatch? target 8.x)"
+        );
+      }
+    });
   }
 };

--- a/scripts/adapter/pf2e/shopGrouping.mjs
+++ b/scripts/adapter/pf2e/shopGrouping.mjs
@@ -1,0 +1,271 @@
+import { getAdapter } from "../index.mjs";
+import { dbg } from "../../utils/debugLog.mjs";
+import { vendorPriceMultiplier, groupingFactorMultiplier, globalFactorMultiplier } from "../../utils/vendorPricing.mjs";
+
+/* ---------- pf2e display / pricing helpers (system-specific) ----------
+ * The favor / global / grouping factor MATH lives in the shared vendorPricing
+ * helpers (system-agnostic, unitless multipliers). Only the bucket-key
+ * derivation, rarity/type vocabulary, and currency reads below are pf2e-specific.
+ * pf2e item price is `system.price.value` (a {pp,gp,sp,cp} object) priced per
+ * `system.price.per` units. */
+
+/**
+ * Per-unit base price in copper, via the shared converter.
+ * pf2e prices a batch of `per` units for `value`, so unit price = value / per.
+ *
+ * @param {Item} item
+ * @returns {number} copper pieces per single unit (0 when unpriced)
+ */
+export function basePriceCp(item) {
+  const value = item?.system?.price?.value ?? {};
+  const per = Math.max(1, Number(item?.system?.price?.per ?? 1));
+  const conv = getAdapter().currency;
+  if (!conv) return 0;
+  return conv.bundleToBase(value) / per;
+}
+
+/**
+ * Full per-item cost multiplier: Favor × global × type-factor × rarity-factor,
+ * all compounded. Returns 1 when the item has no vendor parent.
+ *
+ * @param {Item} item
+ * @returns {number}
+ */
+export function vendorItemMultiplier(item) {
+  const vendor = item?.parent;
+  if (!vendor) return 1;
+  const favorM  = vendorPriceMultiplier(vendor);
+  const globalM = globalFactorMultiplier(vendor);
+  const typeM   = groupingFactorMultiplier(vendor, "type", groupType(item));
+  const rarityM = groupingFactorMultiplier(vendor, "rarity", rarityOf(item).key);
+  const m = favorM * globalM * typeM * rarityM;
+  dbg("pf2e-shopGrouping:vendorItemMultiplier", { item: item.id, favorM, globalM, typeM, rarityM, m });
+  return m;
+}
+
+/** Localized rarity label + raw key. pf2e rarity lives at system.traits.rarity. */
+export function rarityOf(item) {
+  const key = item.system?.traits?.rarity || "common";
+  const label = game.i18n.localize(CONFIG.PF2E?.rarityTraits?.[key] ?? key);
+  return { key, label };
+}
+
+/** pf2e item type used for grouping (weapon/armor/consumable/backpack/treasure/…). */
+function groupType(item) {
+  return item.type;
+}
+
+/** Localized document sub-type label (Foundry-standard TYPES.Item.* keys). */
+export function typeSubtitle(item) {
+  return game.i18n.localize(`TYPES.Item.${item.type}`);
+}
+
+/** Item description as single-line plaintext ("" if none). CSS clamps the visible
+ *  line; the full description appears in the ware's hover item card. */
+export function descriptionSubtitle(item) {
+  const html = item.system?.description?.value;
+  if (!html) return "";
+  const el = document.createElement("div");
+  el.innerHTML = String(html);
+  el.querySelectorAll("br,p,div,li,h1,h2,h3,h4,h5,h6,tr").forEach(n => n.insertAdjacentText("afterend", " "));
+  return (el.textContent ?? "").replace(/ /g, " ").replace(/\s+/g, " ").trim();
+}
+
+/* ---------------------------- Column registry ----------------------------
+ * Each column: { id, header (i18n key | ""), align: "start"|"center"|"end",
+ *                cell(item) -> { text, tooltip?, classes?, coins? } }            */
+
+const COLUMNS = {
+  rarity: {
+    id: "rarity", header: "INTERACTIVE_ITEMS.Vendor.Col.Rarity", align: "center",
+    cell(item) {
+      const { key, label } = rarityOf(item);
+      return label ? { text: label, classes: `pus-rarity pus-rarity-${key}` } : { text: "" };
+    }
+  },
+  stock: {
+    id: "stock", header: "INTERACTIVE_ITEMS.Vendor.Col.Stock", align: "center",
+    cell(item) { return { text: `×${getAdapter().getItemQuantity(item)}` }; }
+  },
+  price: {
+    id: "price", header: "INTERACTIVE_ITEMS.Vendor.Col.Price", align: "end",
+    cell(item) {
+      const conv = getAdapter().currency;
+      const base = basePriceCp(item);
+      if (!base || !conv) return { text: "0", classes: "pus-price" };
+
+      // Exact cp after factors, then float-safe ceil: kills noise (237.0000001 → 237)
+      // and rounds any genuine sub-cp fraction up — only the smallest denomination is
+      // bumped. Matches getItemChargeCp so display === what the player pays.
+      const exactCp = base * vendorItemMultiplier(item);
+      const sellBase = Math.max(0, Math.ceil(Math.round(exactCp * 1e4) / 1e4));
+
+      let classes = "pus-price";
+      if (base > 0 && sellBase < base) classes += " pus-price-down";
+      else if (base > 0 && sellBase > base) classes += " pus-price-up";
+
+      // A free ware shows a bare "0" — no denomination/coin appended.
+      if (sellBase <= 0) return { text: "0", classes };
+
+      const { coins } = conv.decompose(sellBase);
+      const coinEntries = conv.changeDenoms.filter(d => coins[d]).map(d => ({
+        amount: coins[d], denom: d,
+        label: game.i18n.localize(`PF2E.Currency.${d}`)
+      }));
+      return {
+        text: coinEntries.map(c => `${c.amount} ${c.denom}`).join(" "),
+        coins: coinEntries,
+        classes
+      };
+    }
+  }
+};
+
+/* ---------------------------- Grouping registry ---------------------------- */
+
+export const SHOP_GROUPINGS = {
+  type: {
+    id: "type",
+    label: "INTERACTIVE_ITEMS.Vendor.Group.Type",
+    columns: ["rarity", "stock", "price"],
+    groupKeyOf: (item) => groupType(item),
+    groupTitleOf: (key) => game.i18n.localize(`TYPES.Item.${key}`),
+    sortGroups(a, b) { return a.title.localeCompare(b.title); }  // pf2e: alpha
+  }
+  // Future: add { rarity: {...}, name: {...}, ... } here — each picks COLUMNS + grouping fns.
+};
+
+export const DEFAULT_GROUPING = "type";
+
+/* -------------------- Settings-panel dimension registry -------------------- */
+
+/** Settings-panel grouping dimensions: how to bucket + label + order items for the factor list. */
+export const SETTINGS_DIMENSIONS = {
+  type: {
+    keyOf: (item) => groupType(item),
+    labelOf: (key) => game.i18n.localize(`TYPES.Item.${key}`),
+    order: () => []                                              // alpha fallback (no canonical order)
+  },
+  rarity: {
+    keyOf: (item) => rarityOf(item).key,
+    labelOf: (key) => rarityOf({ system: { traits: { rarity: key } } }).label,
+    order: () => ["common", "uncommon", "rare", "unique"]
+  }
+};
+
+/**
+ * Buckets `items` by the given settings dimension, returning only buckets that have
+ * at least one item, ordered by the dimension's canonical order (unknowns alpha-last).
+ *
+ * @returns {Array<{ key, label, count }>}
+ */
+export function buildSettingsGroups(items, dimension) {
+  const dim = SETTINGS_DIMENSIONS[dimension] ?? SETTINGS_DIMENSIONS.type;
+  const counts = new Map();
+  for (const item of items) {
+    const key = dim.keyOf(item);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const order = dim.order();
+  return [...counts.entries()]
+    .map(([key, count]) => ({ key, label: dim.labelOf(key), count }))
+    .sort((a, b) => {
+      const ai = order.indexOf(a.key), bi = order.indexOf(b.key);
+      if (ai !== -1 && bi !== -1) return ai - bi;
+      if (ai !== -1) return -1;
+      if (bi !== -1) return 1;
+      return a.label.localeCompare(b.label);
+    });
+}
+
+/* ------------------------ Build the grouped structure ------------------------ */
+
+/**
+ * @returns {{ groupingId, columnTemplate, headers, groups }}
+ *   headers: [{ id, label, align }]   columnTemplate: a grid-template-columns string
+ *   groups:  [{ key, title, wares: [wareRow] }]
+ */
+export function buildShop(items, groupingId = DEFAULT_GROUPING) {
+  const grouping = SHOP_GROUPINGS[groupingId] ?? SHOP_GROUPINGS[DEFAULT_GROUPING];
+  const columns = grouping.columns.map(id => COLUMNS[id]);
+  dbg("pf2e-shopGrouping:buildShop", { groupingId: grouping.id, items: items.length, columns: grouping.columns });
+
+  const buckets = new Map();
+  for (const item of items) {
+    const key = grouping.groupKeyOf(item);
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key).push(item);
+  }
+
+  const groups = [...buckets.entries()].map(([key, groupItems]) => ({
+    key,
+    title: grouping.groupTitleOf(key),
+    wares: groupItems
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(item => buildWareRow(item, columns))
+  }));
+  groups.sort((a, b) => grouping.sortGroups(a, b));
+
+  return {
+    groupingId: grouping.id,
+    // name (flex) + one track per grouping column + GM visibility toggle + basket + Buy
+    columnTemplate: `minmax(0, 1fr) ${columns.map(() => "max-content").join(" ")} max-content max-content max-content`,
+    headers: columns.map(c => ({ id: c.id, label: c.header, align: c.align })),
+    groups
+  };
+}
+
+/**
+ * Build the shop structure from pf2e's prepared inventory sections (the exact
+ * sections/labels/order the Inventory tab shows — Weapons & Shields, Armor,
+ * Equipment, Consumables, Ammunition, Treasure, Containers), so the Shop groups
+ * match the inventory categories. Empty sections are kept (the inventory shows
+ * them too).
+ *
+ * @param {Array<{label:string, types:string[], items:Array<{item:Item}>}>} sections
+ * @param {string} [groupingId]
+ * @param {{includeHidden?: boolean, rarity?: string}} [options]  includeHidden=false drops
+ *   GM-hidden wares (`flags.pick-up-stix.shopVisible === false`) — the player storefront;
+ *   rarity (when set) keeps only that rarity and drops the now-empty sections.
+ * @returns {{ groupingId, headers, groups }}
+ */
+export function buildShopFromSections(sections, groupingId = DEFAULT_GROUPING, { includeHidden = true, rarity = "" } = {}) {
+  const grouping = SHOP_GROUPINGS[groupingId] ?? SHOP_GROUPINGS[DEFAULT_GROUPING];
+  const columns = grouping.columns.map(id => COLUMNS[id]);
+  dbg("pf2e-shopGrouping:buildShopFromSections", { sections: sections?.length ?? 0, includeHidden, rarity });
+  let groups = (sections ?? []).map(section => ({
+    key: (section.types ?? []).join("-"),
+    title: section.label,
+    wares: (section.items ?? [])
+      .map(row => row?.item)
+      .filter(Boolean)
+      .filter(item => !item.isCurrency) // a vendor doesn't sell its own coins
+      .filter(item => includeHidden || item.getFlag("pick-up-stix", "shopVisible") !== false)
+      .filter(item => !rarity || rarityOf(item).key === rarity) // rarity filter (when set)
+      .map(item => buildWareRow(item, columns))
+  }));
+  // With a rarity filter active, drop now-empty sections so only matching categories
+  // show; an all-empty result falls through to the template's Empty state.
+  if (rarity) groups = groups.filter(g => g.wares.length > 0);
+  return {
+    groupingId: grouping.id,
+    headers: columns.map(c => ({ id: c.id, label: c.header, align: c.align })),
+    groups
+  };
+}
+
+function buildWareRow(item, columns) {
+  const description = descriptionSubtitle(item);
+  const stock = getAdapter().getItemQuantity(item);
+  return {
+    id: item.id,
+    name: item.name,
+    img: item.img,
+    subtitle: description || typeSubtitle(item),
+    rarity: rarityOf(item).key,
+    stock,
+    multiStock: stock > 1,
+    shopVisible: item.getFlag("pick-up-stix", "shopVisible") !== false,
+    cells: columns.map(c => ({ align: c.align, id: c.id, ...c.cell(item) }))
+  };
+}

--- a/scripts/adapter/pf2e/vendorModel.mjs
+++ b/scripts/adapter/pf2e/vendorModel.mjs
@@ -1,0 +1,45 @@
+import VendorModel from "../../models/VendorModel.mjs";
+
+const fields = foundry.data.fields;
+
+/**
+ * pf2e-compatible data model for the `pick-up-stix.vendor` actor sub-type.
+ *
+ * Mirrors Pf2eInteractiveItemModel: extends the system-agnostic base
+ * VendorModel and adds the stub fields pf2e's prepareBaseData chain reads
+ * before the module can intervene:
+ *   ActorPF2e.prepareBaseData         → system.details.level.value
+ *   TokenDocumentPF2e.prepareBaseData → system.details.alliance
+ *   LootPF2e.isMerchant / isLoot      → system.lootSheetType
+ *
+ * The actor document class is LootPF2e (registered in the pf2e adapter
+ * constructor), but `actor.system` is THIS model — the two registries are
+ * independent, exactly as for interactiveItem. Registered on
+ * CONFIG.Actor.dataModels in place of the base VendorModel by the pf2e adapter
+ * constructor.
+ */
+export default class Pf2eVendorModel extends VendorModel {
+
+  static defineSchema() {
+    return {
+      ...super.defineSchema(),
+      /**
+       * Stub for pf2e's actor.system.details block (cf. Pf2eInteractiveItemModel).
+       * ActorPF2e.prepareBaseData reads details.level.value (clamped integer);
+       * TokenDocumentPF2e.prepareBaseData reads details.alliance for disposition.
+       */
+      details: new fields.SchemaField({
+        level: new fields.SchemaField({
+          value: new fields.NumberField({ required: true, initial: 0, integer: true, min: 0 })
+        }),
+        alliance: new fields.StringField({ required: false, initial: null, nullable: true })
+      }),
+      /**
+       * LootPF2e.isMerchant reads system.lootSheetType. We render our own sheet
+       * (never LootSheetPF2e), so the value is cosmetic, but "Merchant" keeps the
+       * actor self-coherent as a shop.
+       */
+      lootSheetType: new fields.StringField({ required: false, initial: "Merchant" })
+    };
+  }
+}

--- a/scripts/adapter/pf2e/vendorSheet.mjs
+++ b/scripts/adapter/pf2e/vendorSheet.mjs
@@ -1,0 +1,996 @@
+/**
+ * Pf2eVendorSheet — ApplicationV1 sheet for the `pick-up-stix.vendor` sub-type.
+ *
+ * Extends pf2e's ActorSheetPF2e and REUSES pf2e's native inventory machinery so
+ * the Inventory tab looks and behaves exactly like a pf2e actor's inventory
+ * (purple section bands, currency row, search, item rows with the +/qty/delete
+ * controls — the `+` creates an item of that section's type). It then adds a
+ * read-only Shop tab. The vendor stays a LootPF2e-backed actor (NOT a full NPC),
+ * so we patch the IWR attributes pf2e's getData sorts (LootPF2e has none).
+ *
+ * ActorSheetPF2e is not exported by pf2e, so the class is produced by a factory
+ * called from `registerVendorSheet()` with the runtime-resolved base class.
+ */
+
+import { getAdapter } from "../index.mjs";
+import { dbg } from "../../utils/debugLog.mjs";
+import { buildShopFromSections, buildSettingsGroups } from "./shopGrouping.mjs";
+import { getPlayerCandidateTokens, purchaseItem, purchaseCart } from "../../transfer/ItemTransfer.mjs";
+import { dispatchGM } from "../../utils/gmDispatch.mjs";
+import { notifyPurchase } from "../../utils/notify.mjs";
+import { emitSocketEvent } from "../../socket/SocketHandler.mjs";
+import { getVendorQueue, findUserVendorQueues, promptVendorQueueSwitch } from "../../utils/vendorQueue.mjs";
+import {
+  getVendorFavor, getVendorFavorFactor, getFavorMin, getFavorMax,
+  getFavorFactorMin, getFavorFactorMax, getFavorFactorDefault,
+  getVendorGroupingFactor, getVendorGlobalFactor, getMaxPriceFactor
+} from "../../utils/vendorPricing.mjs";
+import { saveDefaultInventory, computeRestockDiff, applyRestock, promptRestockRemoval }
+  from "../../utils/vendorInventory.mjs";
+import { createRowControl } from "../../utils/domButtons.mjs";
+
+/**
+ * @param {typeof foundry.appv1.sheets.ActorSheet} ActorSheetPF2e
+ * @returns {typeof foundry.appv1.sheets.ActorSheet}
+ */
+export function definePf2eVendorSheet(ActorSheetPF2e) {
+
+  return class Pf2eVendorSheet extends ActorSheetPF2e {
+
+    /** Shopping cart: itemId → quantity. Survives re-renders (the app persists). */
+    #cart = new Map();
+
+    /** Once-per-open guard for the gated queue join (reset in close so reopen re-joins). */
+    #hasJoinedQueue = false;
+
+    /** GM settings panel: which dimension the per-bucket factor list edits ("type" | "rarity"). */
+    #settingsBy = "type";
+    /** `${dimension}:${key}` factor rows currently expanded (survives re-render). */
+    #expandedFactorRows = new Set();
+    /** Settings panel starts collapsed on every open; live toggles survive re-renders within a session. */
+    #favorCollapsed = true;
+    /** ResizeObserver that keeps the settings backdrop sized to the list below it (GM only). */
+    #backdropObserver = null;
+
+    /** `controlToken` hook id — re-evaluates buyer affordability when token selection changes. */
+    #controlHookId = null;
+
+    /** Ware filters (view-only, sheet-local). "" = all rarities; affordable hides what the buyer can't buy. */
+    #filterRarity = "";
+    #filterAffordable = false;
+
+    static get defaultOptions() {
+      return foundry.utils.mergeObject(super.defaultOptions, {
+        classes: ["pick-up-stix", "pf2e", "sheet", "actor", "vendor-sheet"],
+        template: "modules/pick-up-stix/templates/vendor/pf2e-vendor.hbs",
+        width: 700,
+        height: 720,
+        scrollY: [".inventory-list", ".tab.shop"],
+        tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "inventory" }]
+      });
+    }
+
+    get title() {
+      return `${game.i18n.localize("TYPES.Actor.pick-up-stix.vendor")}: ${this.actor.name}`;
+    }
+
+    /**
+     * Reuse pf2e's full sheet context (inventory sections, currency, traits,
+     * editable/owner flags) via super.getData, then add our Shop tab data.
+     *
+     * `ActorSheetPF2e.getData` sorts `system.attributes.{immunities,weaknesses,
+     * resistances}` — built for creatures. Our LootPF2e-backed vendor has none
+     * (`LootPF2e.prepareBaseData` sets `attributes = {}`), so a model stub would
+     * be wiped; seed them on the prepared data right before super reads them.
+     * Transient — re-seeded on every render.
+     */
+    async getData(options = this.options) {
+      const attrs = (this.actor.system.attributes ??= {});
+      attrs.immunities ??= [];
+      attrs.weaknesses ??= [];
+      attrs.resistances ??= [];
+
+      const context = await super.getData(options);
+      context.isGM = game.user.isGM;
+      // Buy/cart controls RENDER for every viewer (GM + players) so a waiting shopper
+      // can see what they'll be able to do. They're only ENABLED for the active
+      // shopper — the GM, or the player at the front of the queue; #refreshCart owns
+      // the disabled state and drops a waiting shopper's cart.
+      context.canShop = true;
+      // Shopping queue strip — GM: collapsible panel; players: plain strip. Both
+      // see who's shopping now and who's waiting.
+      context.queue = this.#prepareQueue();
+      context.queueCollapsed = this.#isQueueCollapsed();
+      // Show the VALUE column on every inventory section (matches the NPC look;
+      // base prepareInventory only sets this true for npc/loot/party types).
+      if (context.inventory) context.inventory.showValueAlways = true;
+      // Build the Shop from the same prepared inventory sections, so the Shop
+      // groups use the identical categories/labels/order as the Inventory tab.
+      // The Shop tab lists only wares actually in the shop (shopVisible !== false)
+      // for GM and players alike; the GM manages visibility from the Inventory tab.
+      // The rarity filter is applied server-side (re-render); affordable is client-side.
+      context.shop = buildShopFromSections(context.inventory?.sections ?? [], undefined,
+        { includeHidden: false, rarity: this.#filterRarity });
+      // Ware filters (all viewers).
+      context.filters = this.#prepareFilters();
+      // GM-only pricing settings panel (favor sliders + per-bucket price factors)
+      // and shop-management state (the All-visible master toggle).
+      if (context.isGM) {
+        context.favor = this.#prepareFavorContext();
+        context.settings = this.#prepareSettingsContext();
+        const physical = this.actor.items.filter(i => getAdapter().isPhysicalItem(i));
+        context.allVisible = physical.length > 0
+          && physical.every(i => i.getFlag("pick-up-stix", "shopVisible") !== false);
+      }
+      dbg("pf2e-vendor-sheet:getData", {
+        actor: this.actor?.name, isGM: context.isGM, active: this.#isActiveShopper(), queue: context.queue.length
+      });
+      return context;
+    }
+
+    /**
+     * Reuse pf2e's native inventory listeners (create/qty/delete/identify/search/
+     * drag-drop) via super, then add our header image-edit handler. Drag-to-stock
+     * is handled by pf2e's native `_onDropItem` (the module's container-drop gate
+     * passes through for non-loot-type, non-container drops).
+     */
+    activateListeners(html) {
+      super.activateListeners(html);
+
+      html.find("[data-action='editActorImage']").on("click", (event) => {
+        event.preventDefault();
+        const fp = new foundry.applications.apps.FilePicker.implementation({
+          type: "image",
+          current: this.actor.img,
+          callback: (path) => this.actor.update({ img: path, "prototypeToken.texture.src": path })
+        });
+        fp.render(true);
+      });
+
+      // Non-GM shoppers have no Inventory tab — default them to the Shop tab.
+      if (!game.user.isGM) this._tabs?.[0]?.activate?.("shop");
+
+      // The shop renders inside a not-editable form for non-owner shoppers, so
+      // Foundry disables its controls — re-enable them, then bind.
+      html.find(".vendor-buy, .shop-cart-toggle, .cart-clear, .cart-checkout, .qty-step, .qty-val, " +
+        ".pus-filter-rarity, .pus-filter-affordable, .pus-filter-reset")
+        .prop("disabled", false);
+      html.find(".vendor-buy").on("click", this.#onBuyWare.bind(this));
+      html.find(".shop-cart-toggle").on("click", this.#onToggleCart.bind(this));
+      html.find(".cart-clear").on("click", this.#onClearCart.bind(this));
+      html.find(".cart-checkout").on("click", this.#onCheckoutCart.bind(this));
+      html.find(".qty-step").on("click", this.#onStepCartQty.bind(this));
+      html.find(".qty-val").on("change", this.#onCartQtyChange.bind(this));
+
+      // Click a ware row (outside its controls) to open the item's sheet (read-only for players).
+      html.find(".tab.shop .pus-shop-list li[data-item-id]").on("click", this.#onWareRowClick.bind(this));
+
+      // Ware filters (all viewers): rarity → re-render (server-side); affordable → DOM filter; reset → both.
+      // Affordable is a button (not a form input) so pf2e's submit-on-change never re-renders over it.
+      html.find(".pus-filter-rarity").on("change", this.#onFilterRarityChange.bind(this));
+      html.find(".pus-filter-affordable").on("click", this.#onFilterAffordableChange.bind(this));
+      html.find(".pus-filter-reset").on("click", this.#onResetFilters.bind(this));
+
+      // GM queue-panel collapse toggle (DOM-only; the CSS height transition runs live).
+      html.find(".pus-queue-panel .pus-collapse-bar").on("click", this.#onToggleQueuePanel.bind(this));
+
+      // GM settings panel: collapse toggle, settings-by switch, factor-row expand.
+      html.find(".pus-favor-panel .pus-collapse-bar").on("click", this.#onToggleFavorPanel.bind(this));
+      html.find(".pus-settings-by-btn").on("click", this.#onSettingsBy.bind(this));
+      html.find(".pus-factor-head").on("click", this.#onToggleFactorRow.bind(this));
+      // Slider/number wiring + out-of-bounds flag clamping (all GM-guarded internally).
+      this.#clampFavorFlags();
+      this.#wireFavorControls();
+      this.#wireSettingsControls();
+      this.#wireSettingsBackdrop();
+
+      // GM shop-management: the All master toggle + Save-default / Restock (toolbar
+      // on the Inventory tab), plus a per-row shop-visibility toggle injected into
+      // each native inventory row. All isGM-gated.
+      html.find(".pus-shop-all-toggle").on("click", this.#onToggleAllShop.bind(this));
+      html.find(".pus-shop-save").on("click", this.#onSetInventory.bind(this));
+      html.find(".pus-shop-restock").on("click", this.#onRestock.bind(this));
+      this.#injectInventoryShopToggles();
+
+      // Join the vendor's queue once per open (gated against being queued elsewhere).
+      // A V1 DocumentSheet auto-re-renders on any update to its actor, so the queue
+      // flag changing re-runs getData/canShop on every client with the sheet open —
+      // no explicit queue hook needed (unlike the dnd5e V2 sheet).
+      if (!this.#hasJoinedQueue) {
+        this.#hasJoinedQueue = true;
+        this.#requestJoin();   // fire-and-forget; may pop the switch dialog
+      }
+
+      // The buyer is resolved from the controlled token; the vendor sheet does NOT
+      // auto-re-render when token selection changes (the buyer is a different
+      // document), so refresh the buy/cart disabled state AND re-apply the affordable
+      // filter for the new buyer on controlToken. Registered once; torn down in close().
+      if (this.#controlHookId === null) {
+        this.#controlHookId = Hooks.on("controlToken", () => {
+          if (!this.rendered) return;
+          this.#refreshCart();
+          this.#applyAffordableFilter();
+        });
+      }
+
+      // Sync basket/buy/qty/footer states against the (re-render-surviving) cart,
+      // then apply the client-side affordable filter (the rarity filter is baked in
+      // server-side via getData).
+      this.#refreshCart();
+      this.#applyAffordableFilter();
+    }
+
+    /**
+     * The buyer actor for this viewer: their controlled/scene token's actor, else their assigned
+     * character. The character fallback matters when a player has no token on the current scene —
+     * without it the buyer is null and every buy/cart control (even a free 0-cost ware) disables.
+     * Mirrors the resolution in #isActiveShopper.
+     */
+    #resolveBuyer() {
+      return getPlayerCandidateTokens()[0]?.actor ?? game.user.character ?? null;
+    }
+
+    /**
+     * Left-clicking a ware row (anywhere but its controls) opens the item's sheet.
+     * Players don't own the vendor's items, so Foundry renders the sheet read-only
+     * for them; the GM gets the normal editable sheet.
+     */
+    #onWareRowClick(event) {
+      // The basket/buy/visibility/qty controls have their own handlers — ignore those.
+      if (event.target.closest(".col-controls, .shop-ware-qty")) return;
+      const id = event.currentTarget.dataset.itemId;
+      const item = this.actor.items.get(id);
+      if (!item) { dbg("pf2e-vendor-sheet:onWareRowClick", "no item", { id }); return; }
+      dbg("pf2e-vendor-sheet:onWareRowClick", "opening item sheet", { item: id, name: item.name });
+      item.sheet.render(true);
+    }
+
+    /** Buy one unit of the clicked ware → socket → GM-side purchaseItem. */
+    async #onBuyWare(event) {
+      event.preventDefault();
+      if (!this.#isActiveShopper()) { dbg("pf2e-vendor-sheet:onBuyWare", "not active shopper, bail"); return; }
+      const itemId = event.currentTarget.closest("[data-item-id]")?.dataset.itemId;
+      const item = this.actor.items.get(itemId);
+      if (!item) { dbg("pf2e-vendor-sheet:onBuyWare", "no item for row", { itemId }); return; }
+
+      const qty = 1; // vendors sell one unit per Buy click (cart handles multiples)
+      // Buyer = first pickup candidate (controlled non-interactive token, else
+      // the assigned character's scene token) — same resolution as the pickup flow.
+      const buyer = this.#resolveBuyer();
+      if (!buyer) {
+        dbg("pf2e-vendor-sheet:onBuyWare", "no buyer, bail");
+        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoBuyer"));
+        return;
+      }
+
+      const adapter = getAdapter();
+      if (!adapter.canAfford(buyer, item, qty)) {
+        dbg("pf2e-vendor-sheet:onBuyWare", "cannot afford, bail", { item: item.id, buyer: buyer.id });
+        ui.notifications.warn(game.i18n.format("INTERACTIVE_ITEMS.Notify.NotEnoughCoin", { name: item.name }));
+        return;
+      }
+      const chargeCp = adapter.getItemChargeCp(item, qty);
+      if (chargeCp > 0 && !adapter.planSettlement(buyer, item.parent, chargeCp)) {
+        dbg("pf2e-vendor-sheet:onBuyWare", "no change available, bail", { item: item.id, buyer: buyer.id });
+        ui.notifications.warn(game.i18n.format("INTERACTIVE_ITEMS.Notify.NoChange", { name: item.name }));
+        return;
+      }
+
+      dbg("pf2e-vendor-sheet:onBuyWare", "dispatching purchase", {
+        vendor: this.actor.id, item: item.id, buyer: buyer.id, qty
+      });
+      await dispatchGM(
+        "purchaseItem",
+        { vendorActorId: this.actor.id, itemId: item.id, buyerActorId: buyer.id, quantity: qty },
+        async () => purchaseItem(this.actor.id, item.id, buyer.id, qty)
+      );
+      if (!game.user.isGM) notifyPurchase(item.name, this.actor.name, qty); // buyer self-notifies
+    }
+
+    /* ------------------------------- Cart ------------------------------- */
+
+    /** Basket toggle on a row — add (qty 1) or remove the ware from the cart. */
+    #onToggleCart(event) {
+      if (!this.#isActiveShopper()) { dbg("pf2e-vendor-sheet:onToggleCart", "not active shopper, bail"); return; }
+      const id = event.currentTarget.closest("[data-item-id]")?.dataset.itemId;
+      if (!id) return;
+      if (this.#cart.has(id)) this.#cart.delete(id);
+      else this.#cart.set(id, 1);
+      dbg("pf2e-vendor-sheet:onToggleCart", { id, inCart: this.#cart.has(id), size: this.#cart.size });
+      this.#refreshCart();
+    }
+
+    /** Trash button in the cart footer — empty the basket without buying. */
+    #onClearCart() {
+      if (!this.#cart.size) return;
+      dbg("pf2e-vendor-sheet:onClearCart", { size: this.#cart.size });
+      this.#cart.clear();
+      this.#refreshCart();
+    }
+
+    /** A −/+ stepper on an in-cart multi-stock ware. */
+    #onStepCartQty(event) {
+      const id = event.currentTarget.closest("[data-item-id]")?.dataset.itemId;
+      if (!id || !this.#cart.has(id)) return;
+      const step = Number(event.currentTarget.dataset.step) || 0;
+      this.#setCartQty(id, (this.#cart.get(id) ?? 1) + step);
+    }
+
+    /** Typed cart quantity change. */
+    #onCartQtyChange(event) {
+      const input = event.currentTarget;
+      const id = input.closest("[data-item-id]")?.dataset.itemId;
+      if (!id) return;
+      this.#setCartQty(id, Math.round(Number(input.value) || 1));
+    }
+
+    /** Clamp `requested` to [1, stock], then down until the whole cart fits the buyer. */
+    #setCartQty(id, requested) {
+      if (!this.#cart.has(id)) return;
+      const item = this.actor.items.get(id);
+      if (!item) return;
+      const adapter = getAdapter();
+      const stock = adapter.getItemQuantity(item);
+      let qty = Math.max(1, Math.min(stock, Math.round(Number(requested) || 1)));
+
+      const buyer = this.#resolveBuyer();
+      const wealthCp = buyer ? adapter.getActorWealthCp(buyer) : 0;
+      let otherCp = 0;
+      for (const [otherId, otherQty] of this.#cart) {
+        if (otherId === id) continue;
+        const it = this.actor.items.get(otherId);
+        if (it) otherCp += adapter.getItemChargeCp(it, otherQty);
+      }
+      while (qty > 1 && otherCp + adapter.getItemChargeCp(item, qty) > wealthCp) qty--;
+
+      dbg("pf2e-vendor-sheet:setCartQty", { id, requested, qty, stock });
+      this.#cart.set(id, qty);
+      this.#refreshCart();
+    }
+
+    /** Checkout the whole cart as one batched transaction → GM-side purchaseCart. */
+    async #onCheckoutCart() {
+      const cartItems = [...this.#cart.entries()]; // [[itemId, qty], ...]
+      if (!cartItems.length) return;
+      const buyer = this.#resolveBuyer();
+      if (!buyer) {
+        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NoBuyer"));
+        return;
+      }
+
+      const adapter = getAdapter();
+      const totalCp = cartItems.reduce((sum, [id, qty]) => {
+        const item = this.actor.items.get(id);
+        return sum + (item ? adapter.getItemChargeCp(item, qty) : 0);
+      }, 0);
+      if (totalCp > 0 && adapter.getActorWealthCp(buyer) < totalCp) {
+        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Notify.NotEnoughCoin"));
+        return;
+      }
+
+      // Resolve names now — the GM mutates stock during the purchase, so rows may
+      // be gone by the time the self-notify fires.
+      const lines = cartItems.reduce((acc, [id, qty]) => {
+        const name = this.actor.items.get(id)?.name;
+        if (name) acc.push({ name, qty });
+        return acc;
+      }, []);
+      dbg("pf2e-vendor-sheet:onCheckoutCart", { items: cartItems.length, buyer: buyer.id, vendor: this.actor.id });
+      this.#cart.clear();
+      this.#refreshCart();
+      await dispatchGM(
+        "purchaseCart",
+        { vendorActorId: this.actor.id, cartItems, buyerActorId: buyer.id },
+        async () => purchaseCart(this.actor.id, cartItems, buyer.id)
+      );
+      if (!game.user.isGM) for (const { name, qty } of lines) notifyPurchase(name, this.actor.name, qty);
+    }
+
+    /** Format a copper amount as a short coin string (e.g. 3060 → "30 gp 6 sp"). */
+    #formatCp(cp) {
+      const conv = getAdapter().currency;
+      if (!conv) return `${cp}`;
+      const { coins } = conv.decompose(cp);
+      const parts = conv.changeDenoms.filter(d => coins[d]).map(d => `${coins[d]} ${d}`);
+      return parts.join(" ") || `0 ${conv.defaultDenom}`;
+    }
+
+    /**
+     * Single DOM pass: clamp the cart to live stock, then update each row's
+     * basket/buy/qty states and the footer total/count/checkout. Called after
+     * every cart mutation and once per render (the cart survives re-renders).
+     */
+    #refreshCart() {
+      const root = this.element?.[0] ?? this.element;
+      if (!root) return;
+
+      // Waiting shopper (a non-GM player not at the front of the queue): the buy/cart
+      // controls stay in the DOM but disabled, and any in-progress cart is dropped.
+      // Reset the footer and bail before the active-shopper pricing pass.
+      if (!this.#isActiveShopper()) {
+        this.#cart.clear();
+        for (const el of root.querySelectorAll(".vendor-buy, .shop-cart-toggle, .cart-checkout, .cart-clear, .qty-step, .qty-val")) {
+          el.disabled = true;
+        }
+        for (const el of root.querySelectorAll(".shop-cart-toggle.active, .shop-ware-qty.active")) el.classList.remove("active");
+        const footer = root.querySelector(".shop-cart-footer");
+        if (footer) {
+          footer.classList.remove("active");
+          const totalEl = footer.querySelector(".cart-total");
+          if (totalEl) totalEl.textContent = this.#formatCp(0);
+          const countEl = footer.querySelector(".cart-count");
+          if (countEl) countEl.textContent = "0";
+        }
+        dbg("pf2e-vendor-sheet:refreshCart", "waiting shopper — controls disabled");
+        return;
+      }
+
+      const adapter = getAdapter();
+      const buyer = this.#resolveBuyer();
+      const wealthCp = buyer ? adapter.getActorWealthCp(buyer) : 0;
+
+      // Drop sold-out / removed ids; clamp survivors to live stock.
+      let cartCp = 0, cartUnits = 0;
+      for (const [id, qty] of [...this.#cart]) {
+        const item = this.actor.items.get(id);
+        if (!item) { this.#cart.delete(id); continue; }
+        const stock = adapter.getItemQuantity(item);
+        const q = Math.min(qty, stock);
+        if (q !== qty) this.#cart.set(id, q);
+        cartCp += adapter.getItemChargeCp(item, q);
+        cartUnits += q;
+      }
+      const hasCart = this.#cart.size > 0;
+
+      for (const row of root.querySelectorAll(".tab.shop li[data-item-id]")) {
+        const id = row.dataset.itemId;
+        const item = this.actor.items.get(id);
+        if (!item) continue;
+        const inCart = this.#cart.has(id);
+        const unitCp = adapter.getItemChargeCp(item, 1);
+        const stock = adapter.getItemQuantity(item);
+
+        const basket = row.querySelector(".shop-cart-toggle");
+        if (basket) {
+          basket.classList.toggle("active", inCart);
+          // Removable when in cart; addable only if one more unit still fits.
+          basket.disabled = !inCart && (!buyer || (cartCp + unitCp) > wealthCp);
+        }
+        const buy = row.querySelector(".vendor-buy");
+        if (buy) buy.disabled = hasCart || !(buyer && adapter.canAfford(buyer, item, 1));
+
+        const qtyWrap = row.querySelector(".shop-ware-qty");
+        if (qtyWrap) {
+          qtyWrap.classList.toggle("active", inCart);
+          const qtyVal = qtyWrap.querySelector(".qty-val");
+          if (qtyVal) {
+            qtyVal.disabled = !inCart;
+            qtyVal.max = String(stock);
+            if (inCart) qtyVal.value = String(this.#cart.get(id));
+          }
+          for (const step of qtyWrap.querySelectorAll(".qty-step")) step.disabled = !inCart;
+        }
+      }
+
+      const footer = root.querySelector(".shop-cart-footer");
+      if (footer) {
+        footer.classList.toggle("active", hasCart);
+        const totalEl = footer.querySelector(".cart-total");
+        if (totalEl) totalEl.textContent = this.#formatCp(cartCp);
+        const countEl = footer.querySelector(".cart-count");
+        if (countEl) countEl.textContent = String(cartUnits);
+        const checkout = footer.querySelector(".cart-checkout");
+        if (checkout) checkout.disabled = !(hasCart && buyer && cartCp <= wealthCp);
+        const clear = footer.querySelector(".cart-clear");
+        if (clear) clear.disabled = !hasCart;
+      }
+    }
+
+    /* ----------------------- GM pricing settings ----------------------- */
+
+    /** Favor panel context (GM): current values, slider bounds, and formatted display strings. */
+    #prepareFavorContext() {
+      const favor = getVendorFavor(this.actor);
+      const factor = getVendorFavorFactor(this.actor);
+      const sign = (v) => `${v > 0 ? "+" : ""}${v}`;
+      return {
+        value: favor,
+        factor,
+        valueDisplay: sign(favor),
+        factorDisplay: `${factor}%`,
+        favorMin: getFavorMin(),
+        favorMax: getFavorMax(),
+        factorMin: getFavorFactorMin(),
+        factorMax: getFavorFactorMax(),
+        collapsed: this.#favorCollapsed
+      };
+    }
+
+    /** GM context for the "Settings by" toggle + the per-bucket factor list (only buckets present in stock). */
+    #prepareSettingsContext() {
+      const physical = this.actor.items.filter(i => getAdapter().isPhysicalItem(i));
+      const groups = buildSettingsGroups(physical, this.#settingsBy);
+      const maxFactor = getMaxPriceFactor();
+      const globalFactor = getVendorGlobalFactor(this.actor);
+      return {
+        by: this.#settingsBy,
+        dimensions: [
+          { key: "type",   label: "INTERACTIVE_ITEMS.Vendor.SettingsBy.Type",   active: this.#settingsBy === "type" },
+          { key: "rarity", label: "INTERACTIVE_ITEMS.Vendor.SettingsBy.Rarity", active: this.#settingsBy === "rarity" }
+        ],
+        maxFactor,
+        globalFactor,
+        globalFactorDisplay: (globalFactor / 100).toFixed(2),
+        rows: groups.map(g => {
+          const factor = getVendorGroupingFactor(this.actor, this.#settingsBy, g.key);
+          return {
+            dimension: this.#settingsBy,
+            key: g.key,
+            label: g.label,
+            count: g.count,
+            factor,
+            factorDisplay: (factor / 100).toFixed(2),
+            // Reuse the ware-row rarity palette to tint the group name when grouped by rarity.
+            colorClass: this.#settingsBy === "rarity" ? `pus-rarity pus-rarity-${g.key}` : "",
+            expanded: this.#expandedFactorRows.has(`${this.#settingsBy}:${g.key}`)
+          };
+        })
+      };
+    }
+
+    /**
+     * Clamp out-of-bounds favor / favorFactor / globalPriceFactor flags to the current world-setting
+     * limits in one batched update. GM only; no-op (no re-render) when everything is already in range.
+     */
+    async #clampFavorFlags() {
+      if (!game.user.isGM) return;
+      const rawFavor = Number(this.actor.getFlag("pick-up-stix", "favor"));
+      const rawFactor = Number(this.actor.getFlag("pick-up-stix", "favorFactor"));
+      const rawGlobal = Number(this.actor.getFlag("pick-up-stix", "globalPriceFactor"));
+      const max = getMaxPriceFactor();
+      const clampedFavor = Number.isFinite(rawFavor)
+        ? Math.max(getFavorMin(), Math.min(getFavorMax(), Math.round(rawFavor))) : null;
+      const clampedFactor = Number.isFinite(rawFactor)
+        ? Math.max(getFavorFactorMin(), Math.min(getFavorFactorMax(), Math.round(rawFactor))) : null;
+      const clampedGlobal = Number.isFinite(rawGlobal)
+        ? Math.max(0, Math.min(max, Math.round(rawGlobal))) : null;
+      const updates = {};
+      if (clampedFavor !== null && clampedFavor !== rawFavor) updates["flags.pick-up-stix.favor"] = clampedFavor;
+      if (clampedFactor !== null && clampedFactor !== rawFactor) updates["flags.pick-up-stix.favorFactor"] = clampedFactor;
+      if (clampedGlobal !== null && clampedGlobal !== rawGlobal) updates["flags.pick-up-stix.globalPriceFactor"] = clampedGlobal;
+      if (!foundry.utils.isEmpty(updates)) {
+        dbg("pf2e-vendor-sheet:clampFavorFlags", { vendor: this.actor.id, updates });
+        await this.actor.update(updates);
+      }
+    }
+
+    /** Wire the favor / favorFactor sliders (GM). `input` updates the live label; `change` clamps + writes the flag. */
+    #wireFavorControls() {
+      if (!game.user.isGM) return;
+      const root = this.element?.[0] ?? this.element;
+      const panel = root?.querySelector(".pus-favor-panel");
+      if (!panel || panel.dataset.pusWired === "1") return;
+      panel.dataset.pusWired = "1";
+      const sign = (v) => `${v > 0 ? "+" : ""}${v}`;
+      for (const range of panel.querySelectorAll(".pus-favor-range")) {
+        const valueEl = range.closest(".pus-favor-slider").querySelector(".pus-favor-value");
+        const isFavor = range.dataset.flag === "favor";
+        const fmt = isFavor ? (v) => sign(v) : (v) => `${v}%`;
+        range.addEventListener("input", () => { valueEl.textContent = fmt(Number(range.value)); });
+        range.addEventListener("change", async () => {
+          const raw = Math.round(Number(range.value) || 0);
+          const v = isFavor
+            ? Math.max(getFavorMin(), Math.min(getFavorMax(), raw))
+            : Math.max(getFavorFactorMin(), Math.min(getFavorFactorMax(), raw || getFavorFactorDefault()));
+          dbg("pf2e-vendor-sheet:favorControlChange", { vendor: this.actor.id, flag: range.dataset.flag, value: v });
+          await this.actor.setFlag("pick-up-stix", range.dataset.flag, v);
+        });
+      }
+    }
+
+    /** Wire the global price factor + per-bucket factor sliders/number inputs in the settings panel (GM). */
+    #wireSettingsControls() {
+      if (!game.user.isGM) return;
+      const root = this.element?.[0] ?? this.element;
+      const list = root?.querySelector(".pus-factor-list");
+      if (!list || list.dataset.pusWired === "1") return;
+      list.dataset.pusWired = "1";
+      const max = getMaxPriceFactor();
+      const clamp = (v) => Math.max(0, Math.min(max, Math.round(Number(v) || 0)));
+
+      const globalRoot = list.closest(".pus-favor-content-inner");
+      const globalRange = globalRoot?.querySelector(".pus-global-factor-range");
+      const globalNum = globalRoot?.querySelector(".pus-global-factor-num");
+      if (globalRange) {
+        globalRange.addEventListener("input", () => { if (globalNum) globalNum.value = String(clamp(globalRange.value)); });
+        if (globalNum) globalNum.addEventListener("input", () => { globalRange.value = String(clamp(globalNum.value)); });
+        const commitGlobal = async (el) => {
+          const v = clamp(el.value);
+          dbg("pf2e-vendor-sheet:globalFactorChange", { vendor: this.actor.id, value: v });
+          await this.actor.setFlag("pick-up-stix", "globalPriceFactor", v);
+        };
+        globalRange.addEventListener("change", () => commitGlobal(globalRange));
+        if (globalNum) globalNum.addEventListener("change", () => commitGlobal(globalNum));
+      }
+
+      for (const row of list.querySelectorAll(".pus-factor-row")) {
+        const range = row.querySelector(".pus-factor-range");
+        const num = row.querySelector(".pus-factor-num");
+        const mult = row.querySelector(".pus-factor-mult");
+        if (!range || !num) continue;
+        const flagKey = `groupingFactors.${row.dataset.dimension}.${row.dataset.key}`;
+        const syncLive = (v) => {
+          num.value = String(v);
+          if (mult) mult.textContent = `×${(v / 100).toFixed(2)}`;
+        };
+        range.addEventListener("input", () => syncLive(clamp(range.value)));
+        num.addEventListener("input", () => {
+          range.value = String(clamp(num.value));
+          if (mult) mult.textContent = `×${(clamp(num.value) / 100).toFixed(2)}`;
+        });
+        const commit = async (el) => {
+          const v = clamp(el.value);
+          dbg("pf2e-vendor-sheet:factorChange", { vendor: this.actor.id, flagKey, value: v });
+          await this.actor.setFlag("pick-up-stix", flagKey, v);
+        };
+        range.addEventListener("change", () => commit(range));
+        num.addEventListener("change", () => commit(num));
+      }
+    }
+
+    /**
+     * Size the settings backdrop to span from the bottom of the (variable-height) settings panel down
+     * to the bottom of the shop content, so the open panel shades + blocks the list beneath it.
+     */
+    #sizeSettingsBackdrop() {
+      const root = this.element?.[0] ?? this.element;
+      const content = root?.querySelector(".pus-favor-content");
+      const backdrop = content?.querySelector(":scope > .pus-settings-backdrop");
+      if (!content || !backdrop) return;
+      const tab = content.closest(".tab");
+      if (!tab) return;
+      const tabRect = tab.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const contentBottomInScroll = (contentRect.bottom - tabRect.top) + tab.scrollTop;
+      const h = Math.max(0, tab.scrollHeight - contentBottomInScroll);
+      backdrop.style.height = `${h}px`;
+    }
+
+    /** (Re)observe the settings content + shop tab so the backdrop height tracks expansion/resize. GM only. */
+    #wireSettingsBackdrop() {
+      if (!game.user.isGM) return;
+      const root = this.element?.[0] ?? this.element;
+      const content = root?.querySelector(".pus-favor-content");
+      const tab = content?.closest(".tab");
+      if (!content || !tab) return;
+      if (!this.#backdropObserver) this.#backdropObserver = new ResizeObserver(() => this.#sizeSettingsBackdrop());
+      this.#backdropObserver.disconnect();
+      this.#backdropObserver.observe(content);
+      this.#backdropObserver.observe(tab);
+      dbg("pf2e-vendor-sheet:wireSettingsBackdrop", "observing settings + tab for backdrop sizing");
+      this.#sizeSettingsBackdrop();
+    }
+
+    /** Collapse/expand the settings panel — DOM-only so the CSS transition runs; field records the state. */
+    #onToggleFavorPanel(event) {
+      const bar = event.currentTarget;
+      const panel = bar.closest(".pus-favor-panel");
+      if (!panel) return;
+      const collapsed = panel.classList.toggle("collapsed");
+      bar.setAttribute("aria-expanded", String(!collapsed));
+      dbg("pf2e-vendor-sheet:onToggleFavorPanel", { vendor: this.actor.id, collapsed });
+      this.#favorCollapsed = collapsed;
+    }
+
+    /** Switch the factor list between the Type and Rarity dimensions (GM). Re-renders the shop. */
+    #onSettingsBy(event) {
+      const dim = event.currentTarget.dataset.dimension;
+      if (dim !== "type" && dim !== "rarity") return;
+      if (this.#settingsBy === dim) return;
+      dbg("pf2e-vendor-sheet:onSettingsBy", { vendor: this.actor.id, dim });
+      this.#settingsBy = dim;
+      this.render(false);
+    }
+
+    /** Expand/collapse one grouping-factor row. DOM-only; the Set records state for the next re-render. */
+    #onToggleFactorRow(event) {
+      if (event.target.closest(".pus-factor-body")) return;   // ignore clicks on the slider/number
+      const head = event.currentTarget;
+      const row = head.closest(".pus-factor-row");
+      if (!row) return;
+      const id = `${row.dataset.dimension}:${row.dataset.key}`;
+      const expanded = row.classList.toggle("expanded");
+      head.setAttribute("aria-expanded", String(expanded));
+      if (expanded) this.#expandedFactorRows.add(id);
+      else this.#expandedFactorRows.delete(id);
+      dbg("pf2e-vendor-sheet:onToggleFactorRow", { vendor: this.actor.id, id, expanded });
+    }
+
+    /* --------------------- Shop visibility / restock ------------------- */
+
+    /**
+     * Inject a shop-visibility toggle (fa-store) into each native inventory row's
+     * controls (GM). Active = the ware is in the shop; dimmed = hidden. Clicking it
+     * flips the item's `shopVisible` flag → re-render → the Shop tab + player
+     * storefront re-filter. Idempotent (the DOM is rebuilt each render, so we
+     * re-inject). Scoped to top-level section rows — not container-contents/subitems.
+     */
+    #injectInventoryShopToggles() {
+      if (!game.user.isGM) return;
+      const root = this.element?.[0] ?? this.element;
+      const invTab = root?.querySelector(".tab.inventory");
+      if (!invTab) return;
+      const adapter = getAdapter();
+      let injected = 0;
+      for (const li of invTab.querySelectorAll("ul.items:not(.container-contents):not(.subitems) > li[data-item-id]")) {
+        const item = this.actor.items.get(li.dataset.itemId);
+        if (!item || !adapter.isPhysicalItem(item)) continue;
+        const controls = li.querySelector(":scope > .data > .item-controls:not(.readonly)");
+        if (!controls || controls.querySelector(":scope > .pus-inv-shop-toggle")) continue;   // idempotent
+        const visible = item.getFlag("pick-up-stix", "shopVisible") !== false;
+        controls.prepend(createRowControl({
+          iconClass: "fa-solid fa-store fa-fw",
+          titleKey: "INTERACTIVE_ITEMS.Vendor.ToggleShopVisible",
+          extraClass: "pus-inv-shop-toggle",
+          active: visible,
+          onClick: async () => {
+            dbg("pf2e-vendor-sheet:invShopToggle", { item: item.id, name: item.name, from: visible, to: !visible });
+            await item.setFlag("pick-up-stix", "shopVisible", !visible);
+          }
+        }));
+        injected++;
+      }
+      dbg("pf2e-vendor-sheet:injectInventoryShopToggles", { injected });
+    }
+
+    /** Master toggle: add every physical item to the shop, or remove them all if already all in (GM). */
+    async #onToggleAllShop() {
+      const adapter = getAdapter();
+      const physical = this.actor.items.filter(i => adapter.isPhysicalItem(i));
+      const allVisible = physical.length > 0
+        && physical.every(i => i.getFlag("pick-up-stix", "shopVisible") !== false);
+      const next = !allVisible;
+      dbg("pf2e-vendor-sheet:onToggleAllShop", { from: allVisible, to: next, count: physical.length });
+      const updates = physical.map(i => ({ _id: i.id, "flags.pick-up-stix.shopVisible": next }));
+      if (updates.length) await this.actor.updateEmbeddedDocuments("Item", updates);
+    }
+
+    /** Snapshot the current physical inventory as this vendor's default (GM). */
+    async #onSetInventory() {
+      dbg("pf2e-vendor-sheet:onSetInventory", { vendor: this.actor.id });
+      const count = await saveDefaultInventory(this.actor);
+      ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Vendor.SetInventoryDone", { count }));
+    }
+
+    /** Restock to the saved default: always add missing items/qty; confirm before removing extras (GM). */
+    async #onRestock() {
+      const diff = computeRestockDiff(this.actor);
+      if (!diff) {
+        dbg("pf2e-vendor-sheet:onRestock", "no default saved, bail", { vendor: this.actor.id });
+        ui.notifications.warn(game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockNoDefault"));
+        return;
+      }
+      const hasExtras = diff.extraQty.length > 0 || diff.extraItems.length > 0;
+      const hasAdds = diff.toCreate.length > 0 || diff.toIncrease.length > 0;
+      if (!hasExtras && !hasAdds) {
+        dbg("pf2e-vendor-sheet:onRestock", "already matches default", { vendor: this.actor.id });
+        ui.notifications.info(game.i18n.localize("INTERACTIVE_ITEMS.Vendor.RestockNothing"));
+        return;
+      }
+      const removeExtras = hasExtras ? await promptRestockRemoval(diff) : false;
+      dbg("pf2e-vendor-sheet:onRestock", "applying", { vendor: this.actor.id, removeExtras, hasAdds, hasExtras });
+      const summary = await applyRestock(this.actor, diff, { removeExtras });
+      ui.notifications.info(game.i18n.format("INTERACTIVE_ITEMS.Vendor.RestockDone", summary));
+    }
+
+    /* ---------------------------- Ware filters ------------------------- */
+
+    /**
+     * Filter-bar context (all viewers). Rarity options are the rarities actually present in the
+     * in-shop wares, ordered by the pf2e rarity ladder. A stored rarity no longer present resets
+     * to "All" so the select can't show a dead value.
+     */
+    #prepareFilters() {
+      const adapter = getAdapter();
+      const eligible = this.actor.items.filter(i =>
+        adapter.isPhysicalItem(i) && !i.isCurrency
+        && i.getFlag("pick-up-stix", "shopVisible") !== false);
+      const options = buildSettingsGroups(eligible, "rarity");   // [{key,label,count}] ladder-ordered
+      if (this.#filterRarity && !options.some(o => o.key === this.#filterRarity)) {
+        dbg("pf2e-vendor-sheet:prepareFilters", "stored rarity no longer present, resetting", { rarity: this.#filterRarity });
+        this.#filterRarity = "";
+      }
+      return {
+        rarity: this.#filterRarity,
+        affordable: this.#filterAffordable,
+        rarityOptions: options.map(o => ({ key: o.key, label: o.label, selected: o.key === this.#filterRarity }))
+      };
+    }
+
+    /**
+     * Client-side affordable filter: hide wares the resolved buyer can't afford (≥1 unit), hide a
+     * group header when its whole list is hidden, and show the empty-state when nothing is left.
+     * With no buyer the filter is a no-op (show all). Safe to call when off — it resets all hiding.
+     */
+    #applyAffordableFilter() {
+      const root = this.element?.[0] ?? this.element;
+      if (!root) return;
+      const adapter = getAdapter();
+      const buyer = this.#resolveBuyer();
+      const on = this.#filterAffordable;
+      let anyVisible = false;
+
+      for (const li of root.querySelectorAll(".tab.shop .pus-shop-list li[data-item-id]")) {
+        const id = li.dataset.itemId;
+        const item = this.actor.items.get(id);
+        if (!item) continue;
+        // In-cart wares stay visible so the shopper can still see/adjust them.
+        const show = !on || !buyer || this.#cart.has(id) || adapter.canAfford(buyer, item, 1);
+        li.style.display = show ? "" : "none";
+        if (show) anyVisible = true;
+      }
+      // Hide a section header when its list has no visible rows.
+      for (const ul of root.querySelectorAll(".tab.shop .pus-shop-list ul.items")) {
+        const visible = [...ul.querySelectorAll("li[data-item-id]")].some(r => r.style.display !== "none");
+        const header = ul.previousElementSibling;
+        if (header?.matches?.("header[data-group-key]")) header.style.display = visible ? "" : "none";
+      }
+      const empty = root.querySelector(".tab.shop .shop-filter-empty");
+      if (empty) empty.style.display = (on && !anyVisible) ? "" : "none";
+      dbg("pf2e-vendor-sheet:applyAffordableFilter", { on, anyVisible });
+    }
+
+    /** Rarity select changed — re-render so the shop rebuilds with the server-side rarity filter. */
+    #onFilterRarityChange(event) {
+      event.stopPropagation();   // don't let pf2e's form submit-on-change also fire
+      this.#filterRarity = event.currentTarget.value || "";
+      dbg("pf2e-vendor-sheet:onFilterRarityChange", { rarity: this.#filterRarity });
+      this.render(false);
+    }
+
+    /** Affordable toggle button clicked — flip the flag + DOM-only re-filter (no re-render, no flicker). */
+    #onFilterAffordableChange(event) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.#filterAffordable = !this.#filterAffordable;
+      const btn = event.currentTarget;
+      btn.classList.toggle("active", this.#filterAffordable);
+      btn.setAttribute("aria-pressed", String(this.#filterAffordable));
+      dbg("pf2e-vendor-sheet:onFilterAffordableChange", { affordable: this.#filterAffordable });
+      this.#applyAffordableFilter();
+    }
+
+    /** Reset both filters to their default unfiltered state. */
+    #onResetFilters() {
+      if (!this.#filterRarity && !this.#filterAffordable) return;
+      dbg("pf2e-vendor-sheet:onResetFilters", { vendor: this.actor.id });
+      this.#filterRarity = "";
+      this.#filterAffordable = false;
+      this.render(false);
+    }
+
+    /* ------------------------------ Queue ------------------------------ */
+
+    /**
+     * Whether THIS viewer may currently transact: the GM always; a player only when
+     * their actor is at the front of the vendor's queue. Gates the ENABLED state of
+     * the (always-rendered) buy/cart controls — a waiting shopper sees them disabled.
+     */
+    #isActiveShopper() {
+      if (game.user.isGM) return true;
+      const myActor = getPlayerCandidateTokens()[0]?.actor ?? game.user.character;
+      if (!myActor) return false;
+      return getVendorQueue(this.actor)[0] === myActor.id;
+    }
+
+    /** Map the queue actorIds to display rows for the strip (active = index 0). */
+    #prepareQueue() {
+      return getVendorQueue(this.actor).reduce((rows, actorId, i) => {
+        const user = game.users.find(u => u.character?.id === actorId);
+        const character = user?.character ?? game.actors.get(actorId) ?? null;
+        if (!character) return rows;             // actor deleted or no matching user — skip
+        rows.push({
+          actorId,
+          name: character.name,
+          img: character.img ?? "icons/svg/mystery-man.svg",
+          color: user?.color?.css ?? (typeof user?.color === "string" ? user?.color : null),
+          active: i === 0,
+          isSelf: user?.id === game.user.id
+        });
+        return rows;
+      }, []);
+    }
+
+    /** Per-user, per-vendor queue-panel collapse state (defaults to expanded). */
+    #isQueueCollapsed() {
+      const map = game.user.getFlag("pick-up-stix", "queueCollapsed") ?? {};
+      return map[this.actor.id] ?? false;
+    }
+
+    /** Persist the queue-panel collapse state for this user + vendor (user flag → no actor re-render). */
+    async #setQueueCollapsed(collapsed) {
+      const map = { ...(game.user.getFlag("pick-up-stix", "queueCollapsed") ?? {}) };
+      map[this.actor.id] = collapsed;
+      dbg("pf2e-vendor-sheet:setQueueCollapsed", { vendor: this.actor.id, collapsed });
+      await game.user.setFlag("pick-up-stix", "queueCollapsed", map);
+    }
+
+    /** GM queue-panel collapse toggle — DOM-only so the CSS height transition runs on the live DOM. */
+    #onToggleQueuePanel(event) {
+      const bar = event.currentTarget;
+      const panel = bar.closest(".pus-queue-panel");
+      if (!panel) return;
+      const collapsed = panel.classList.toggle("collapsed");
+      bar.setAttribute("aria-expanded", String(!collapsed));
+      dbg("pf2e-vendor-sheet:onToggleQueuePanel", { vendor: this.actor.id, collapsed });
+      this.#setQueueCollapsed(collapsed);
+    }
+
+    /**
+     * Enqueue this user on open/maximize. If they're already in another vendor's queue, confirm the
+     * switch first (single button; the X dismisses → stay put). The GM is never queued. Called
+     * fire-and-forget so the dialog never blocks the render.
+     */
+    async #requestJoin() {
+      if (game.user.isGM) return;
+      const myActor = getPlayerCandidateTokens()[0]?.actor ?? game.user.character;
+      if (!myActor) { dbg("pf2e-vendor-sheet:requestJoin", "no candidate actor, skipping join"); return; }
+      const others = findUserVendorQueues(myActor.id).filter(a => a.id !== this.actor.id);
+      if (!others.length) { this.#joinQueue(myActor); return; }   // not queued elsewhere → join now
+      dbg("pf2e-vendor-sheet:requestJoin", "queued elsewhere, confirming switch", { others: others.map(a => a.id) });
+      const confirmed = await promptVendorQueueSwitch(this.actor.name, others[0].name);
+      if (confirmed) this.#joinQueue(myActor);                     // GM-side join displaces the prior queue(s)
+      else dbg("pf2e-vendor-sheet:requestJoin", "switch declined — staying in prior queue, not joining this one");
+    }
+
+    /** Emit a join request to the active GM (GM is never queued). */
+    #joinQueue(myActor) {
+      if (game.user.isGM) return;
+      dbg("pf2e-vendor-sheet:joinQueue", { vendor: this.actor.id, actor: myActor.id });
+      emitSocketEvent("vendorQueueJoin", { vendorActorId: this.actor.id, actorId: myActor.id });
+    }
+
+    /** A player minimized/closed this vendor sheet — dequeue them and drop their cart. */
+    #leaveQueue() {
+      if (game.user.isGM) return;
+      const myActor = getPlayerCandidateTokens()[0]?.actor ?? game.user.character;
+      if (!myActor) return;
+      this.#cart.clear();                 // leaving clears my basket so nothing carries over
+      dbg("pf2e-vendor-sheet:leaveQueue", { vendor: this.actor.id, actor: myActor.id });
+      emitSocketEvent("vendorQueueLeave", { vendorActorId: this.actor.id, actorId: myActor.id });
+    }
+
+    /* --------------------------- Lifecycle ---------------------------- */
+
+    /**
+     * Leave the queue when the window is minimized (only on a real transition).
+     * V1 Application tracks minimized state on the `_minimized` field (false/true/null
+     * mid-animation) — there is NO `minimized` getter as on ApplicationV2, so read the
+     * field directly.
+     */
+    async minimize() {
+      const wasMinimized = this._minimized === true;
+      await super.minimize();
+      if (!wasMinimized && this._minimized === true) this.#leaveQueue();
+    }
+
+    /** Rejoin (gated) when the window is restored from minimized (V1 `_minimized` field). */
+    async maximize() {
+      const wasMinimized = this._minimized === true;
+      await super.maximize();
+      if (wasMinimized && this._minimized === false) this.#requestJoin();
+    }
+
+    /** Leave the queue + reset transient panel state + tear down observers/hooks on close. */
+    async close(options = {}) {
+      this.#leaveQueue();
+      this.#hasJoinedQueue = false;   // reopen re-joins
+      if (this.#backdropObserver) { this.#backdropObserver.disconnect(); this.#backdropObserver = null; }
+      if (this.#controlHookId !== null) { Hooks.off("controlToken", this.#controlHookId); this.#controlHookId = null; }
+      this.#favorCollapsed = true;    // the settings panel always reopens collapsed
+      this.#filterRarity = "";        // ware filters are view-only — reopen unfiltered
+      this.#filterAffordable = false;
+      return super.close(options);
+    }
+  };
+}

--- a/scripts/pick-up-stix.mjs
+++ b/scripts/pick-up-stix.mjs
@@ -2184,7 +2184,12 @@ Hooks.on("preCreateActor", (actor, data, options, userId) => {
   //   default. Only seed it when the creator didn't specify one, so an explicit
   //   choice isn't clobbered.
   const updates = { "prototypeToken.actorLink": true };
-  if (foundry.utils.getProperty(data, "ownership.default") === undefined) {
+  // Seed LIMITED when the creator didn't choose one. pf2e's
+  // ActorPF2e.createDocuments pre-fills ownership.default = NONE for non-core
+  // sub-types *before* this hook runs, so treat NONE as "unset" too — otherwise
+  // pf2e vendors are invisible to players. (dnd5e leaves it undefined.)
+  const existingOwnership = foundry.utils.getProperty(data, "ownership.default");
+  if (existingOwnership === undefined || existingOwnership === CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE) {
     updates["ownership.default"] = CONST.DOCUMENT_OWNERSHIP_LEVELS.LIMITED;
   }
   actor.updateSource(updates);

--- a/styles/pick-up-stix.css
+++ b/styles/pick-up-stix.css
@@ -657,6 +657,16 @@
 .pus-rarity-legendary { --pus-rarity-color: #ff8000; }
 .pus-rarity-artifact  { --pus-rarity-color: #e6cc80; }
 
+/* pf2e shop: use pf2e's own rarity palette (the defaults above are dnd5e's,
+   and pf2e has no veryRare/legendary/artifact but does have `unique`). Scoped
+   to the pf2e vendor sheet (.pf2e) so the dnd5e vendor keeps its palette. Also
+   tints the pill text so it matches the rarity-coloured ware name. */
+.pick-up-stix.pf2e.vendor-sheet .pus-rarity { color: var(--pus-rarity-color, #888); }
+.pick-up-stix.pf2e.vendor-sheet .pus-rarity-common   { --pus-rarity-color: var(--color-rarity-common, #323232); }
+.pick-up-stix.pf2e.vendor-sheet .pus-rarity-uncommon { --pus-rarity-color: var(--color-rarity-uncommon, #98513d); }
+.pick-up-stix.pf2e.vendor-sheet .pus-rarity-rare     { --pus-rarity-color: var(--color-rarity-rare, #002664); }
+.pick-up-stix.pf2e.vendor-sheet .pus-rarity-unique   { --pus-rarity-color: var(--color-rarity-unique, #54166e); }
+
 .shop-cart-toggle {
   flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
   width: 26px; height: 26px; padding: 0; border-radius: 4px; cursor: pointer;
@@ -1035,6 +1045,11 @@
 .vendor-sheet .pus-collapse-caret { transition: transform 0.2s ease; }
 .vendor-sheet .pus-collapse-panel:not(.collapsed) .pus-collapse-caret { transform: rotate(180deg); }
 
+/* "!" alert right of the Shopping Queue label, shown only while the panel is collapsed
+   (the queue panel only renders when players are queued, so collapsed === shoppers waiting). */
+.vendor-sheet .pus-queue-panel .pus-collapse-alert { display: none; color: #d9762a; font-size: 1.35em; }
+.vendor-sheet .pus-queue-panel.collapsed .pus-collapse-alert { display: inline-block; }
+
 /* Expanding content: an absolute overlay below the bar. Inset left/right to match the bar width
    (the 12px mirrors the panel's horizontal padding). Fades + slides in; `visibility` keeps it
    fully hidden — and non-interactive — when collapsed. The inner wrapper owns the scroll so the
@@ -1208,4 +1223,354 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+}
+
+/* ---- pf2e vendor sheet (reuses pf2e's native inventory partials) ---- */
+/* Header: portrait + name, matching the pf2e sheet header band. */
+.pick-up-stix.vendor-sheet .vendor-sheet-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+}
+.pick-up-stix.vendor-sheet .vendor-sheet-header .profile {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  border: 1px solid var(--color-border-dark, rgba(0, 0, 0, 0.4));
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.pick-up-stix.vendor-sheet .vendor-header-fields {
+  flex: 1;
+  min-width: 0;
+}
+.pick-up-stix.vendor-sheet .vendor-header-fields input[name="name"] {
+  width: 100%;
+  font-size: var(--font-size-24, 24px);
+}
+
+/* Tab visibility (mirrors pf2e's; scoped here so we don't depend on the
+   .npc layout classes, which expect a sidebar structure we don't render). */
+.pick-up-stix.vendor-sheet .sheet-body > .tab { display: none; }
+.pick-up-stix.vendor-sheet .sheet-body > .tab.active { display: flex; flex-direction: column; }
+.pick-up-stix.vendor-sheet .sheet-body { flex: 1; min-height: 0; overflow: hidden; }
+
+/* Blue inventory section bands (the .npc/.loot sheets set this var to the blue;
+   our sheet otherwise falls back to the default brown). */
+.pick-up-stix.vendor-sheet form {
+  --color-pf-inventory-header-bg: var(--primary-background);
+}
+
+/* Vendors aren't creatures — no bulk. Hide the BULK column in headers + rows
+   (the encumbrance footer is already omitted from the template). */
+.pick-up-stix.vendor-sheet .inventory .bulk,
+.pick-up-stix.vendor-sheet .inventory .total-bulk {
+  display: none !important;
+}
+
+/* ---- Shop tab: reuse pf2e inventory row chrome, distinct header band ---- */
+/* The shop section bands use the same header styling as the inventory but a
+   different colour (override the shared bg variable, scoped to the shop tab). */
+.pick-up-stix.vendor-sheet .tab.shop {
+  --color-pf-inventory-header-bg: #4a5e3a;
+}
+/* Shop columns: fixed widths so the header labels line up with the row values
+   (rows otherwise inherit pf2e's flex .data layout for free). */
+.pick-up-stix.vendor-sheet .tab.shop .pus-shop-col {
+  flex: 0 0 auto;
+  align-self: center;
+  white-space: nowrap;
+}
+.pick-up-stix.vendor-sheet .tab.shop .col-rarity { width: 92px; text-align: center; }
+.pick-up-stix.vendor-sheet .tab.shop .col-stock { width: 48px; text-align: center; }
+.pick-up-stix.vendor-sheet .tab.shop .col-price { width: 84px; text-align: right; }
+.pick-up-stix.vendor-sheet .tab.shop .col-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  /* Constant width (basket + buy) so the rarity/stock/price columns stay aligned
+     with the header. The qty stepper lives on its own row, so no extra width. */
+  flex: 0 0 62px;
+}
+.pick-up-stix.vendor-sheet .tab.shop header > span.pus-shop-col { justify-content: center; }
+
+/* Shop control buttons (Buy, basket toggle, cart clear/checkout). */
+.pick-up-stix.vendor-sheet .tab.shop .vendor-buy,
+.pick-up-stix.vendor-sheet .tab.shop .shop-cart-toggle,
+.pick-up-stix.vendor-sheet .shop-cart-footer .cart-clear,
+.pick-up-stix.vendor-sheet .shop-cart-footer .cart-checkout {
+  width: 26px;
+  height: 24px;
+  padding: 0;
+  line-height: 1;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.pick-up-stix.vendor-sheet .tab.shop .vendor-buy[disabled],
+.pick-up-stix.vendor-sheet .tab.shop .shop-cart-toggle[disabled],
+.pick-up-stix.vendor-sheet .shop-cart-footer button[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+.pick-up-stix.vendor-sheet .tab.shop .shop-cart-toggle.active {
+  color: var(--color-text-light-0, #fff);
+  background: var(--primary-background, #44456a);
+}
+
+/* Make the shop ware row a flex column so the .data line and the qty sub-row
+   each stretch full width (pf2e's ul.items column otherwise centers the li's
+   non-stretched children). Scoped to the shop tab only. */
+.pick-up-stix.vendor-sheet .tab.shop .pus-shop-list ul.items > li {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* Breathing room inside each ware row so the icon/name/columns aren't flush against
+   the row's top and bottom edges. The row is clickable (opens the item sheet), so
+   show a pointer cursor over the content (the control buttons keep their own). */
+.pick-up-stix.vendor-sheet .tab.shop .pus-shop-list ul.items > li > .data {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  cursor: pointer;
+}
+
+/* Per-ware quantity stepper — its own row beneath the ware, shown only when
+   the ware is in the cart. Full width + right-aligned so it sits under the basket. */
+.pick-up-stix.vendor-sheet .tab.shop .shop-ware-qty {
+  display: none;
+  align-self: stretch;
+  width: 100%;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 0 34px 4px 0; /* right offset ≈ buy button → stepper sits under the basket */
+}
+.pick-up-stix.vendor-sheet .tab.shop .shop-ware-qty.active { display: flex; }
+.pick-up-stix.vendor-sheet .tab.shop .shop-ware-qty-label {
+  font-size: var(--font-size-11, 11px);
+  opacity: 0.8;
+  margin-right: 2px;
+}
+.pick-up-stix.vendor-sheet .tab.shop .shop-ware-qty .qty-val {
+  width: 44px;
+  text-align: center;
+  padding: 0 2px;
+}
+.pick-up-stix.vendor-sheet .tab.shop .shop-ware-qty .qty-step {
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  line-height: 1;
+}
+
+/* Cart footer — shown only when the cart has items. Matches the shop header
+   green band with light text so it stays readable. */
+.pick-up-stix.vendor-sheet .shop-cart-footer {
+  display: none;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--color-pf-inventory-header-bg, #4a5e3a);
+  color: var(--color-text-light-0, #fff);
+  flex: 0 0 auto;
+}
+.pick-up-stix.vendor-sheet .shop-cart-footer .cart-clear,
+.pick-up-stix.vendor-sheet .shop-cart-footer .cart-checkout {
+  color: var(--color-text-light-0, #fff);
+}
+.pick-up-stix.vendor-sheet .shop-cart-footer.active { display: flex; }
+.pick-up-stix.vendor-sheet .shop-cart-footer .cart-summary { margin-left: auto; }
+.pick-up-stix.vendor-sheet .shop-cart-footer .cart-actions { display: flex; gap: 4px; }
+/* Let the ware list scroll so the cart footer stays pinned to the bottom. */
+.pick-up-stix.vendor-sheet .tab.shop .pus-shop-list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
+}
+/* The ware's type subtitle under its name (inventory rows have no subtitle). */
+.pick-up-stix.vendor-sheet .tab.shop .pus-ware-sub {
+  display: block;
+  font-size: var(--font-size-10, 10px);
+  opacity: 0.7;
+  text-transform: none;
+}
+
+/* ---- pf2e GM settings panel: re-skin to the parchment sheet, not dnd5e's dark overlay ----
+   The shared settings/queue panel markup is styled for dnd5e (light text on a maroon
+   overlay). On pf2e that clashes with the light parchment sheet, so re-skin the surface,
+   borders, and text to pf2e's palette and align it full-width with the inventory bands.
+   Scoped to .pf2e so the dnd5e vendor is untouched. */
+
+/* Light parchment panel surface (replaces the dnd5e maroon mix). */
+.pick-up-stix.pf2e.vendor-sheet { --pus-settings-panel-bg: var(--color-pf-tertiary-light, #f2e8ca); }
+
+/* Full-width to align with pf2e's full-width inventory section bands + ware list
+   (dnd5e insets these panels 12px; pf2e bands run edge-to-edge). */
+.pick-up-stix.pf2e.vendor-sheet .pus-favor-panel,
+.pick-up-stix.pf2e.vendor-sheet .pus-queue-panel { padding-left: 0; padding-right: 0; }
+.pick-up-stix.pf2e.vendor-sheet .pus-favor-content { left: 0; right: 0; }
+
+/* Collapsed queue: the inner strip's 8px top padding otherwise peeks through the
+   grid 0fr collapse — zero it (and its border) so the strip fully disappears. */
+.pick-up-stix.pf2e.vendor-sheet .pus-queue-panel.collapsed .pus-queue-content > .vendor-queue {
+  padding: 0;
+  border: none;
+}
+
+/* Panel container: pf2e brown border, dark text, a soft drop shadow for the overlay. */
+.pick-up-stix.pf2e.vendor-sheet .pus-favor-content-inner {
+  border-color: var(--color-pf-alternate, #786452);
+  color: var(--color-text-dark-input, #333);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-collapse-bar,
+.pick-up-stix.pf2e.vendor-sheet .pus-collapse-title,
+.pick-up-stix.pf2e.vendor-sheet .pus-favor-label,
+.pick-up-stix.pf2e.vendor-sheet .pus-favor-value,
+.pick-up-stix.pf2e.vendor-sheet .pus-settings-by-label,
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-head,
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-mult,
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-hint,
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-empty,
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-count {
+  color: var(--color-text-dark-input, #333);
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-collapse-bar:hover { color: var(--color-pf-primary, #5e0000); }
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-count { opacity: 0.7; }
+
+/* Borders/dividers → pf2e brown instead of dnd5e's translucent white. */
+.pick-up-stix.pf2e.vendor-sheet .pus-settings-divider { border-top-color: var(--color-pf-alternate, #786452); }
+.pick-up-stix.pf2e.vendor-sheet .pus-settings-by-toggle,
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-row { border-color: var(--color-pf-alternate, #786452); }
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-row { background: rgba(255, 255, 255, 0.35); }
+
+/* "Settings by" segmented toggle — pf2e red active state on parchment. */
+.pick-up-stix.pf2e.vendor-sheet .pus-settings-by-btn { color: var(--color-text-dark-input, #333); }
+.pick-up-stix.pf2e.vendor-sheet .pus-settings-by-btn.active {
+  background: var(--color-pf-primary, #5e0000);
+  color: var(--color-pf-tertiary-light, #f2e8ca);
+}
+
+/* Factor-name keeps the rarity tint (--pus-rarity-color) but defaults to dark text. */
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-name {
+  color: var(--pus-rarity-color, var(--color-text-dark-input, #333));
+}
+
+/* Editable number inputs readable on parchment. */
+.pick-up-stix.pf2e.vendor-sheet .pus-factor-num {
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--color-text-dark-input, #333);
+  border: 1px solid var(--color-pf-alternate, #786452);
+}
+
+/* ---- Shop visibility + GM management toolbar (Phase 6.2) ---- */
+
+/* Per-row shop-visibility toggle injected into each native inventory row's controls:
+   full pf2e-red when the ware is in the shop, dimmed when hidden. */
+.pick-up-stix.vendor-sheet .tab.inventory .item-controls .pus-inv-shop-toggle.active {
+  color: var(--color-pf-primary, #5e0000);
+  opacity: 1;
+}
+.pick-up-stix.vendor-sheet .tab.inventory .item-controls .pus-inv-shop-toggle:not(.active) {
+  opacity: 0.4;
+}
+
+/* The All master toggle (in the toolbar): full colour when every ware is in the shop. */
+.pick-up-stix.vendor-sheet .pus-shop-toolbar .pus-shop-all-toggle {
+  background: none;
+  border: none;
+}
+.pick-up-stix.vendor-sheet .pus-shop-toolbar .pus-shop-all-toggle.active {
+  color: var(--color-pf-primary, #5e0000);
+}
+.pick-up-stix.vendor-sheet .pus-shop-toolbar .pus-shop-all-toggle:not(.active) {
+  opacity: 0.35;
+}
+
+/* GM shop-management toolbar: a compact control strip above the ware list. */
+.pick-up-stix.vendor-sheet .pus-shop-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+}
+.pick-up-stix.vendor-sheet .pus-shop-toolbar button {
+  width: 26px;
+  height: 24px;
+  padding: 0;
+  line-height: 1;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.pick-up-stix.vendor-sheet .pus-shop-toolbar .pus-shop-all-label {
+  margin-left: auto;
+  font-size: var(--font-size-12, 12px);
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+/* Ware filter bar on pf2e parchment: brown border + dark, legible text/controls
+   (the shared bar is styled for dnd5e's dark theme — faint white border + grey text).
+   Add breathing room before the first ware band. */
+.pick-up-stix.pf2e.vendor-sheet .pus-shop-filters {
+  border-color: var(--color-pf-alternate, #786452);
+  margin-bottom: 8px;
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-shop-filter-label,
+.pick-up-stix.pf2e.vendor-sheet .pus-filter-reset,
+.pick-up-stix.pf2e.vendor-sheet .shop-filter-empty {
+  color: var(--color-text-dark-input, #333);
+}
+/* Affordable filter is a toggle BUTTON (not a form input, so pf2e's submit-on-change
+   never re-renders over the DOM-only filter) — a pf2e chip that highlights red when on. */
+.pick-up-stix.pf2e.vendor-sheet .pus-filter-affordable {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: auto;
+  padding: 2px 10px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid var(--color-pf-alternate, #786452);
+  border-radius: 4px;
+  color: var(--color-text-dark-input, #333);
+  font-size: var(--font-size-12, 12px);
+  white-space: nowrap;
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-filter-affordable.active {
+  background: var(--color-pf-primary, #5e0000);
+  border-color: var(--color-pf-primary, #5e0000);
+  color: var(--color-pf-tertiary-light, #f2e8ca);
+}
+
+/* Shop price column: the same pf2e coin images used on the inventory coinage row,
+   but smaller, borderless, and masked to a circle. Paths are relative to this
+   stylesheet (modules/pick-up-stix/styles/) → ../../../ reaches the Foundry data
+   root, then systems/pf2e/icons/. */
+.pick-up-stix.pf2e.vendor-sheet .pus-coin-img {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+  border: none;
+  border-radius: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-coin-pp {
+  background-image: url("../../../systems/pf2e/icons/equipment/treasure/currency/platinum-pieces.webp");
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-coin-gp {
+  background-image: url("../../../systems/pf2e/icons/equipment/treasure/currency/gold-pieces.webp");
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-coin-sp {
+  background-image: url("../../../systems/pf2e/icons/equipment/treasure/currency/silver-pieces.webp");
+}
+.pick-up-stix.pf2e.vendor-sheet .pus-coin-cp {
+  background-image: url("../../../systems/pf2e/icons/equipment/treasure/currency/copper-pieces.webp");
 }

--- a/templates/vendor/pf2e-vendor.hbs
+++ b/templates/vendor/pf2e-vendor.hbs
@@ -1,0 +1,308 @@
+{{!-- pf2e vendor sheet (ApplicationV1). Header + Inventory tab (reuses pf2e's
+      native inventory partials — same look/controls as an NPC's inventory) +
+      Shop tab (read-only ware list from buildShop). --}}
+<form class="{{cssClass}}" autocomplete="off">
+  <header class="vendor-sheet-header">
+    <img class="profile" src="{{actor.img}}" data-action="editActorImage"
+         title="{{actor.name}}" alt="{{actor.name}}"/>
+    <div class="vendor-header-fields">
+      <input type="text" name="name" value="{{actor.name}}" placeholder="{{localize 'Name'}}"
+             {{#unless editable}}disabled{{/unless}}/>
+    </div>
+  </header>
+
+  <nav class="sheet-tabs tabs" data-group="primary">
+    {{#if isGM}}
+    <a class="item" data-tab="inventory">
+      <i class="fa-solid fa-box-open"></i> {{localize "PF2E.TabInventoryLabel"}}
+    </a>
+    {{/if}}
+    <a class="item" data-tab="shop">
+      <i class="fa-solid fa-store"></i> {{localize "INTERACTIVE_ITEMS.Vendor.ShopTab"}}
+    </a>
+  </nav>
+
+  <section class="sheet-body">
+    {{#if isGM}}
+    <section class="tab inventory item-container" data-container-type="actorInventory"
+             data-group="primary" data-tab="inventory">
+      {{#if owner}}
+        {{> (resolvePath "templates/actors/partials/coinage.hbs") owner=owner}}
+      {{/if}}
+      {{> (resolvePath "templates/actors/partials/inventory-header.hbs")}}
+      {{!-- GM shop-management toolbar: snapshot the current stock as the default,
+            restock to it, and a master toggle that adds/removes every ware. --}}
+      <div class="pus-shop-toolbar">
+        <button type="button" class="pus-shop-save"
+                data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.SetInventory'}}"
+                aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.SetInventory'}}">
+          <i class="fa-solid fa-floppy-disk"></i>
+        </button>
+        <button type="button" class="pus-shop-restock"
+                data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.Restock'}}"
+                aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.Restock'}}">
+          <i class="fa-solid fa-truck-ramp-box"></i>
+        </button>
+        <span class="pus-shop-all-label">{{localize 'INTERACTIVE_ITEMS.Vendor.AllShop'}}</span>
+        <button type="button" class="pus-shop-all-toggle {{#if allVisible}}active{{/if}}"
+                data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.ToggleAllShop'}}"
+                aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.ToggleAllShop'}}">
+          <i class="fa-solid fa-store"></i>
+        </button>
+      </div>
+      {{> (resolvePath "templates/actors/partials/inventory.hbs")}}
+      {{!-- encumbrance/bulk footer intentionally omitted: vendors aren't creatures --}}
+    </section>
+    {{/if}}
+
+    {{!-- Shop reuses pf2e's inventory row chrome (.inventory / .inventory-list /
+          ul.items / .data / .item-name / .item-icon) so rows match the Inventory
+          tab exactly; only the header band colour differs (set via CSS var). --}}
+    <div class="tab shop inventory" data-group="primary" data-tab="shop">
+      {{!-- GM pricing settings: Favor + per-bucket price factors. A collapsible panel
+            whose content drops as an overlay over the ware list when expanded. --}}
+      {{#if isGM}}
+      <section class="pus-collapse-panel pus-favor-panel {{#if favor.collapsed}}collapsed{{/if}}">
+        <button type="button" class="pus-collapse-bar"
+                data-tooltip="{{ localize 'INTERACTIVE_ITEMS.Vendor.SettingsToggle' }}"
+                aria-expanded="{{#if favor.collapsed}}false{{else}}true{{/if}}">
+          <span class="pus-collapse-title">{{ localize 'INTERACTIVE_ITEMS.Vendor.Settings' }}</span>
+          <i class="fa-solid fa-chevron-down pus-collapse-caret"></i>
+        </button>
+        <div class="pus-favor-content">
+          <div class="pus-settings-backdrop" aria-hidden="true"></div>
+          <div class="pus-favor-content-inner">
+            <div class="pus-favor-controls">
+              <div class="pus-favor-control">
+                <label class="pus-favor-label" data-tooltip="{{ localize 'INTERACTIVE_ITEMS.Vendor.FavorTooltip' }}">
+                  {{ localize 'INTERACTIVE_ITEMS.Vendor.Favor' }}
+                </label>
+                <div class="pus-favor-slider">
+                  <input type="range" class="pus-favor-range" data-flag="favor"
+                         min="{{ favor.favorMin }}" max="{{ favor.favorMax }}" step="1" value="{{ favor.value }}" />
+                  <span class="pus-favor-value">{{ favor.valueDisplay }}</span>
+                </div>
+              </div>
+              <div class="pus-favor-control">
+                <label class="pus-favor-label" data-tooltip="{{ localize 'INTERACTIVE_ITEMS.Vendor.FavorFactorTooltip' }}">
+                  {{ localize 'INTERACTIVE_ITEMS.Vendor.FavorFactor' }}
+                </label>
+                <div class="pus-favor-slider">
+                  <input type="range" class="pus-favor-range" data-flag="favorFactor"
+                         min="{{ favor.factorMin }}" max="{{ favor.factorMax }}" step="1" value="{{ favor.factor }}" />
+                  <span class="pus-favor-value">{{ favor.factorDisplay }}</span>
+                </div>
+              </div>
+            </div>
+            <hr class="pus-settings-divider" />
+
+            <div class="pus-favor-control">
+              <label class="pus-favor-label" data-tooltip="{{ localize 'INTERACTIVE_ITEMS.Vendor.GlobalFactor.Tooltip' }}">
+                {{ localize 'INTERACTIVE_ITEMS.Vendor.GlobalFactor.Label' }}
+              </label>
+              <div class="pus-factor-slider-row">
+                <input type="range" class="pus-factor-range pus-global-factor-range" min="0" max="{{ settings.maxFactor }}"
+                       step="1" value="{{ settings.globalFactor }}" />
+                <input type="number" class="pus-factor-num pus-global-factor-num" min="0" max="{{ settings.maxFactor }}"
+                       step="1" value="{{ settings.globalFactor }}" />
+              </div>
+              <p class="hint pus-factor-hint">{{ localize 'INTERACTIVE_ITEMS.Vendor.Factor.Hint' }} {{ settings.maxFactor }}%</p>
+            </div>
+
+            <div class="pus-settings-by">
+              <span class="pus-settings-by-label">{{ localize 'INTERACTIVE_ITEMS.Vendor.SettingsBy.Label' }}</span>
+              <div class="pus-settings-by-toggle">
+                {{#each settings.dimensions}}
+                <button type="button" class="pus-settings-by-btn {{#if this.active}}active{{/if}}"
+                        data-dimension="{{ this.key }}"
+                        aria-pressed="{{#if this.active}}true{{else}}false{{/if}}">
+                  {{ localize this.label }}
+                </button>
+                {{/each}}
+              </div>
+            </div>
+
+            <div class="pus-factor-list">
+              {{#each settings.rows}}
+              <div class="pus-factor-row {{#if this.expanded}}expanded{{/if}}"
+                   data-dimension="{{ this.dimension }}" data-key="{{ this.key }}">
+                <button type="button" class="pus-factor-head"
+                        aria-expanded="{{#if this.expanded}}true{{else}}false{{/if}}">
+                  <span class="pus-factor-name {{ this.colorClass }}">{{ this.label }}</span>
+                  <span class="pus-factor-count">{{ this.count }} {{ localize 'INTERACTIVE_ITEMS.Vendor.Factor.Items' }}</span>
+                  <span class="pus-factor-mult">&times;{{ this.factorDisplay }}</span>
+                  <i class="fa-solid fa-chevron-down pus-factor-caret"></i>
+                </button>
+                <div class="pus-factor-body">
+                  <div class="pus-factor-body-inner">
+                    <div class="pus-factor-slider-row">
+                      <input type="range" class="pus-factor-range" min="0" max="{{ ../settings.maxFactor }}"
+                             step="1" value="{{ this.factor }}" />
+                      <input type="number" class="pus-factor-num" min="0" max="{{ ../settings.maxFactor }}"
+                             step="1" value="{{ this.factor }}" />
+                    </div>
+                    <p class="hint pus-factor-hint">{{ localize 'INTERACTIVE_ITEMS.Vendor.Factor.Hint' }} {{ ../settings.maxFactor }}%</p>
+                  </div>
+                </div>
+              </div>
+              {{else}}
+              <p class="pus-factor-empty">{{ localize 'INTERACTIVE_ITEMS.Vendor.Factor.Empty' }}</p>
+              {{/each}}
+            </div>
+          </div>
+        </div>
+      </section>
+      {{/if}}
+
+      {{!-- Shopping queue. GM: a collapsible panel; players: a plain strip. Both see
+            who is shopping now (active, first + larger) and who is waiting. --}}
+      {{#if queue.length}}
+      {{#if isGM}}
+      <section class="pus-collapse-panel pus-queue-panel {{#if queueCollapsed}}collapsed{{/if}}">
+        <button type="button" class="pus-collapse-bar"
+                data-tooltip="{{ localize 'INTERACTIVE_ITEMS.Vendor.Queue.Toggle' }}"
+                aria-expanded="{{#if queueCollapsed}}false{{else}}true{{/if}}">
+          <span class="pus-collapse-title">{{ localize 'INTERACTIVE_ITEMS.Vendor.Queue.Title' }}</span>
+          <i class="fa-solid fa-circle-exclamation pus-collapse-alert"
+             data-tooltip="{{ localize 'INTERACTIVE_ITEMS.Vendor.Queue.Waiting' }}"></i>
+          <i class="fa-solid fa-chevron-down pus-collapse-caret"></i>
+        </button>
+        <div class="pus-queue-content">
+          <div class="vendor-queue pus-gm-queue">
+            {{#each queue}}
+            <div class="vendor-queue-shopper {{#if this.active}}active{{/if}} {{#if this.isSelf}}self{{/if}}"
+                 data-actor-id="{{ this.actorId }}"
+                 data-tooltip="{{#if this.active}}{{ localize 'INTERACTIVE_ITEMS.Vendor.Queue.Active' }}{{else}}{{ localize 'INTERACTIVE_ITEMS.Vendor.Queue.Waiting' }}{{/if}}">
+              <div class="vendor-queue-portrait" {{#if this.color}}style="--shopper-color: {{ this.color }};"{{/if}}>
+                <img src="{{ this.img }}" alt="{{ this.name }}" />
+              </div>
+              <span class="vendor-queue-name">{{ this.name }}</span>
+            </div>
+            {{/each}}
+          </div>
+        </div>
+      </section>
+      {{else}}
+      <div class="vendor-queue pus-player-queue">
+        {{#each queue}}
+        <div class="vendor-queue-shopper {{#if this.active}}active{{/if}} {{#if this.isSelf}}self{{/if}}"
+             data-actor-id="{{ this.actorId }}"
+             data-tooltip="{{#if this.active}}{{ localize 'INTERACTIVE_ITEMS.Vendor.Queue.Active' }}{{else}}{{ localize 'INTERACTIVE_ITEMS.Vendor.Queue.Waiting' }}{{/if}}">
+          <div class="vendor-queue-portrait" {{#if this.color}}style="--shopper-color: {{ this.color }};"{{/if}}>
+            <img src="{{ this.img }}" alt="{{ this.name }}" />
+          </div>
+          <span class="vendor-queue-name">{{ this.name }}</span>
+        </div>
+        {{/each}}
+      </div>
+      {{/if}}
+      {{/if}}
+
+      {{!-- Ware filters (all viewers): rarity select + affordable toggle + reset. --}}
+      <section class="pus-shop-filters">
+        <div class="pus-shop-filter">
+          <label class="pus-shop-filter-label" for="pus-filter-rarity">
+            {{localize 'INTERACTIVE_ITEMS.Vendor.Filter.Rarity'}}
+          </label>
+          <select id="pus-filter-rarity" class="pus-filter-rarity">
+            <option value="" {{#unless filters.rarity}}selected{{/unless}}>
+              {{localize 'INTERACTIVE_ITEMS.Vendor.Filter.All'}}
+            </option>
+            {{#each filters.rarityOptions}}
+            <option value="{{this.key}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
+        <button type="button" class="pus-shop-filter pus-filter-affordable {{#if filters.affordable}}active{{/if}}"
+                data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.Filter.AffordableTooltip'}}"
+                aria-pressed="{{#if filters.affordable}}true{{else}}false{{/if}}">
+          <i class="fa-solid fa-coins"></i>
+          <span>{{localize 'INTERACTIVE_ITEMS.Vendor.Filter.Affordable'}}</span>
+        </button>
+        <button type="button" class="pus-filter-reset"
+                data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.Filter.Reset'}}"
+                aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.Filter.Reset'}}">
+          <i class="fa-solid fa-arrow-rotate-left"></i>
+        </button>
+      </section>
+
+      <section class="pus-shop-list inventory-list directory-list inventory-pane">
+        {{#each shop.groups}}
+        <header data-group-key="{{this.key}}">
+          <h3 class="item-name">{{this.title}}</h3>
+          {{#each ../shop.headers}}
+          <span class="pus-shop-col col-{{this.id}} shop-align-{{this.align}}">{{localize this.label}}</span>
+          {{/each}}
+          {{#if @root.canShop}}<span class="pus-shop-col col-controls"></span>{{/if}}
+        </header>
+        <ul class="items">
+          {{#each this.wares}}
+          <li data-item-id="{{this.id}}" draggable="true">
+            <div class="data" data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.ViewDetails'}}">
+              <div class="item-name">
+                <a class="item-image"><img class="item-icon" src="{{this.img}}" alt="{{this.name}}"/></a>
+                <h4 class="name rarity-{{this.rarity}}">
+                  <span class="pus-ware-name">{{this.name}}</span>
+                  {{#if this.subtitle}}<span class="pus-ware-sub">{{this.subtitle}}</span>{{/if}}
+                </h4>
+              </div>
+              {{#each this.cells}}
+              <span class="pus-shop-col col-{{this.id}} shop-align-{{this.align}} {{this.classes}}">{{#if this.coins}}<span class="pus-coin-stack">{{#each this.coins}}<span class="pus-coin-row">{{this.amount}} <span class="pus-coin-img pus-coin-{{this.denom}}" data-tooltip="{{this.label}}"></span></span>{{/each}}</span>{{else}}{{this.text}}{{/if}}</span>
+              {{/each}}
+              {{#if @root.canShop}}
+              <span class="pus-shop-col col-controls">
+                <button type="button" class="shop-cart-toggle"
+                        data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.AddToCart'}}"
+                        aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.AddToCart'}}">
+                  <i class="fa-solid fa-basket-shopping"></i>
+                </button>
+                <button type="button" class="vendor-buy"
+                        data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.Buy'}}"
+                        aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.Buy'}}">
+                  <i class="fa-solid fa-coins"></i>
+                </button>
+              </span>
+              {{/if}}
+            </div>
+            {{#if @root.canShop}}{{#if this.multiStock}}
+            <div class="shop-ware-qty">
+              <span class="shop-ware-qty-label">{{localize "INTERACTIVE_ITEMS.Vendor.CartQty"}}</span>
+              <button type="button" class="qty-step" data-step="-1" tabindex="-1" data-tooltip="-1"><i class="fa-solid fa-minus"></i></button>
+              <input type="number" class="qty-val" min="1" max="{{this.stock}}" value="1" step="1"
+                     aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.CartQty'}}"/>
+              <button type="button" class="qty-step" data-step="1" tabindex="-1" data-tooltip="+1"><i class="fa-solid fa-plus"></i></button>
+            </div>
+            {{/if}}{{/if}}
+          </li>
+          {{/each}}
+        </ul>
+        {{else}}
+        <p class="vendor-ware-empty">{{localize "INTERACTIVE_ITEMS.Vendor.Empty"}}</p>
+        {{/each}}
+      </section>
+      <p class="shop-filter-empty" style="display:none;">
+        {{localize "INTERACTIVE_ITEMS.Vendor.Filter.NoneAffordable"}}
+      </p>
+      {{#if canShop}}
+      <footer class="shop-cart-footer">
+        <span class="cart-count-badge" data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.CartCount'}}">
+          <i class="fa-solid fa-basket-shopping"></i> &times;<span class="cart-count">0</span>
+        </span>
+        <span class="cart-summary">{{localize "INTERACTIVE_ITEMS.Vendor.CartTotal"}}: <span class="cart-total">0</span></span>
+        <div class="cart-actions">
+          <button type="button" class="cart-clear"
+                  data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.ClearCart'}}"
+                  aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.ClearCart'}}">
+            <i class="fa-solid fa-trash"></i>
+          </button>
+          <button type="button" class="cart-checkout"
+                  data-tooltip="{{localize 'INTERACTIVE_ITEMS.Vendor.Buy'}}"
+                  aria-label="{{localize 'INTERACTIVE_ITEMS.Vendor.Buy'}}">
+            <i class="fa-solid fa-coins"></i>
+          </button>
+        </div>
+      </footer>
+      {{/if}}
+    </div>
+  </section>
+</form>

--- a/templates/vendor/shop.hbs
+++ b/templates/vendor/shop.hbs
@@ -101,6 +101,8 @@
             data-tooltip="{{ localize "INTERACTIVE_ITEMS.Vendor.Queue.Toggle" }}"
             aria-expanded="{{#if queueCollapsed}}false{{else}}true{{/if}}">
       <span class="pus-collapse-title">{{ localize "INTERACTIVE_ITEMS.Vendor.Queue.Title" }}</span>
+      <i class="fa-solid fa-circle-exclamation pus-collapse-alert"
+         data-tooltip="{{ localize "INTERACTIVE_ITEMS.Vendor.Queue.Waiting" }}"></i>
       <i class="fa-solid fa-chevron-down pus-collapse-caret"></i>
     </button>
     <div class="pus-queue-content">


### PR DESCRIPTION
Ports the vendor feature to the pf2e system at full parity with dnd5e: a creatable vendor actor with native-styled Inventory and Shop tabs, single buy + cart/checkout that moves real pf2e coins, the one-shopper-at-a-time queue, GM favor/factor pricing, per-item shop visibility, save/restock, and rarity/affordable filters.

Additive only — no pf2e world could hold a vendor before this, so nothing existing is invalidated and no migration is needed. The dnd5e vendor is unaffected aside from two small shared tweaks (free wares show a bare `0`, and a `!` shows on a collapsed queue with shoppers waiting).